### PR TITLE
Fix download for Baofeng UV-5R for py3

### DIFF
--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -602,7 +602,7 @@ def _do_download(radio):
             data += _read_block(radio, i, 0x40, False)
 
     if append_model:
-        data += radio.MODEL.ljust(8).encode('ascii', 'ignore')
+        data += radio.MODEL.ljust(8).encode()
 
     LOG.debug("done.")
     return memmap.MemoryMapBytes(data)

--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -602,7 +602,7 @@ def _do_download(radio):
             data += _read_block(radio, i, 0x40, False)
 
     if append_model:
-        data += radio.MODEL.ljust(8)
+        data += radio.MODEL.ljust(8).encode('ascii', 'ignore')
 
     LOG.debug("done.")
     return memmap.MemoryMapBytes(data)


### PR DESCRIPTION
Downloading from UV-5R using Python3 would fail with this error:

ERROR: Failed to clone: Failed to communicate with radio: can't concat str to bytes

As Tony Fuller pointed out in issue #10082, this happened because we were trying to append the radio model name as a string to the downloaded data, which was a bytes array.

To fix this, we now encode the model name before appending it to the data.

Testing: I tried this with my UV-5R and confirmed that the fix works and I can download data.