### PR TITLE
Fix ft857/897 get_memory() of special channels

### DIFF
--- a/chirp/drivers/ft857.py
+++ b/chirp/drivers/ft857.py
@@ -1175,9 +1175,9 @@ class FT857USRadio(FT857Radio):
         self._set_memory(mem, _mem)
 
     def get_memory(self, number):
-        if number in list(self.SPECIAL_60M.keys()):
+        if number in self.SPECIAL_60M:
             return self._get_special_60m(number)
-        elif number < 0 and (
+        elif isinstance(number, int) and number < 0 and (
                 self.SPECIAL_MEMORIES_REV[number] in
                 list(self.SPECIAL_60M.keys())):
             # I can't stop delete operation from losing extd_number but


### PR DESCRIPTION
Due to a change in comparing a string to an int in python3, we will
fail to run get_memory() in the ft857 driver for special channels on
the US variant when checking for 60m.

Fixes: #10209
