### PR TITLE
periodically sync from hg

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Please read about contributing to Chirp at https://chirp.danplanet.com/projects/chirp/wiki/DevelopersProcess

--- a/.github/workflows/sync-hg.yaml
+++ b/.github/workflows/sync-hg.yaml
@@ -1,0 +1,25 @@
+name: Sync from d-rats.com/hg/chirp.hg
+on:
+  schedule:
+    - cron: '47 * * * *'
+  workflow_dispatch:
+jobs:
+  sync:
+    name: Sync
+    if: github.repository == 'kk7ds/chirp'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: install git-remote-hg
+        run: |
+          wget https://raw.github.com/felipec/git-remote-hg/master/git-remote-hg -O /usr/local/bin/git-remote-hg
+          chmod +x /usr/local/bin/git-remote-hg
+      - name: pull
+        run: |
+          git remote add upstream hg::http://d-rats.com/hg/chirp.hg
+          git pull --ff-only upstream branches/default
+      - name: push
+        run: |
+          git push


### PR DESCRIPTION
This adds a Github Actions workflow to periodically sync any new commits from the mercurial repo. It can also be run manually. It won't run on forks.

I also added a CONTRIBUTING.md that Github will link to in some cases that aren't particularly well defined in their docs. Hopefully this will guide contributors from Github to the dev mailing list.