### PR TITLE
Fix search after recent column addition

### DIFF
--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -974,12 +974,9 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
         self._grid.SelectRow(self.mem2row(number))
 
     def cb_find(self, text):
-        # FIXME: This should be more dynamic
-        cols = [
-            0,   # Freq
-            1,   # Name
-            14,  # Comment
-        ]
+        search_cols = ('freq', 'name', 'comment')
+        cols = [self._col_defs.index(self._col_def_by_name(x))
+                for x in search_cols]
         num_rows = self._grid.GetNumberRows()
         try:
             current_row = self._grid.GetSelectedRows()[0] + 1


### PR DESCRIPTION
Adding DTCS Polarity changed the column ordering, which prevents us
from searching the comment field. This fixes that, and the FIXME in
that code to make the columns we search referenced by name so it does
not happen again.
