### PR TITLE
Remove Incorrect Class and Alias from 935G driver

### DIFF
--- a/chirp/drivers/kg935g.py
+++ b/chirp/drivers/kg935g.py
@@ -430,8 +430,6 @@ _MEM_FORMAT = """
 # MRT 1.2 correct spelling of Wouxon
 
 
-
-
 @directory.register
 class KG935GRadio(chirp_common.CloneModeRadio,
                   chirp_common.ExperimentalRadio):

--- a/chirp/drivers/kg935g.py
+++ b/chirp/drivers/kg935g.py
@@ -430,9 +430,6 @@ _MEM_FORMAT = """
 # MRT 1.2 correct spelling of Wouxon
 
 
-class KGUV8TRadio(chirp_common.Alias):
-    VENDOR = "Wouxun"
-    MODEL = "KG-UV8T"
 
 
 @directory.register
@@ -449,7 +446,6 @@ class KG935GRadio(chirp_common.CloneModeRadio,
     POWER_LEVELS = [chirp_common.PowerLevel("L", watts=0.5),
                     chirp_common.PowerLevel("M", watts=4.5),
                     chirp_common.PowerLevel("H", watts=5.5)]
-    ALIASES = [KGUV8TRadio, ]
     NEEDS_COMPAT_SERIAL = False
     _record_start = 0x7C
 


### PR DESCRIPTION
Remove Incorrect Class and Alias from 935G driver

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
