### PR TITLE
Fix DMR-MARC query

### DIFF
--- a/chirp/dmrmarc.py
+++ b/chirp/dmrmarc.py
@@ -44,28 +44,26 @@ class DMRMARCRadio(chirp_common.NetworkSourceRadio):
 
     def set_params(self, city, state, country):
         """Set the parameters to be used for a query"""
-        self._city = city and [x.strip() for x in city.split(",")] or ['']
-        self._state = state and [x.strip() for x in state.split(",")] or ['']
-        self._country = country and [x.strip() for x in country.split(",")] \
-            or ['']
+        self._city = city
+        self._state = state
+        self._country = country
 
     def do_fetch(self):
+        url = 'https://radioid.net/api/dmr/repeater/?%s' % (
+                   urllib.urlencode([('city', self._city),
+                                     ('state', self._state),
+                                     ('country', self._country)]))
         fn = tempfile.mktemp(".json")
-        filename, headers = urllib.urlretrieve(self.URL, fn)
+        filename, headers = urllib.urlretrieve(url, fn)
         with open(fn, 'r') as f:
             try:
-                self._repeaters = json.load(f)['repeaters']
+                self._repeaters = json.load(f)['results']
             except AttributeError:
                 raise errors.RadioError(
                     "Unexpected response from %s" % self.URL)
             except ValueError as e:
                 raise errors.RadioError(
                     "Invalid JSON from %s. %s" % (self.URL, str(e)))
-
-        self._repeaters = list_filter(self._repeaters, "city", self._city)
-        self._repeaters = list_filter(self._repeaters, "state", self._state)
-        self._repeaters = list_filter(self._repeaters, "country",
-                                      self._country)
 
     def get_features(self):
         if not self._repeaters:
@@ -102,7 +100,7 @@ class DMRMARCRadio(chirp_common.NetworkSourceRadio):
             mem.duplex = ""
         mem.offset = abs(offset)
         mem.mode = 'DMR'
-        mem.comment = repeater.get('map_info')
+        mem.comment = repeater.get('details')
 
         mem.extra = RadioSettingGroup("Extra", "extra")
 

--- a/tests/unit/test_network_sources.py
+++ b/tests/unit/test_network_sources.py
@@ -1,0 +1,24 @@
+import unittest
+
+from chirp import dmrmarc
+
+# Hopefully this will provide a sentinel and forcing function for
+# network sources when APIs stop working. Unfortunately, live queries
+# are more likely to add spurious failures into the tests, but time
+# will tell if it's worth it.
+
+class TestDMRMARC(unittest.TestCase):
+    def test_marc_works(self):
+        r = dmrmarc.DMRMARCRadio(None)
+        r.set_params('portland', 'oregon', '')
+        f = r.get_features()
+
+        # Assert that we found some repeaters. If they all go away in
+        # Portland, this will break and we will need another target
+        self.assertGreater(f.memory_bounds[1], 2)
+
+        for i in range(*f.memory_bounds):
+            m = r.get_memory(i)
+            self.assertEqual('DMR', m.mode)
+            # Assume all DMR repeaters are above 100MHz
+            self.assertGreater(m.freq, 100000000)


### PR DESCRIPTION
The API has moved and changed a bit, and the expected format of the
query parameters is different. This seems to work for me in my area
with the following:

City: Portland
State: Oregon
Country: United States

Using a state abbreviation, or a country name like "us" or "usa" do
not work.
