### PR TITLE
Properly handle immutable settings

### DIFF
--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -239,6 +239,7 @@ class ChirpSettingGrid(wx.Panel):
                     LOG.warning('Unsupported setting type %r' % value)
                     editor = None
                 if editor:
+                    editor.Enable(value.get_mutable())
                     self.pg.Append(editor)
 
     @property

--- a/chirp/wxui/settingsedit.py
+++ b/chirp/wxui/settingsedit.py
@@ -66,6 +66,10 @@ class ChirpSettingsEdit(common.ChirpEditor):
             for i in range(self._group_control.GetPageCount()):
                 page = self._group_control.GetPage(i)
                 for name, (setting, val) in page.get_setting_values().items():
+                    if not setting.value.get_mutable():
+                        LOG.debug('Skipping immutable setting %r' % (
+                            setting.get_name()))
+                        continue
                     LOG.debug('Setting %s:%s=%r' % (page.name,
                                                     setting.get_name(),
                                                     val))


### PR DESCRIPTION
This makes immutable settings insensitive to input in the UI, and avoids trying to set them on update.