### PR TITLE
Reserve some characters from setting names

### DIFF
--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -15,6 +15,8 @@
 
 from chirp import chirp_common
 
+BANNED_NAME_CHARACTERS = r'%'
+
 
 class InvalidValueError(Exception):
 
@@ -25,6 +27,11 @@ class InvalidValueError(Exception):
 class InternalError(Exception):
 
     """A driver provided an invalid settings object structure"""
+    pass
+
+
+class InvalidNameError(Exception):
+    """A driver provided a setting with an invalid name"""
     pass
 
 
@@ -306,6 +313,10 @@ class RadioSettingGroup(object):
             raise InternalError("Incorrect type %s" % type(element))
 
     def __init__(self, name, shortname, *elements):
+        for c in BANNED_NAME_CHARACTERS:
+            if c in name:
+                raise InvalidNameError(
+                    'Name must not contain %r character' % c)
         self._name = name            # Setting identifier
         self._shortname = shortname  # Short human-readable name/description
         self.__doc__ = name          # Longer explanation/documentation

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -140,3 +140,12 @@ class TestSettingContainers(base.BaseTest):
         rs.set_apply_callback(test_cb, "foo", "bar")
         self.assertTrue(rs.has_apply_callback())
         self.assertRaises(TestException, rs.run_apply_callback)
+
+    def test_setting_banned_name(self):
+        self.assertRaises(settings.InvalidNameError,
+                          settings.RadioSetting, "foo%bar", "Foo")
+
+    def test_setting_banned_name_characters(self):
+        for c in settings.BANNED_NAME_CHARACTERS:
+            self.assertRaises(settings.InvalidNameError,
+                              settings.RadioSetting, "foo%sbar" % c, "Foo")


### PR DESCRIPTION
This creates a list of banned characters for use in setting name
identifiers so that the setting editor can mark them up in more
convenient ways.
