### PR TITLE
Attempt to parse random pasted text

### DIFF
--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -1005,7 +1005,17 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
             payload = pickle.loads(data.GetData().tobytes())
             self._cb_paste_memories(payload)
         elif data.GetFormat() == wx.DF_UNICODETEXT:
-            LOG.debug('FIXME: handle pasted text: %r' % data.GetText())
+            try:
+                mem = chirp_common.mem_from_text(data.GetText())
+            except Exception as e:
+                LOG.warning('Failed to parse pasted data %r: %s' % (
+                    data.GetText(), e))
+                return
+            # Since matching the offset is kinda iffy, set our band plan
+            # set the offset, if a rule exists.
+            self._set_memory_defaults(mem, 'offset')
+            self._cb_paste_memories({'mems': [mem],
+                                     'features': self._features})
         else:
             LOG.warning('Unknown data format %s' % data.GetFormat().Type)
 

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -74,6 +74,84 @@ class TestUtilityFunctions(base.BaseTest):
         self.assertEqual(140, chirp_common.from_MHz(14000001))
         self.assertEqual(140, chirp_common.from_kHz(14001))
 
+    def test_mem_from_text_rb1(self):
+        text = '145.2500 	-0.6 MHz 	97.4 	OPEN'
+        mem = chirp_common.mem_from_text(text)
+        self.assertIsNotNone(mem)
+        self.assertEqual(145250000, mem.freq)
+        self.assertEqual(600000, mem.offset)
+        self.assertEqual('-', mem.duplex)
+        self.assertEqual('Tone', mem.tmode)
+        self.assertEqual(97.4, mem.rtone)
+
+    def test_mem_from_text_rb2(self):
+        text = '147.3000 	+0.6 MHz 	156.7 / 156.7 	OPEN'
+        mem = chirp_common.mem_from_text(text)
+        self.assertIsNotNone(mem)
+        self.assertEqual(147300000, mem.freq)
+        self.assertEqual(600000, mem.offset)
+        self.assertEqual('+', mem.duplex)
+        self.assertEqual('TSQL', mem.tmode)
+        self.assertEqual(156.7, mem.ctone)
+
+    def test_mem_from_text_rb3(self):
+        text = '441.1000 	+5 MHz 	D125 / D125 	OPEN'
+        mem = chirp_common.mem_from_text(text)
+        self.assertIsNotNone(mem)
+        self.assertEqual(441100000, mem.freq)
+        self.assertEqual(5000000, mem.offset)
+        self.assertEqual('+', mem.duplex)
+        self.assertEqual('DTCS', mem.tmode)
+        self.assertEqual(125, mem.dtcs)
+
+    def test_mem_from_text_rb4(self):
+        text = '441.1000 	+5 MHz 	88.5 / D125 	OPEN'
+        mem = chirp_common.mem_from_text(text)
+        self.assertIsNotNone(mem)
+        self.assertEqual(441100000, mem.freq)
+        self.assertEqual(5000000, mem.offset)
+        self.assertEqual('+', mem.duplex)
+        self.assertEqual('Cross', mem.tmode)
+        self.assertEqual(88.5, mem.rtone)
+        self.assertEqual(125, mem.rx_dtcs)
+        self.assertEqual('Tone->DTCS', mem.cross_mode)
+
+    def test_mem_from_text_random1(self):
+        text = 'Glass Butte 147.200 + 162.2'
+        mem = chirp_common.mem_from_text(text)
+        self.assertIsNotNone(mem)
+        self.assertEqual(147200000, mem.freq)
+        # This is a default
+        self.assertEqual(600000, mem.offset)
+        # Just a random + or - on the line isn't enough to trigger offset
+        # pattern
+        self.assertEqual('+', mem.duplex)
+        self.assertEqual('Tone', mem.tmode)
+        self.assertEqual(162.2, mem.rtone)
+
+    def test_mem_from_text_random2(self):
+        text = 'Glass - Butte 147.200 + 162.2'
+        mem = chirp_common.mem_from_text(text)
+        self.assertIsNotNone(mem)
+        self.assertEqual(147200000, mem.freq)
+        # This is a default
+        self.assertEqual(600000, mem.offset)
+        # Just a random + or - on the line isn't enough to trigger offset
+        # pattern
+        self.assertEqual('+', mem.duplex)
+        self.assertEqual('Tone', mem.tmode)
+        self.assertEqual(162.2, mem.rtone)
+
+    def test_mem_from_text_random3(self):
+        text = '146.640 | 146.040 | 136.5'
+        mem = chirp_common.mem_from_text(text)
+        self.assertIsNotNone(mem)
+        self.assertEqual(146640000, mem.freq)
+        self.assertEqual(600000, mem.offset)
+        self.assertEqual('-', mem.duplex)
+        self.assertEqual('Tone', mem.tmode)
+        self.assertEqual(136.5, mem.rtone)
+
 
 class TestSplitTone(base.BaseTest):
     def _test_split_tone_decode(self, tx, rx, **vals):


### PR DESCRIPTION
This is pretty error-prone, but if we find stuff in the text clipboard
that looks like frequency/tone data, try to parse it out into a
memory and paste it into the grid. Works pretty well for repeaterbook
lines, and a few other local repeater group websites I tried. It's
definitely not something we can do with a high degree of accuracy,
but if you just copy a frequency and tone, it does a decent job.
