### PR TITLE
tox windows

### DIFF
--- a/chirp/drivers/icf.py
+++ b/chirp/drivers/icf.py
@@ -591,7 +591,7 @@ def read_file(filename):
 
 def write_file(radio, filename):
     """Write an ICF file"""
-    f = open(filename, 'w')
+    f = open(filename, 'w', newline='\r\n')
 
     model = radio._model
     mdata = '%02x%02x%02x%02x' % (ord(model[0]),
@@ -600,18 +600,18 @@ def write_file(radio, filename):
                                   ord(model[3]))
     data = radio._mmap.get_packed()
 
-    f.write('%s\r\n' % mdata)
-    f.write('#Comment=%s\r\n' % radio._icf_data.get('Comment', ''))
-    f.write('#MapRev=%i\r\n' % radio._icf_data.get('MapRev', 1))
-    f.write('#EtcData=%06i\r\n' % radio._icf_data.get('EtcData', 0))
+    f.write('%s\n' % mdata)
+    f.write('#Comment=%s\n' % radio._icf_data.get('Comment', ''))
+    f.write('#MapRev=%i\n' % radio._icf_data.get('MapRev', 1))
+    f.write('#EtcData=%06i\n' % radio._icf_data.get('EtcData', 0))
 
     blksize = radio._icf_data.get('recordsize', 32)
     for addr in range(0, len(data), blksize):
         block = binascii.hexlify(data[addr:addr + blksize]).decode().upper()
         if blksize == 32:
-            line = '%08X%02X%s\r\n' % (addr, blksize, block)
+            line = '%08X%02X%s\n' % (addr, blksize, block)
         else:
-            line = '%04X%02X%s\r\n' % (addr, blksize, block)
+            line = '%04X%02X%s\n' % (addr, blksize, block)
         f.write(line)
     f.close()
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,8 @@ pytest
 pytest-xdist
 pytest-html
 six
+pep8
 pyserial
 future
 requests
+pywin32; platform_system=="Windows"

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -320,23 +320,27 @@ class TestImageMetadata(base.BaseTest):
         self.assertEqual(expected, metadata)
 
     def test_load_mmap_no_metadata(self):
-        f = tempfile.NamedTemporaryFile()
-        f.write(b'thisisrawdata')
-        f.flush()
+        fn = os.path.join(tempfile.gettempdir(), 'testfile')
+        with open(fn, 'wb') as f:
+            f.write(b'thisisrawdata')
+            f.flush()
 
         with mock.patch('chirp.memmap.MemoryMap') as mock_mmap:
-            chirp_common.FileBackedRadio(None).load_mmap(f.name)
+            chirp_common.FileBackedRadio(None).load_mmap(fn)
             mock_mmap.assert_called_once_with(b'thisisrawdata')
+        os.remove(fn)
 
     def test_load_mmap_bad_metadata(self):
-        f = tempfile.NamedTemporaryFile()
-        f.write(b'thisisrawdata')
-        f.write(chirp_common.FileBackedRadio.MAGIC + b'bad')
-        f.flush()
+        fn = os.path.join(tempfile.gettempdir(), 'testfile')
+        with open(fn, 'wb') as f:
+            f.write(b'thisisrawdata')
+            f.write(chirp_common.FileBackedRadio.MAGIC + b'bad')
+            f.flush()
 
         with mock.patch('chirp.memmap.MemoryMap') as mock_mmap:
-            chirp_common.FileBackedRadio(None).load_mmap(f.name)
+            chirp_common.FileBackedRadio(None).load_mmap(fn)
             mock_mmap.assert_called_once_with(b'thisisrawdata')
+        os.remove(fn)
 
     def test_save_mmap_includes_metadata(self):
         # Make sure that a file saved with a .img extension includes
@@ -346,8 +350,7 @@ class TestImageMetadata(base.BaseTest):
             MODEL = 'Foomaster 9000'
             VARIANT = 'R'
 
-        with tempfile.NamedTemporaryFile(suffix='.Img') as f:
-            fn = f.name
+        fn = os.path.join(tempfile.gettempdir(), 'test.img')
         r = TestRadio(None)
         r._mmap = mock.Mock()
         r._mmap.get_byte_compatible.return_value.get_packed.return_value = (

--- a/tests/unit/test_icf.py
+++ b/tests/unit/test_icf.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import shutil
 import tempfile
 import unittest
 
@@ -22,60 +23,70 @@ from chirp.drivers import ic2820, icf, id31
 
 
 class TestFileICF(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+
+    def cleanUp(self):
+        shutil.rmtree(self.tempdir)
+
     def test_read_icf_data_modern(self):
-        with tempfile.NamedTemporaryFile(suffix='.icf', mode='w') as f:
-            f.write('12345678\r\n#Foo=somefoovalue\r\n#Bar=123\r\n')
+        fn = os.path.join(self.tempdir, 'test.icf')
+        with open(fn, 'w', newline='\r\n') as f:
+            f.write('12345678\n#Foo=somefoovalue\n#Bar=123\n')
             f.write('0000000020015C70000020800000E4002020202020'
-                    '20202020202020202020200040810204\r\n')
+                    '20202020202020202020200040810204\n')
             f.write('000000202008102040810204081020408102040810'
-                    '20015B9903E821700000E4284C614772\r\n')
-            f.write('#CD=fakehash\r\n')
+                    '20015B9903E821700000E4284C614772\n')
+            f.write('#CD=fakehash\n')
             f.flush()
 
-            icfdata, mmap = icf.read_file(f.name)
+        icfdata, mmap = icf.read_file(fn)
 
