### PR TITLE
RepeaterBook band filter

### DIFF
--- a/chirp/bandplan_na.py
+++ b/chirp/bandplan_na.py
@@ -143,7 +143,7 @@ BANDS_2M = (
 )
 
 BANDS_1_25M = (
-  bandplan.Band((222000000, 225000000), "1.25 Meters"),
+  bandplan.Band((222000000, 225000000), "1.25 Meter Band"),
   bandplan.Band((222000000, 222150000), "Weak-signal modes"),
   bandplan.Band((222000000, 222025000), "EME"),
   bandplan.Band((222050000, 222060000), "Propagation beacons"),
@@ -158,7 +158,7 @@ BANDS_1_25M = (
 )
 
 BANDS_70CM = (
-  bandplan.Band((420000000, 450000000), "70cm Band"),
+  bandplan.Band((420000000, 450000000), "70 Centimeter Band"),
   bandplan.Band((420000000, 426000000), "ATV repeater or simplex"),
   bandplan.Band((426000000, 432000000), "ATV simplex"),
   bandplan.Band((432000000, 432070000), "EME (Earth-Moon-Earth)"),

--- a/tests/unit/test_bandplan.py
+++ b/tests/unit/test_bandplan.py
@@ -1,0 +1,33 @@
+import unittest
+
+from chirp import bandplan
+
+
+class FakeConfig:
+    def __init__(self, bandplan):
+        self.bandplan = bandplan
+
+    def is_defined(self, opt, sec):
+        return True
+
+    def get(self, opt, sec):
+        return None
+
+    def get_bool(self, opt, sec):
+        return opt == self.bandplan
+
+
+class BandPlanTest(unittest.TestCase):
+    def test_get_repeater_bands(self):
+        plans = bandplan.BandPlans(FakeConfig('north_america'))
+        expected = ['10 Meter Band',
+                    '6 Meter Band',
+                    '2 Meter Band',
+                    '1.25 Meter Band',
+                    '70 Centimeter Band',
+                    '33 Centimeter Band',
+                    '23 Centimeter Band',
+                    '13 Centimeter Band']
+
+        self.assertEqual(expected,
+                         [b.name for b in plans.get_repeater_bands()])


### PR DESCRIPTION
- Fix two mis-named bands in bandplan_na
- Add a get_repeater_bands() function to BandPlans
- Allow filtering RepeaterBook queries by band
