### PR TITLE
Fix settings with multiple values

### DIFF
--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -450,7 +450,7 @@ class RadioSetting(RadioSettingGroup):
             if len(self) == 1:
                 return self._elements[self._element_order[0]]
             else:
-                return self._elements.values()
+                return list(self._elements.values())
         else:
             return self.__dict__[name]
 

--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -223,6 +223,10 @@ class ChirpSettingGrid(wx.Panel):
             if not isinstance(element, settings.RadioSetting):
                 LOG.debug('Skipping nested group %s' % element)
                 continue
+            if len(element.keys()) > 1:
+                self.pg.Append(wx.propgrid.PropertyCategory(
+                    element.get_shortname()))
+
             for i in element.keys():
                 value = element[i]
                 if isinstance(value, settings.RadioSettingValueInteger):
@@ -239,6 +243,9 @@ class ChirpSettingGrid(wx.Panel):
                     LOG.warning('Unsupported setting type %r' % value)
                     editor = None
                 if editor:
+                    editor.SetName('%s@%i' % (name, i))
+                    if len(element.keys()) > 1:
+                        editor.SetLabel('')
                     editor.Enable(value.get_mutable())
                     self.pg.Append(editor)
 
@@ -312,11 +319,12 @@ class ChirpSettingGrid(wx.Panel):
         """Return a dict of {name: (RadioSetting, newvalue)}"""
         values = {}
         for prop in self.pg._Items():
+            basename = prop.GetName().split('@')[0]
             if isinstance(prop, wx.propgrid.EnumProperty):
-                value = self._choices[prop.GetName()][prop.GetValue()]
+                value = self._choices[basename][prop.GetValue()]
             else:
                 value = prop.GetValue()
-            setting = self._group[prop.GetName()]
+            setting = self._group[basename]
             values[prop.GetName()] = setting, value
         return values
 

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -714,7 +714,7 @@ class ChirpMemPropDialog(wx.Dialog):
                 for setting in mem.extra:
                     name = setting.get_name()
                     try:
-                        setting.value = extra[name]
+                        setting.value = extra['%s@0' % name]
                     except KeyError:
                         raise
                         LOG.warning('Missing setting %r' % name)

--- a/chirp/wxui/settingsedit.py
+++ b/chirp/wxui/settingsedit.py
@@ -66,14 +66,22 @@ class ChirpSettingsEdit(common.ChirpEditor):
             for i in range(self._group_control.GetPageCount()):
                 page = self._group_control.GetPage(i)
                 for name, (setting, val) in page.get_setting_values().items():
-                    if not setting.value.get_mutable():
-                        LOG.debug('Skipping immutable setting %r' % (
-                            setting.get_name()))
-                        continue
-                    LOG.debug('Setting %s:%s=%r' % (page.name,
-                                                    setting.get_name(),
-                                                    val))
-                    setting.value = val
+                    if isinstance(setting.value, list):
+                        values = setting.value
+                    else:
+                        values = [setting.value]
+                    for j, value in enumerate(values):
+                        if not value.get_mutable():
+                            LOG.debug('Skipping immutable setting %r' % (
+                                setting.get_name()))
+                            continue
+                        LOG.debug('Setting %s:%s[%i]=%r' % (page.name,
+                                                            setting.get_name(),
+                                                            j,
+                                                            val))
+                        realname, index = name.split('@')
+                        if int(index) == j:
+                            setting[j] = val
             return True
         except Exception as e:
             LOG.exception('Failed to apply settings')


### PR DESCRIPTION
RadioSetting objects can have multiple values, which the wxui settings editor does not support properly. Unfortunately, the design of the propgrid makes it hard to support this, so this patch uses a property name of name@index for the properties to separate them. It's not great, but it works for now.

This should fix the problem reported in #122 