-            self.assertEqual({'model': b'\x12\x34\x56\x78',
-                              'Foo': 'somefoovalue',
-                              'Bar': 123,
-                              'recordsize': 32,
-                              'CD': 'fakehash'}, icfdata)
+        self.assertEqual({'model': b'\x12\x34\x56\x78',
+                          'Foo': 'somefoovalue',
+                          'Bar': 123,
+                          'recordsize': 32,
+                          'CD': 'fakehash'}, icfdata)
 
-            try:
-                directory.icf_to_radio(f.name)
-            except Exception as e:
-                self.assertIn('12345678', str(e))
-            else:
-                self.fail('Directory failed to reject unknown model')
+        try:
+            directory.icf_to_radio(fn)
+        except Exception as e:
+            self.assertIn('12345678', str(e))
+        else:
+            self.fail('Directory failed to reject unknown model')
 
     def test_read_icf_data_old(self):
-        with tempfile.NamedTemporaryFile(suffix='.icf', mode='w') as f:
-            f.write('29700001\r\n#\r\n')
-            f.write('00001008BBB7C0000927C04351435143512020\r\n')
-            f.write('00101020202020202020202020202020202020\r\n')
+        fn = os.path.join(self.tempdir, 'test.icf')
+        with open(fn, 'w', newline='\r\n') as f:
+            f.write('29700001\n#\n')
+            f.write('00001008BBB7C0000927C04351435143512020\n')
+            f.write('00101020202020202020202020202020202020\n')
             f.flush()
 
-            icfdata, mmap = icf.read_file(f.name)
+        icfdata, mmap = icf.read_file(fn)
 
-            self.assertEqual({'model': b'\x29\x70\x00\x01',
-                              'recordsize': 16}, icfdata)
+        self.assertEqual({'model': b'\x29\x70\x00\x01',
+                          'recordsize': 16}, icfdata)
 
     def test_read_write_icf(self):
-        with tempfile.NamedTemporaryFile(suffix='.icf', mode='w') as f:
+        fn1 = os.path.join(self.tempdir, 'test1.icf')
+        with open(fn1, 'w', newline='\r\n') as f:
             # These are different values than the default, so make
             # sure we persist them to the output ICF file.
-            f.write('33220001\r\n#MapRev=2\r\n#EtcData=000006\r\n')
+            f.write('33220001\n#MapRev=2\n#EtcData=000006\n')
             f.write('0000000020015C70000020800000E4002020202020'
-                    '20202020202020202020200040810204\r\n')
+                    '20202020202020202020200040810204\n')
             f.write('000000202008102040810204081020408102040810'
-                    '20015B9903E821700000E4284C614772\r\n')
-            f.write('#CD=fakehash\r\n')
+                    '20015B9903E821700000E4284C614772\n')
+            f.write('#CD=fakehash\n')
             f.flush()
 
-            r = id31.ID31Radio(f.name)
+        r = id31.ID31Radio(fn1)
 
-        with tempfile.NamedTemporaryFile(suffix='.icf', mode='w') as f:
-            r.save(f.name)
-            icfdata, mmap = icf.read_file(f.name)
+        fn2 = os.path.join(self.tempdir, 'test2.icf')
+        with open(fn2, 'w', newline='\r\n') as f:
+            r.save(fn2)
+            icfdata, mmap = icf.read_file(fn2)
             self.assertEqual({'MapRev': 2,
                               'EtcData': 6,
                               'Comment': '',
@@ -87,10 +98,11 @@ class TestFileICF(unittest.TestCase):
                                 '..', 'images', 'Icom_ID-31A.img')
 
         r = id31.ID31Radio(img_file)
-        with tempfile.NamedTemporaryFile(suffix='.icf', mode='w') as f:
-            r.save(f.name)
+        fn = os.path.join(self.tempdir, 'test.icf')
+        with open(fn, 'w', newline='\r\n') as f:
+            r.save(fn)
 
-            icfdata, mmap = icf.read_file(f.name)
+            icfdata, mmap = icf.read_file(fn)
             # If we sourced from an image, we use our defaults in
             # generating the ICF metdata
             self.assertEqual({'MapRev': 1,
@@ -100,7 +112,7 @@ class TestFileICF(unittest.TestCase):
                               'recordsize': 32}, icfdata)
 
             self.assertEqual(id31.ID31Radio,
-                             directory.icf_to_radio(f.name))
+                             directory.icf_to_radio(fn))
 
 
     def test_read_img_write_icf_old(self):
@@ -108,10 +120,11 @@ class TestFileICF(unittest.TestCase):
                                 '..', 'images', 'Icom_IC-2820H.img')
 
         r = ic2820.IC2820Radio(img_file)
-        with tempfile.NamedTemporaryFile(suffix='.icf', mode='w') as f:
-            r.save(f.name)
+        fn = os.path.join(self.tempdir, 'test.icf')
+        with open(fn, 'w', newline='\r\n') as f:
+            r.save(fn)
 
-            icfdata, mmap = icf.read_file(f.name)
+            icfdata, mmap = icf.read_file(fn)
             self.assertEqual({'MapRev': 1,
                               'EtcData': 0,
                               'Comment': '',
@@ -119,7 +132,7 @@ class TestFileICF(unittest.TestCase):
                               'recordsize': 16}, icfdata)
 
             self.assertEqual(ic2820.IC2820Radio,
-                             directory.icf_to_radio(f.name))
+                             directory.icf_to_radio(fn))
 
 
 class TestCloneICF(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = unit,driver,style,py3clean,py3unit,py3driver
+envlist = style,py3unit,py3driver
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
- Fix up icf writing tests for consistent newlines
- Fixes for tests under windows
- Changes to common unit tests for windows
