### PR TITLE
Fix crash on linux due to missing print preview

### DIFF
--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -847,7 +847,10 @@ class ChirpMain(wx.Frame):
         ]
         for ident, enabled in items:
             menuitem = self.GetMenuBar().FindItemById(ident)
-            menuitem.Enable(enabled)
+            if menuitem:
+                # Some items may not be present on all systems (i.e.
+                # print preview on Linux)
+                menuitem.Enable(enabled)
 
     def _window_close(self, event):
         for i in range(self._editors.GetPageCount()):


### PR DESCRIPTION
On Linux we don't add the print preview menu item, but the window
update function tries to en/disable it anyway.

Fixes #10236
