### PR TITLE
Add snap/snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,109 @@
+name: chirp-snap
+summary: A free, open-source tool for programming your amateur radio
+description: |
+    CHIRP is a free, open-source tool for programming your amateur radio. 
+    It supports a large number of manufacturers and models, as well as 
+    provides a way to interface with multiple data sources and formats.
+adopt-info: chirp
+grade: stable
+confinement: strict
+base: core18
+
+architectures:
+  - build-on: amd64
+
+# This is a python2 GTK2 Application:
+# https://snapcraft.io/docs/gtk2-applications
+
+plugs:
+  gtk-2-engines:
+    interface: content
+    target: $SNAP/lib/gtk-2.0
+    default-provider: gtk2-common-themes
+  gtk-2-themes:
+    interface: content
+    target: $SNAP/data-dir/themes
+    default-provider: gtk-common-themes
+
+hooks:
+  configure:
+    plugs:
+      - home
+      - network
+      - network-bind
+      - removable-media
+  pre-refresh:
+    plugs:
+      - home
+      - network
+      - network-bind
+      - removable-media
+
+apps:
+  chirp-snap:
+    command: bin/chirpw
+    environment:
+      # Fallback to XWayland if running in a Wayland session.
+      DISABLE_WAYLAND: 1
+      # Needed for fontconfig
+      XDG_DATA_HOME: ${SNAP}/usr/share
+      FONTCONFIG_PATH: ${SNAP}/etc/fonts/config.d
+      FONTCONFIG_FILE: ${SNAP}/etc/fonts/fonts.conf
+    plugs:
+      - home
+      - network
+      - network-bind
+      - removable-media
+      - desktop-legacy
+      - unity7
+      - x11
+      - raw-usb
+      - serial-port
+
+parts:
+  chirp:
+    plugin: python
+    python-version: python2
+    #python-packages: [pycairo, pygobject, pygtk, libxml2, pyserial, python-future, python-suds]
+    source: https://github.com/kk7ds/chirp.git
+    override-pull: |
+      snapcraftctl pull
+      # invalid snap version "chirp-daily-20220219+git1.3e607109": cannot be longer than 32 characters (got: 34)
+      LATEST_COMMIT_DATE=$(git log -1 --date=format:"%Y%m%d" --format="%ad")
+      LATEST_COMMIT_SHORT=$(git rev-parse --short HEAD)
+      version="chirp-daily-${LATEST_COMMIT_DATE}+${LATEST_COMMIT_SHORT}"
+      snapcraftctl set-version "$version"
+    stage-packages:
+      - python-gtk2
+      - python-serial
+      - python-libxml2
+      - python-future
+    after:
+      - desktop-gtk2
+  # https://github.com/ubuntu/snapcraft-desktop-helpers/blob/master/snapcraft.yaml
+  desktop-gtk2:
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk
+    plugin: make
+    make-parameters: ["FLAVOR=gtk2"]
+    build-packages:
+      - build-essential
+      - libgtk2.0-dev
+    stage-packages:
+      - libxkbcommon0  # XKB_CONFIG_ROOT
+      - ttf-ubuntu-font-family
+      - dmz-cursor-theme
+      - light-themes
+      - adwaita-icon-theme
+      - gnome-themes-standard
+      - shared-mime-info
+      - libgtk2.0-0
+      - libgdk-pixbuf2.0-0
+      - libglib2.0-bin
+      - libgtk2.0-bin
+      - unity-gtk2-module
+      - locales-all
+      - libappindicator1
+      - xdg-user-dirs
+      - ibus-gtk
+      - libibus-1.0-5


### PR DESCRIPTION
Hey Dan, @kk7ds, I recently bumped into snapcraft (again) and thought I'd create a snap for Chirp. I know you've had success with the Flatpak build script I put together a few years ago and so I thought I'd give this a go too.

I tested this out with my Baofeng H-777 and was able to download and upload just fine. The snap landing page is currently at https://snapcraft.io/chirp-snap, let me know if you'd like to be added as a collaborator or would like ownership of it.

```
sudo snap install chirp-snap --edge
sudo snap alias chirp-snap chirp
/snap/bin/chirp
```

Let me know if you'd rather me send in an hg changeset over to the dev mailing list. I didn't see anything about your repo here being read-only so I'm assuming you have a git -> mercurial process set up.

Tony

[Edit] I did a force push to remove some unnecessary commands that I copied from the arduino snap. Serial port access seems to work without manually connecting the snap.