### PR TITLE
Fix FT60 for py3

### DIFF
--- a/chirp/drivers/ft60.py
+++ b/chirp/drivers/ft60.py
@@ -27,7 +27,7 @@ from textwrap import dedent
 
 LOG = logging.getLogger(__name__)
 
-ACK = "\x06"
+ACK = b"\x06"
 
 
 def _send(pipe, data):
@@ -38,7 +38,7 @@ def _send(pipe, data):
 
 
 def _download(radio):
-    data = ""
+    data = b""
     for i in range(0, 10):
         chunk = radio.pipe.read(8)
         if len(chunk) == 8:
@@ -70,7 +70,7 @@ def _download(radio):
             status.msg = "Cloning from radio"
             radio.status_fn(status)
 
-    return memmap.MemoryMap(data)
+    return memmap.MemoryMapBytes(data)
 
 
 def _upload(radio):

--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -324,7 +324,7 @@
 | <a name="Yaesu_FT-4XE"></a> Yaesu_FT-4XE |  |  | Yes | 0.14% |
 | <a name="Yaesu_FT-4XR"></a> Yaesu_FT-4XR |  |  | Yes | 0.11% |
 | <a name="Yaesu_FT-50"></a> Yaesu_FT-50 |  |  | Yes | 0.04% |
-| <a name="Yaesu_FT-60"></a> Yaesu_FT-60 |  |  | Yes | 0.49% |
+| <a name="Yaesu_FT-60"></a> Yaesu_FT-60 | Unit tested; needs confirm | 24-Dec-2022 | Yes | 0.49% |
 | <a name="Yaesu_FT-65E"></a> Yaesu_FT-65E |  |  | Yes | 0.08% |
 | <a name="Yaesu_FT-65R"></a> Yaesu_FT-65R |  |  | Yes | 0.18% |
 | <a name="Yaesu_FT-70D"></a> Yaesu_FT-70D | [@n8sqt](https://github.com/n8sqt) | 05-Dec-2022 | Yes | 0.27% |
@@ -362,7 +362,7 @@
 
 **Drivers:** 357
 
-**Tested:** 74% (267/90) (89% of usage stats)
+**Tested:** 75% (268/89) (90% of usage stats)
 
 **Byte clean:** 83% (299/58)
 

--- a/tests/py3_driver_testers.txt
+++ b/tests/py3_driver_testers.txt
@@ -252,6 +252,7 @@ Wouxun_KG-UV6,@KC9HI,11-Dec-2022
 Wouxun_KG-UVD1P,+Wouxun_KG-UV6,11-Dec-2022
 Wouxun_KG-UV920P-A,@KC9HI,22-Dec-2022
 Yaesu_FT-1500M,@f3sty,05-Dec-2022
+Yaesu_FT-60,Unit tested; needs confirm,24-Dec-2022
 Yaesu_FT-70D,@n8sqt,05-Dec-2022
 Yaesu_FT-7800_7900,@kk7ds,24-Oct-2022
 Yaesu_FT-8800,@kk7ds,24-Oct-2022


### PR DESCRIPTION
The FT60 driver is heavily used and extremely simple in its clone
routines. As such, this adds a unit test to exercise that part, which
along with the regular driver tests, should mean this is pretty high
confidence (although not nearly as good as a real test of course).
