### PR TITLE
Fix prompting for offset when duplex=off

### DIFF
--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -693,6 +693,9 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
         self._set_memory_defaults(mem, 'offset')
         if mem.duplex == 'split':
             msg = _('Enter TX Frequency (MHz)')
+        elif mem.duplex == 'off':
+            # Clearly no need to prompt for this duplex
+            return True
         elif 0 < mem.offset < 70000000:
             # We don't need to ask, offset looks like an offset
             return True


### PR DESCRIPTION
When the user selects a duplex of off, we could have found a
zero offset (either because it was already set on the memory,
or because the band plan gave us a default) and fall through to the
prompt for an offset value. This makes us specifically bail early
if "off" is selected, as no prompt for offset/txfreq would ever be
needed in that case.
