### PR TITLE
Serialize memory map before sending

### DIFF
--- a/chirp/drivers/icomciv.py
+++ b/chirp/drivers/icomciv.py
@@ -167,7 +167,11 @@ class Frame:
         """Send the frame over @serial, using @src and @dst addresses"""
         hdr = struct.pack("BBBBBB", 0xFE, 0xFE, src, dst, self._cmd, self._sub)
         raw = bytearray(hdr)
-        raw.extend(self._data)
+        if isinstance(self._data, MemoryMapBytes):
+            data = self._data.get_packed()
+        else:
+            data = self._data
+        raw.extend(data)
         raw.append(0xFD)
 
         LOG.debug("%02x -> %02x (%i):\n%s" %


### PR DESCRIPTION
In original Chirp, a MemoryMap instance is transparently converted
to a string using the str() function, since MemoryMap implements
__str__. In py3, we need bytes from a MemoryMapBytes instance. We
cannot use __bytes__ to do this transparently, since that function
is not supported in Py2, so we need to explicitly check and then
call get_packed() to obtain the bytes.