### PR TITLE
Fixes for Kenwood TK-x180 under Python3

### DIFF
--- a/.github/workflows/py3-test.yaml
+++ b/.github/workflows/py3-test.yaml
@@ -46,6 +46,17 @@ jobs:
           name: driver_report
           path: driver_report.html
 
+  driver-py310:
+    name: Driver tests (Python 3.10)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run tox
+        uses: ./.github/actions/py3-tox
+        with:
+          tox_target: py3driver
+
   matrix:
     name: Create support matrix
     runs-on: ubuntu-latest

--- a/chirp/drivers/anytone778uv.py
+++ b/chirp/drivers/anytone778uv.py
@@ -1143,7 +1143,7 @@ class AnyTone778UVBase(chirp_common.CloneModeRadio,
         # Starting Display
         name = ""
         for i in range(7):  # 0 - 7
-            name += chr(self._memobj.starting_display.line[i])
+            name += chr(int(self._memobj.starting_display.line[i]))
         name = name.upper().rstrip()  # remove trailing spaces
 
         rs = RadioSettingValueString(0, 7, name)
@@ -1220,7 +1220,7 @@ class AnyTone778UVBase(chirp_common.CloneModeRadio,
                 str1 = ""
                 for sx in chrx:
                     if int(sx) > 31 and int(sx) < 127:
-                        str1 += chr(sx)
+                        str1 += chr(int(sx))
                 return str1
 
             def _pswd_vfy(setting, obj, atrb):

--- a/chirp/drivers/ic2730.py
+++ b/chirp/drivers/ic2730.py
@@ -817,7 +817,7 @@ class IC2730Radio(icf.IcomRawCloneModeRadio):
 
         stx = ""
         for i in range(0, 16):
-            stx += chr(_cmnt.com[i])
+            stx += chr(int(_cmnt.com[i]))
         stx = stx.rstrip()
         rx = RadioSettingValueString(0, 16, stx)
         rset = RadioSetting("comment.com", "Comment (16 chars)", rx)
@@ -1187,7 +1187,7 @@ class IC2730Radio(icf.IcomRawCloneModeRadio):
         for kx in range(0, 25):
             stx = ""
             for i in range(0, 6):
-                stx += chr(_pses[kx].name[i])
+                stx += chr(int(_pses[kx].name[i]))
             stx = stx.rstrip()
             rx = RadioSettingValueString(0, 6, stx)
             rset = RadioSetting("pgmscanedge/%d.name" % kx,
@@ -1286,7 +1286,7 @@ class IC2730Radio(icf.IcomRawCloneModeRadio):
         for kx in range(0, 10):
             stx = ""
             for i in range(0, 6):
-                stx += chr(_psln[kx].nam[i])
+                stx += chr(int(_psln[kx].nam[i]))
             stx = stx.rstrip()
             rx = RadioSettingValueString(0, 6, stx)
             rset = RadioSetting("pslnam/%d.nam" % kx,

--- a/chirp/drivers/tk8180.py
+++ b/chirp/drivers/tk8180.py
@@ -353,7 +353,7 @@ def do_upload(radio):
             send(radio, make_frame('Z', block, b'\xFF'))
         else:
             checksum = checksum_data(chunk)
-            send(radio, make_frame('W', block, chunk + chr(checksum)))
+            send(radio, make_frame('W', block, chunk + bytes([checksum])))
 
         ack = radio.pipe.read(1)
         if ack != b'\x06':

--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -276,7 +276,7 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
             mnx = ""
             for char in _nam.name:
                 if int(char) < 127:
-                    mnx += chr(char)
+                    mnx += chr(int(char))
             mem.name = mnx
         if _mem.rxfreq == 0x0ffffffff or _mem.rxfreq == 0:
             mem.empty = True
@@ -499,7 +499,7 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
             str1 = ""
             for sx in chrx:
                 if int(sx) > 31 and int(sx) < 127:
-                    str1 += chr(sx)
+                    str1 += chr(int(sx))
             return str1
 
         def _pswd_vfy(setting, obj, atrb):

--- a/chirp/drivers/ts480.py
+++ b/chirp/drivers/ts480.py
@@ -586,7 +586,7 @@ class TS480_CRadio(chirp_common.CloneModeRadio):
             _mem.split = 1
         mnx = ""
         for char in _mem.name:
-            mnx += chr(char)
+            mnx += chr(int(char))
         mem.name = mnx.strip()
         mem.name = mem.name.upper()
         if _mem.rxfreq == 0:

--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -131,6 +131,10 @@ class ChirpSettingGrid(wx.Panel):
                 if editor:
                     self.pg.Append(editor)
 
+    @property
+    def name(self):
+        return self._group.get_name()
+
     def _pg_changed(self, event):
         wx.PostEvent(self, EditorChanged(self.GetId()))
 
@@ -188,15 +192,21 @@ class ChirpSettingGrid(wx.Panel):
                                 setting.get_name(),
                                 value=str(value))
 
-    def get_values(self):
+    def get_setting_values(self):
+        """Return a dict of {name: (RadioSetting, newvalue)}"""
         values = {}
         for prop in self.pg._Items():
             if isinstance(prop, wx.propgrid.EnumProperty):
                 value = self._choices[prop.GetName()][prop.GetValue()]
             else:
                 value = prop.GetValue()
-            values[prop.GetName()] = value
+            setting = self._group[prop.GetName()]
+            values[prop.GetName()] = setting, value
         return values
+
+    def get_values(self):
+        """Return a dict of {name: newvalue}"""
+        return {k: v[1] for k, v in self.get_setting_values().items()}
 
     def saved(self):
         for prop in self.pg._Items():

--- a/chirp/wxui/settingsedit.py
+++ b/chirp/wxui/settingsedit.py
@@ -59,9 +59,11 @@ class ChirpSettingsEdit(common.ChirpEditor):
             all_values = {}
             for i in range(self._group_control.GetPageCount()):
                 page = self._group_control.GetPage(i)
-                all_values.update(page.get_values())
-            for group in self._settings:
-                self._apply_setting_group(all_values, group)
+                for name, (setting, val) in page.get_setting_values().items():
+                    LOG.debug('Setting %s:%s=%r' % (page.name,
+                                                    setting.get_name(),
+                                                    val))
+                    setting.value = val
             return True
         except Exception as e:
             LOG.exception('Failed to apply settings')
@@ -73,7 +75,8 @@ class ChirpSettingsEdit(common.ChirpEditor):
         for element in group.values():
             if isinstance(element, settings.RadioSetting):
                 if element.value.get_mutable():
-                    element.value = all_values[element.get_name()]
+                    element.value = \
+                        all_values[group.get_name()][element.get_name()]
             else:
                 self._apply_setting_group(all_values, element)
 

--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -121,7 +121,7 @@
 | Kenwood_TK-388G |  |  |  |
 | Kenwood_TK-7102 | [@kk7ds](https://github.com/kk7ds) | 15-Feb-2019 | Yes |
 | Kenwood_TK-7108 | [@kk7ds](https://github.com/kk7ds) | 15-Feb-2019 | Yes |
-| Kenwood_TK-7180 |  |  | Yes |
+| Kenwood_TK-7180 | [@kk7ds](https://github.com/kk7ds) | 18-Oct-2022 | Yes |
 | Kenwood_TK-760 |  |  |  |
 | Kenwood_TK-760G |  |  |  |
 | Kenwood_TK-762 |  |  |  |
@@ -130,7 +130,7 @@
 | Kenwood_TK-768G |  |  |  |
 | Kenwood_TK-8102 | [@kk7ds](https://github.com/kk7ds) | 15-Feb-2019 | Yes |
 | Kenwood_TK-8108 | [@kk7ds](https://github.com/kk7ds) | 15-Feb-2019 | Yes |
-| Kenwood_TK-8180 |  |  | Yes |
+| Kenwood_TK-8180 | [@kk7ds](https://github.com/kk7ds) | 18-Oct-2022 | Yes |
 | Kenwood_TK-860 |  |  |  |
 | Kenwood_TK-860G |  |  |  |
 | Kenwood_TK-862 |  |  |  |

--- a/tests/py3_driver_testers.txt
+++ b/tests/py3_driver_testers.txt
@@ -7,10 +7,12 @@ Baofeng_BF-888,@kk7ds,13-Feb-2019
 Baofeng_UV-3R,@yarda,26-Sep-2022
 Icom_ID-31A,@kk7ds,12-Feb-2019
 Icom_IC-910,@mfncooper,1-Oct-2021
-Kenwood_TK-8102,@kk7ds,15-Feb-2019
 Kenwood_TK-7102,@kk7ds,15-Feb-2019
-Kenwood_TK-8108,@kk7ds,15-Feb-2019
 Kenwood_TK-7108,@kk7ds,15-Feb-2019
+Kenwood_TK-7180,@kk7ds,18-Oct-2022
+Kenwood_TK-8102,@kk7ds,15-Feb-2019
+Kenwood_TK-8108,@kk7ds,15-Feb-2019
+Kenwood_TK-8180,@kk7ds,18-Oct-2022
 Yaesu_FT-7800_7900,@kk7ds,14-Feb-2019
 Yaesu_FT-817,@kk7ds,14-Feb-2019
 Yaesu_VX-3,@kk7ds,15-Feb-2019


### PR DESCRIPTION
Found a bug in the actual driver, plus a bug in the WXUI settings editor.  I was doing that on Python 3.10 and noticed some driver tests fail there for some reason, so also fix that.