### PR TITLE
Exclude tests/ from getting installed as packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ stock_configs = glob("stock_configs/*")
 
 setup(name='chirp',
       descrption='A cross-platform cross-radio programming tool',
-      packages=find_packages(),
+      packages=find_packages(exclude=["tests", "tests.*"]),
       version=CHIRP_VERSION,
       url='https://chirp.danplanet.com',
       python_requires=">=3.3,<4",


### PR DESCRIPTION
`setuptools.find_packages()` [without parameters finds every directory resembling a package in the root directory by default](https://setuptools.pypa.io/en/latest/userguide/quickstart.html#package-discovery), including `tests/`. As a result, `tests` get installed as a separate package in `site-packages`, and in a system installation (ie not a virtualenv), this conflicts with other packages named `tests` (which also shouldn't happen but that's a different story). Exclude them from getting installed, but still have them present for their intended uses.