### PR TITLE
Implement ICF hashing

### DIFF
--- a/tests/unit/test_icf.py
+++ b/tests/unit/test_icf.py
@@ -80,6 +80,7 @@ class TestFileICF(unittest.TestCase):
                               'EtcData': 6,
                               'Comment': '',
                               'model': r._model,
+                              'CD': '9674E1C86BA17D36DB9D3D8A144F1081',
                               'recordsize': 32}, icfdata)
 
     def test_read_img_write_icf_modern(self):
@@ -97,6 +98,7 @@ class TestFileICF(unittest.TestCase):
                               'EtcData': 5,
                               'Comment': '',
                               'model': r._model,
+                              'CD': '9F240F598EF20683726ED252278C61D0',
                               'recordsize': 32}, icfdata)
 
             self.assertEqual(id31.ID31Radio,


### PR DESCRIPTION
This adds generating the proper #CD=$hash value at the end of ICF
files, which is required for the radio to read the image off of an
SD card. Tested with a real ID31, but it also generate the same
hash as CS-5100 for ID5100.
