### PR TITLE
Close editorset when closing page

### DIFF
--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -906,6 +906,7 @@ class ChirpMain(wx.Frame):
 
     def _menu_close(self, event):
         if self._prompt_to_close_editor(self.current_editorset):
+            self.current_editorset.close()
             self._editors.DeletePage(self._editors.GetSelection())
             self._update_window_for_editor()
 


### PR DESCRIPTION
When a page is deleted from the notebook, the corresponding editorset is not closed. This can leave running threads, which will prevent a clean exit from the application. For example: Download from a radio; close the corresponding page; exit Chirp; the application hangs on exit. Fix: explicitly close the editorset before deleting the page from the notebook.