### PR TITLE
Add support for "CRT 279 UV" KT7900D Clone

### DIFF
--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -253,6 +253,7 @@ KT7900D_fp5 = "VC4254"
 KT7900D_fp6 = "VC5264"
 KT7900D_fp7 = "VC9204"
 KT7900D_fp8 = "VC9214"
+KT7900D_fp9 = "VC5302"
 
 # QB25 (quad band) - a clone of KT7900D
 QB25_fp = "QB-25"
@@ -4147,7 +4148,8 @@ class KT7900D(BTechColor):
     _350_range = (350000000, 371000000)
     _magic = MSTRING_KT8900D
     _fileid = [KT7900D_fp, KT7900D_fp1, KT7900D_fp2, KT7900D_fp3, KT7900D_fp4,
-               KT7900D_fp5, KT7900D_fp6, KT7900D_fp7, KT7900D_fp8, QB25_fp, ]
+               KT7900D_fp5, KT7900D_fp6, KT7900D_fp7, KT7900D_fp8, KT7900D_fp9,
+               QB25_fp, ]
     # Clones
     ALIASES = [SKT8900D, QB25, ]
 


### PR DESCRIPTION
Added chip version VC5302 to KT7900D.
Using QYT -> KT7900D Fully functional
Attached Factory default image downloaded with the changes.

[QYT_KT7900D_20221122.img.gz](https://github.com/kk7ds/chirp/files/10066554/QYT_KT7900D_20221122.img.gz)
