### PR TITLE
Probably fix some wouxun_common radios

### DIFF
--- a/chirp/drivers/puxing.py
+++ b/chirp/drivers/puxing.py
@@ -25,19 +25,19 @@ LOG = logging.getLogger(__name__)
 
 
 def _puxing_prep(radio):
-    radio.pipe.write("\x02PROGRA")
+    radio.pipe.write(b"\x02PROGRA")
     ack = radio.pipe.read(1)
-    if ack != "\x06":
+    if ack != b"\x06":
         raise Exception("Radio did not ACK first command")
 
-    radio.pipe.write("M\x02")
+    radio.pipe.write(b"M\x02")
     ident = radio.pipe.read(8)
     if len(ident) != 8:
         LOG.debug(util.hexprint(ident))
         raise Exception("Radio did not send identification")
 
-    radio.pipe.write("\x06")
-    if radio.pipe.read(1) != "\x06":
+    radio.pipe.write(b"\x06")
+    if radio.pipe.read(1) != b"\x06":
         raise Exception("Radio did not ACK ident")
 
 
@@ -152,6 +152,7 @@ class Puxing777Radio(chirp_common.CloneModeRadio):
     """Puxing PX-777"""
     VENDOR = "Puxing"
     MODEL = "PX-777"
+    NEEDS_COMPAT_SERIAL = False
 
     def sync_in(self):
         self._mmap = puxing_download(self)
@@ -357,9 +358,9 @@ class Puxing777Radio(chirp_common.CloneModeRadio):
 def puxing_2r_prep(radio):
     """Do the Puxing 2R identification dance"""
     radio.pipe.timeout = 0.2
-    radio.pipe.write("PROGRAM\x02")
+    radio.pipe.write(b"PROGRAM\x02")
     ack = radio.pipe.read(1)
-    if ack != "\x06":
+    if ack != b"\x06":
         raise Exception("Radio is not responding")
 
     radio.pipe.write(ack)

--- a/chirp/drivers/th_uv3r.py
+++ b/chirp/drivers/th_uv3r.py
@@ -25,9 +25,9 @@ LOG = logging.getLogger(__name__)
 
 def tyt_uv3r_prep(radio):
     try:
-        radio.pipe.write("PROGRAMa")
+        radio.pipe.write(b"PROGRAMa")
         ack = radio.pipe.read(1)
-        if ack != "\x06":
+        if ack != b"\x06":
             raise errors.RadioError("Radio did not ACK first command")
     except:
         raise errors.RadioError("Unable to communicate with the radio")
@@ -78,6 +78,7 @@ class TYTUV3RRadio(chirp_common.CloneModeRadio):
     MODEL = "TH-UV3R"
     BAUD_RATE = 2400
     _memsize = 2320
+    NEEDS_COMPAT_SERIAL = False
 
     def get_features(self):
         rf = chirp_common.RadioFeatures()

--- a/chirp/drivers/th_uv3r25.py
+++ b/chirp/drivers/th_uv3r25.py
@@ -69,6 +69,7 @@ VOICE_MODE_LIST = ["Compander", "Scrambler", "None"]
 class TYTUV3R25Radio(TYTUV3RRadio):
     MODEL = "TH-UV3R-25"
     _memsize = 2864
+    NEEDS_COMPAT_SERIAL = False
 
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=2.00),
                     chirp_common.PowerLevel("Low", watts=0.80)]

--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -199,7 +199,7 @@
 | <a name="Polmar_DB-50M"></a> Polmar_DB-50M | [Implied by AnyTone_5888UV](#user-content-AnyTone_5888UV) | 9-Dec-2022 | Yes | 0.03% |
 | <a name="Powerwerx_DB-750X"></a> Powerwerx_DB-750X | [Implied by AnyTone_5888UV](#user-content-AnyTone_5888UV) | 9-Dec-2022 | Yes | 0.01% |
 | <a name="Puxing_PX-2R"></a> Puxing_PX-2R |  |  |  | 0.05% |
-| <a name="Puxing_PX-777"></a> Puxing_PX-777 |  |  |  | 0.11% |
+| <a name="Puxing_PX-777"></a> Puxing_PX-777 |  |  | Yes | 0.11% |
 | <a name="Puxing_PX-888K"></a> Puxing_PX-888K |  |  |  | 0.07% |
 | <a name="QYT_KT-8R"></a> QYT_KT-8R | [@KC9HI](https://github.com/KC9HI) | 11-Nov-2022 | Yes | 0.09% |
 | <a name="QYT_KT-UV980"></a> QYT_KT-UV980 | [Implied by WACCOM_MINI-8900](#user-content-WACCOM_MINI-8900) | 11-Nov-2022 | Yes | 0.04% |
@@ -286,8 +286,8 @@
 | <a name="TYT_TH-7800_File"></a> TYT_TH-7800_File |  |  |  | 0.00% |
 | <a name="TYT_TH-9800"></a> TYT_TH-9800 | Unit tested; needs confirm | 24-Dec-2022 | Yes | 0.65% |
 | <a name="TYT_TH-9800_File"></a> TYT_TH-9800_File |  |  | Yes | 0.00% |
-| <a name="TYT_TH-UV3R"></a> TYT_TH-UV3R |  |  |  | 0.04% |
-| <a name="TYT_TH-UV3R-25"></a> TYT_TH-UV3R-25 |  |  |  | 0.02% |
+| <a name="TYT_TH-UV3R"></a> TYT_TH-UV3R |  |  | Yes | 0.04% |
+| <a name="TYT_TH-UV3R-25"></a> TYT_TH-UV3R-25 |  |  | Yes | 0.02% |
 | <a name="TYT_TH-UV8000"></a> TYT_TH-UV8000 |  |  |  | 0.31% |
 | <a name="TYT_TH-UV88"></a> TYT_TH-UV88 | [@KC9HI](https://github.com/KC9HI) | 5-Dec-2022 | Yes | 0.51% |
 | <a name="TYT_TH-UVF1"></a> TYT_TH-UVF1 | [@kk7ds](https://github.com/kk7ds) | 13-Dec-2022 | Yes | 0.06% |
@@ -364,7 +364,7 @@
 
 **Tested:** 77% (276/81) (91% of usage stats)
 
-**Byte clean:** 84% (302/55)
+**Byte clean:** 85% (305/52)
 
 ## Meaning of this testing
 


### PR DESCRIPTION
These radios largely use the wouxun_common routines for cloning and
thus are probably fixed by making sure they send byte strings for the
commands. I haven't written tests for these, but this will increase
the likelihood someone will be able to report them as "just works."
