### PR TITLE
Use import_logic during paste

### DIFF
--- a/chirp/import_logic.py
+++ b/chirp/import_logic.py
@@ -186,8 +186,7 @@ def _import_duplex(dst_radio, srcrf, mem):
         for lo, hi, limit in ranges:
             if lo < mem.freq <= hi:
                 if abs(mem.offset) > limit:
-                    raise DestNotCompatible("Unable to create import memory: "
-                                            "offset is abnormally large.")
+                    raise DestNotCompatible("offset is abnormally large.")
 
 
 def import_mem(dst_radio, src_features, src_mem, overrides={}):
@@ -225,8 +224,7 @@ def import_mem(dst_radio, src_features, src_mem, overrides={}):
     msgs = dst_radio.validate_memory(dst_mem)
     errs = [x for x in msgs if isinstance(x, chirp_common.ValidationError)]
     if errs:
-        raise DestNotCompatible("Unable to create import memory: %s" %
-                                ", ".join(errs))
+        raise DestNotCompatible(", ".join(errs))
 
     return dst_mem
 


### PR DESCRIPTION
The import_logic routines try to make good decisions about how to
convert a memory from one radio to another. This makes us use that
logic when pasting so that we are more likely to succeed.

This also changes the format of the DestNotCompatible exception
in import_logic to reflect how we want to show it to the users in
the wxui.

Also decorate cb_copy() and cb_paste() with error_proof so we expose
failures to the user.
