### PR TITLE
Update snap/snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,8 +9,8 @@ grade: stable
 confinement: strict
 base: core18
 
-architectures:
-  - build-on: amd64
+#architectures:
+#  - build-on: amd64
 
 # This is a python2 GTK2 Application:
 # https://snapcraft.io/docs/gtk2-applications
@@ -42,6 +42,7 @@ hooks:
 apps:
   chirp-snap:
     command: bin/chirpw
+    desktop: share/applications/chirp.desktop
     environment:
       # Fallback to XWayland if running in a Wayland session.
       DISABLE_WAYLAND: 1
@@ -68,11 +69,16 @@ parts:
     source: https://github.com/kk7ds/chirp.git
     override-pull: |
       snapcraftctl pull
-      # invalid snap version "chirp-daily-20220219+git1.3e607109": cannot be longer than 32 characters (got: 34)
+      # snap version cannot be longer than 32 characters
       LATEST_COMMIT_DATE=$(git log -1 --date=format:"%Y%m%d" --format="%ad")
       LATEST_COMMIT_SHORT=$(git rev-parse --short HEAD)
-      version="chirp-daily-${LATEST_COMMIT_DATE}+${LATEST_COMMIT_SHORT}"
-      snapcraftctl set-version "$version"
+      CHIRP_VERSION="daily-${LATEST_COMMIT_DATE}+${LATEST_COMMIT_SHORT}"
+      sed -i "s/CHIRP_VERSION = \".*\"/CHIRP_VERSION = \"${CHIRP_VERSION}\"/" chirp/__init__.py
+      sed -i "s,^Icon=.*$,Icon=\$\{SNAP\}/share/chirp-snap.svg," share/chirp.desktop
+      snapcraftctl set-version "$CHIRP_VERSION"
+    override-build: |
+      snapcraftctl build
+      cp ${SNAPCRAFT_PART_SRC}/share/chirp.svg ${SNAPCRAFT_PART_INSTALL}/share/chirp-snap.svg
     stage-packages:
       - python-gtk2
       - python-serial
@@ -89,6 +95,7 @@ parts:
     build-packages:
       - build-essential
       - libgtk2.0-dev
+      - gettext
     stage-packages:
       - libxkbcommon0  # XKB_CONFIG_ROOT
       - ttf-ubuntu-font-family


### PR DESCRIPTION
- Build on all architectures (works on the pi yay!)
- Update in-app version so it doesn't say 0.3.0dev
- Add desktop entry for Chirp
- Fix a localization build issue where `gettext` was missing

After fact, I've realized I've broken [the guidelines](https://chirp.danplanet.com/projects/chirp/wiki/DevelopersProcess#Patch-Guidelines). Let me know if you need me to fix up the commit message. Thanks!

https://snapcraft.io/chirp-snap