### PR TITLE
Don't die if GTK Mac integration is missing

### DIFF
--- a/chirp/ui/mainapp.py
+++ b/chirp/ui/mainapp.py
@@ -2212,14 +2212,14 @@ of file.
         try:
             import gtk_osxapplication
             macapp = gtk_osxapplication.OSXApplication()
-        except ImportError:
+        except ImportError as e:
             pass
 
         # for gtk-mac-integration >= 2.0.7
         try:
             import gtkosx_application
             macapp = gtkosx_application.Application()
-        except ImportError:
+        except ImportError as e:
             pass
 
         if macapp is None:


### PR DESCRIPTION
If GTK Mac integration is missing, Chirp dies when it tries to log this
fact. The code is designed to handle the absence of this capability and
simply omit the Mac-specific features, so handle the logging gracefully
and carry on.

Fixes #8845