### PR TITLE
Improve sync between browser and other tabs

### DIFF
--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -133,6 +133,9 @@ class ChirpEditor(wx.Panel):
     def status_message(self, message):
         wx.PostEvent(self, StatusMessage(self.GetId(), message=message))
 
+    def refresh(self):
+        pass
+
     def cb_copy(self, cut=False):
         pass
 

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -138,12 +138,21 @@ class ChirpEditorSet(wx.Panel):
         if (CONF.get_bool('developer', 'state') and
                 not isinstance(radio, chirp_common.LiveRadio)):
             browser = developer.ChirpRadioBrowser(parent_radio, self._editors)
+            browser.Bind(common.EVT_EDITOR_CHANGED, self._refresh_all)
             self.add_editor(browser, _('Browser'))
             info = radioinfo.ChirpRadioInfo(parent_radio, self._editors)
             self.add_editor(info, _('Info'))
 
         # After the GUI is built, set focus to the current editor
         wx.CallAfter(self.current_editor.SetFocus)
+
+    def _refresh_all(self, event):
+        LOG.info('Radio browser changed; refreshing all others')
+        for i in range(self._editors.GetPageCount()):
+            editor = self._editors.GetPage(i)
+            if editor.GetId() != event.GetId():
+                LOG.debug('refreshing %s' % editor)
+                editor.refresh()
 
     def _editor_changed(self, event):
         self._modified = True

--- a/chirp/wxui/settingsedit.py
+++ b/chirp/wxui/settingsedit.py
@@ -54,6 +54,11 @@ class ChirpSettingsEdit(common.ChirpEditor):
             self.do_radio(lambda job: wx.CallAfter(self._initialize, job),
                           'get_settings')
 
+    def refresh(self):
+        self._group_control.DeleteAllPages()
+        # Next select will re-load everything
+        self._initialized = False
+
     def _load_settings(self):
         for group in self._settings:
             self._add_group(group)


### PR DESCRIPTION
This makes us refresh browser panels when we have made changes on
another tab, and also the reverse.

Fixes #10179
