### PR TITLE
hg_uv98: skip register if `future` is not available

### DIFF
--- a/chirp/drivers/hg_uv98.py
+++ b/chirp/drivers/hg_uv98.py
@@ -20,7 +20,6 @@
 #  KG7KMV and Bartłomiej Zieliński
 # Based on the implementation of Kenwood TK-8102
 
-from builtins import bytes
 import os
 import logging
 import struct
@@ -32,6 +31,18 @@ from chirp.settings import RadioSettingValueBoolean, RadioSettingValueList
 from chirp.settings import RadioSettingValueString, RadioSettings
 
 LOG = logging.getLogger(__name__)
+
+# Gross hack to handle missing future module on un-updatable
+# platforms like MacOS. Just avoid registering these radio
+# classes for now.
+try:
+    from builtins import bytes
+    has_future = True
+except ImportError:
+    has_future = False
+    LOG.debug('python-future package is not '
+              'available; %s requires it' % __name__)
+
 
 MEM_FORMAT = """
 #seekto 0x0000;
@@ -308,7 +319,6 @@ class RadioSettingValueChannel(RadioSettingValueList):
         return int(self.get_value().partition(" ")[0])
 
 
-@directory.register
 class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
     """
     Lanchonlh HG-UV98
@@ -895,3 +905,7 @@ class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRad
 
             if hasattr(_settings, name):
                 setattr(_settings, name, value)
+
+
+if has_future:
+    LanchonlhHG_UV98 = directory.register(LanchonlhHG_UV98)


### PR DESCRIPTION
this driver currently depends on builtins.bytes

ass try/except ImportError when doing

```
from builtins import bytes
```

since some platforms dont have the `future` package and the driver shouldn't crash the whole program in those cases.

fixes #10110