### PR TITLE
Add missing Ukrainian language option

### DIFF
--- a/chirp/ui/mainapp.py
+++ b/chirp/ui/mainapp.py
@@ -1758,7 +1758,7 @@ of file.
     def do_change_language(self):
         langs = ["Auto", "English", "Polish", "Italian", "Dutch", "German",
                  "Hungarian", "Russian", "Portuguese (BR)", "French",
-                 "Spanish", 'Chinese (Simplified)']
+                 "Spanish", 'Chinese (Simplified)', 'Ukrainian']
         d = inputdialog.ChoiceDialog(langs, parent=self,
                                      title="Choose Language")
         d.label.set_text(_("Choose a language or Auto to use the "

--- a/chirpw
+++ b/chirpw
@@ -55,6 +55,7 @@ if manual_language and manual_language != "Auto":
                   "French":               "fr",
                   "Spanish":              "es_ES",
                   "Chinese (Simplified)": "zh_CN",
+                  'Ukrainian':            "uk_UA",
                   }
     try:
         LOG.info("Language: %s", lang_codes[manual_language])


### PR DESCRIPTION
For some reason, Ukrainian language option was missing. The translation
itself is, unfortunately, incomplete, but it should be awailable
nevertheless.