### PR TITLE
Bugfix unassigned RR import

### DIFF
--- a/chirp/wxui/query_sources.py
+++ b/chirp/wxui/query_sources.py
@@ -515,7 +515,7 @@ class RRCAQueryDialog(QuerySourceDialog):
         return vbox
 
     def populateprov(self, event):
-        self.selected_province(event.GetString)
+        self.selected_province(provchoice.GetStringSelection())
 
     def populatepc(self):
         # init and grab conf defaults and populate the selector


### PR DESCRIPTION
When you very kindly moved my EVT_CHOICE method for the province selector to where it should be, it broke the populating of the county Choice dropdown when user changes province Choice selector. Here's a fix. Probably not the "right" fix, but it restores it to a working state.