### PR TITLE
Fix setting properties with categories

### DIFF
--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -319,6 +319,8 @@ class ChirpSettingGrid(wx.Panel):
         """Return a dict of {name: (RadioSetting, newvalue)}"""
         values = {}
         for prop in self.pg._Items():
+            if prop.IsCategory():
+                continue
             basename = prop.GetName().split('@')[0]
             if isinstance(prop, wx.propgrid.EnumProperty):
                 value = self._choices[basename][prop.GetValue()]


### PR DESCRIPTION
The previous patch added category headers to multi-value props to make them visually easier to read. Those show up in the list to apply, which won't work of course because they're just labels. Skip those on apply.