### PR TITLE
Let tox install us properly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist = style,py3unit,py3driver
-skipsdist = True
 
 [testenv]
 basepython = python2.7
@@ -33,13 +32,12 @@ commands =
 [testenv:style]
 basepython = python3
 sitepackages = False
-whitelist_externals = python3.exe
 deps =
     pep8
     future
     flake8
 commands =
-    python3 ./tools/cpep8.py
+    python ./tools/cpep8.py
     flake8 --builtins="_" chirp/wxui
 
 [textenv:py3clean]
@@ -76,11 +74,9 @@ basepython = python3
 sitepackages = False
 whitelist_externals =
     git
-    python3.exe
 deps =
     -rtest-requirements.txt
 commands =
-    python3 share/make_supported.py model_support.html
-    python3 setup.py develop
-    python3 tools/py3_driver_progress.py -o tests/Python3_Driver_Testing.md tests/py3_driver_testers.txt
+    python share/make_supported.py model_support.html
+    python tools/py3_driver_progress.py -o tests/Python3_Driver_Testing.md tests/py3_driver_testers.txt
     git diff --exit-code tests/Python3_Driver_Testing.md


### PR DESCRIPTION
This avoids the need for develop in the makesupported target. Also,
use "python" in the test commands, which tox links to the basepython.
Otherwise it's possible to run python from outside the virtualenv,
like on windows with "python3". This is why we needed to add
python3.exe and why we don't need it anymore.
