### PR TITLE
snapcraft.yaml Updates

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,9 +9,6 @@ grade: stable
 confinement: strict
 base: core18
 
-#architectures:
-#  - build-on: amd64
-
 # This is a python2 GTK2 Application:
 # https://snapcraft.io/docs/gtk2-applications
 
@@ -69,13 +66,14 @@ parts:
     source: https://github.com/kk7ds/chirp.git
     override-pull: |
       snapcraftctl pull
-      # snap version cannot be longer than 32 characters
-      LATEST_COMMIT_DATE=$(git log -1 --date=format:"%Y%m%d" --format="%ad")
-      LATEST_COMMIT_SHORT=$(git rev-parse --short HEAD)
-      CHIRP_VERSION="daily-${LATEST_COMMIT_DATE}+${LATEST_COMMIT_SHORT}"
-      sed -i "s/CHIRP_VERSION = \".*\"/CHIRP_VERSION = \"${CHIRP_VERSION}\"/" chirp/__init__.py
+      # Set timezone to America/Los_Angeles
+      sudo sudo ln -sf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime
+      sed -i "s/CHIRP_VERSION = \".*\"/CHIRP_VERSION = \"daily-$(date +%Y%m%d)\"/" chirp/__init__.py
       sed -i "s,^Icon=.*$,Icon=\$\{SNAP\}/share/chirp-snap.svg," share/chirp.desktop
-      snapcraftctl set-version "$CHIRP_VERSION"
+      # snap version cannot be longer than 32 characters
+      LATEST_COMMIT_SHORT=$(git rev-parse --short HEAD)
+      SNAP_VERSION="snap-$(date +%Y%m%d)+${LATEST_COMMIT_SHORT}"
+      snapcraftctl set-version "$SNAP_VERSION"
     override-build: |
       snapcraftctl build
       cp ${SNAPCRAFT_PART_SRC}/share/chirp.svg ${SNAPCRAFT_PART_INSTALL}/share/chirp-snap.svg

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,6 +77,10 @@ parts:
     override-build: |
       snapcraftctl build
       cp ${SNAPCRAFT_PART_SRC}/share/chirp.svg ${SNAPCRAFT_PART_INSTALL}/share/chirp-snap.svg
+      rsync -av ${SNAPCRAFT_PART_INSTALL}/share/ ${SNAPCRAFT_PART_INSTALL}/usr/share/
+      rm ${SNAPCRAFT_PART_INSTALL}/usr/share/pixmaps/chirp.png
+    build-packages:
+      - rsync
     stage-packages:
       - python-gtk2
       - python-serial


### PR DESCRIPTION
Hi @kk7ds,

I have a few changes for `snap/snapcraft.yml`:

- Remove `architectures` deadcode
- Set the timezone to America/Los_Angelos so that the snap version matches the windows/osx/flatpak builds
- Set the snap version (as displayed in the snap store) to match the CHIRP_VERSION (plus a short git hash)
- Fix the icon used in the application menu shortcut to the snap
- rsync `$SNAP/share/` to `$SNAP/usr/share/` pending feedback on https://forum.snapcraft.io/t/python-install-prefix/31248
- Fixes https://github.com/goldstar611/chirp/issues/1
- Fixes https://chirp.danplanet.com/issues/9971