### PR TITLE
Fix ICF-based radios for clone out

### DIFF
--- a/chirp/drivers/icf.py
+++ b/chirp/drivers/icf.py
@@ -115,15 +115,19 @@ class RadioStream:
 
         return frames
 
-    def get_frames(self, nolimit=False):
+    def get_frames(self, nolimit=False, limit=None):
         """Read any pending frames from the stream"""
         while True:
-            _data = self.pipe.read(64)
+            _data = self.pipe.read(1)
             if not _data:
+                if limit:
+                    LOG.warning('Hit timeout before one frame')
                 break
             else:
                 self.data += _data
 
+            if limit and '\xFD' in self.data:
+                break
             if not nolimit and len(self.data) > 128 and "\xFD" in self.data:
                 break  # Give us a chance to do some status
             if len(self.data) > 1024:
@@ -318,7 +322,7 @@ def clone_from_radio(radio):
         raise errors.RadioError("Failed to communicate with the radio: %s" % e)
 
 
-def send_mem_chunk(radio, start, stop, bs=32):
+def send_mem_chunk(radio, stream, start, stop, bs=32):
     """Send a single chunk of the radio's memory from @start-@stop"""
     _mmap = radio.get_mmap()
 
@@ -343,6 +347,8 @@ def send_mem_chunk(radio, start, stop, bs=32):
                          chunk,
                          raw=False,
                          checksum=True)
+
+        stream.get_frames(1)
 
         if radio.status_fn:
             status.cur = i+bs
@@ -377,9 +383,8 @@ def _clone_to_radio(radio):
     frames = []
 
     for start, stop, bs in radio.get_ranges():
-        if not send_mem_chunk(radio, start, stop, bs):
+        if not send_mem_chunk(radio, stream, start, stop, bs):
             break
-        frames += stream.get_frames()
 
     send_clone_frame(radio, CMD_CLONE_END, radio.get_endframe(), raw=True)
 


### PR DESCRIPTION
At some point we apparently started slamming data down the serial line at too high a rate for older radios. When using an ID-800, the clone dialog finishes in a few seconds, and the radio times out because it missed a huge chunk of the image because it overran its buffer. This seemed to work okay for radios that use the direct serial connection to the 2.5mm data jack, but not via the OPC-478 type interface.

This change makes us read our own echo frames before sending the next one, which slows us down a lot. It feels a lot slower, but it means we're at least pacing the physical echo.

Tested with an ID-800, ID-880 and IC-2820 and this fixes things.