### PR TITLE
Wrap unwrapped radio prompts

### DIFF
--- a/chirp/wxui/clone.py
+++ b/chirp/wxui/clone.py
@@ -15,6 +15,7 @@
 
 import collections
 import logging
+import textwrap
 import threading
 
 import serial
@@ -118,6 +119,9 @@ class ChirpRadioPromptDialog(wx.Dialog):
 
         prompts = self.radio.get_prompts()
         self.message = getattr(prompts, self.prompt)
+
+        if '\n' not in self.message:
+            self.message = '\n'.join(textwrap.wrap(self.message))
 
         bs = self.CreateButtonSizer(buttons)
         vbox = wx.BoxSizer(wx.VERTICAL)


### PR DESCRIPTION
The move to allowing markup-based radio prompts caused us to display
un-marked-up prompts as long single lines. If there are no newlines
in the prompt, assume it may need wrapping for proper visuals.
Otherwise, take the prompt as-is.
