### PR TITLE
Fix flip_high_order_bit() on py3

### DIFF
--- a/chirp/drivers/icf.py
+++ b/chirp/drivers/icf.py
@@ -952,7 +952,7 @@ class IcomCloneModeRadio(chirp_common.CloneModeRadio):
 
 
 def flip_high_order_bit(data):
-    return [chr(ord(d) ^ 0x80) for d in list(data)]
+    return bytes([d ^ 0x80 for d in list(data)])
 
 
 def escape_raw_byte(byte):


### PR DESCRIPTION
Some remaining unconverted string manip from the py2 branch.
