### PR TITLE
Fix Float properties

### DIFF
--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -67,6 +67,9 @@ class RadioSettingValue:
     def __trunc__(self):
         return int(self.get_value())
 
+    def __float__(self):
+        return float(self.get_value())
+
     def __str__(self):
         return str(self.get_value())
 

--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -263,15 +263,20 @@ class ChirpSettingGrid(wx.Panel):
                                 value=int(value))
 
     def _get_editor_float(self, setting, value):
-        class ChirpFloatProperty(wx.propgrid.IntProperty):
+        class ChirpFloatProperty(wx.propgrid.FloatProperty):
             def ValidateValue(self, val, info):
-                if not (val > value.get_min() and val < value.get_max()):
+                if value.get_min() and not val >= value.get_min():
                     info.SetFailureMessage(
-                        _('Value must be between %.4f and %.4f') % (
-                            value.get_min(), value.get_max()))
+                        _('Value must be at least %.4f' % value.get_min()))
+                    return False
+                if value.get_max() and not val <= value.get_max():
+                    info.SetFailureMessage(
+                        _('Value must be at most %.4f' % value.get_max()))
+                    return False
+                return True
         return ChirpFloatProperty(setting.get_shortname(),
                                   setting.get_name(),
-                                  value=int(value))
+                                  value=float(value))
 
     def _get_editor_choice(self, setting, value):
         choices = value.get_options()


### PR DESCRIPTION
Apparently the ChirpFloatProperty was copied from ChirpIntProperty and never updated. This makes it work as expected.