### PR TITLE
Mark ID-51 Plus 2 as implied

### DIFF
--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -105,7 +105,7 @@
 | <a name="Icom_ID-51"></a> Icom_ID-51 | [Implied by Icom_ID-31A](#user-content-Icom_ID-31A) | 1-Dec-2022 | Yes | 0.02% |
 | <a name="Icom_ID-5100"></a> Icom_ID-5100 | [@kk7ds](https://github.com/kk7ds) | 17-Dec-2022 | Yes | 0.00% |
 | <a name="Icom_ID-51_Plus"></a> Icom_ID-51_Plus | [Implied by Icom_ID-31A](#user-content-Icom_ID-31A) | 1-Dec-2022 | Yes | 0.02% |
-| <a name="Icom_ID-51_Plus2"></a> Icom_ID-51_Plus2 |  |  | Yes | 0.00% |
+| <a name="Icom_ID-51_Plus2"></a> Icom_ID-51_Plus2 | [Implied by Icom_ID-31A](#user-content-Icom_ID-31A) | 17-Dec-2022 | Yes | 0.00% |
 | <a name="Icom_ID-800H_v2"></a> Icom_ID-800H_v2 | [@kk7ds](https://github.com/kk7ds) | 22-Oct-2022 | Yes | 0.01% |
 | <a name="Icom_ID-80H"></a> Icom_ID-80H | [Probably works](https://github.com/kk7ds/chirp/blob/py3/chirp/drivers/icf.py) | 22-Oct-2022 | Yes | 0.01% |
 | <a name="Icom_ID-880H"></a> Icom_ID-880H | [@kk7ds](https://github.com/kk7ds) | 22-Oct-2022 | Yes | 0.02% |
@@ -360,7 +360,7 @@
 
 **Drivers:** 355
 
-**Tested:** 71% (253/102) (89% of usage stats)
+**Tested:** 71% (254/101) (89% of usage stats)
 
 **Byte clean:** 80% (287/68)
 

--- a/tests/py3_driver_testers.txt
+++ b/tests/py3_driver_testers.txt
@@ -77,6 +77,7 @@ Icom_IC-910,@mfncooper,1-Oct-2021
 Icom_ID-31A,@kk7ds,1-Dec-2022
 Icom_ID-51,+Icom_ID-31A,1-Dec-2022
 Icom_ID-51_Plus,+Icom_ID-31A,1-Dec-2022
+Icom_ID-51_Plus2,+Icom_ID-31A,17-Dec-2022
 Icom_ID-4100,+Icom_ID-5100,1-Dec-2022
 Icom_ID-5100,@kk7ds,17-Dec-2022
 Icom_ID-800H_v2,@kk7ds,22-Oct-2022


### PR DESCRIPTION
This is basically the same as the ID-31, but uses new raw mode cloning
like the 5100, 2730, etc.
