### PR TITLE
[QRZ-1] Add support for Intro Lines that are padded with null characters

### DIFF
--- a/chirp/drivers/th_uv88.py
+++ b/chirp/drivers/th_uv88.py
@@ -917,7 +917,10 @@ class THUV88Radio(chirp_common.CloneModeRadio):
         # software only
         name = ""
         for i in range(15):  # 0 - 15
-            name += chr(self._memobj.openradioname.name1[i])
+            char = chr(self._memobj.openradioname.name1[i])
+            if char == "\x00":
+                char = " "  # Other software may have 0x00 mid-name
+            name += char
         name = name.rstrip()  # remove trailing spaces
 
         rx = RadioSettingValueString(0, 15, name)
@@ -927,7 +930,10 @@ class THUV88Radio(chirp_common.CloneModeRadio):
         # software only
         name = ""
         for i in range(15):  # 0 - 15
-            name += chr(self._memobj.openradioname.name2[i])
+            char = chr(self._memobj.openradioname.name2[i])
+            if char == "\x00":
+                char = " "  # Other software may have 0x00 mid-name
+            name += char
         name = name.rstrip()  # remove trailing spaces
 
         rx = RadioSettingValueString(0, 15, name)


### PR DESCRIPTION
The QRZ-1 (and variants like the TYT TH-UV88 and Retevis RT85) come from
the factory with the Intro Lines right-padded with spaces. The CHIRP driver
for these radios expects them to be padded with spaces.

It is now known that it is possible for the Intro Lines to also be right-
padded with null characters. When this is encountered, the Settings tabs
are blank.

This patch adds support to gracefully handle Intro Lines that have been
padded with null characters.

fixes #10129
