### PR TITLE
Various bug fixes

### DIFF
--- a/chirp/drivers/thd74.py
+++ b/chirp/drivers/thd74.py
@@ -183,7 +183,7 @@ class THD74Radio(chirp_common.CloneModeRadio):
     NEEDS_COMPAT_SERIAL = False
     BAUD_RATE = 9600
     HARDWARE_FLOW = sys.platform == "darwin"  # only OS X driver needs hw flow
-    FORMATS = [directory.register_format('Kenwood MCP-D74', 'd74')]
+    FORMATS = [directory.register_format('Kenwood MCP-D74', '*.d74')]
 
     _memsize = 0x7A300
 

--- a/chirp/drivers/ts2000.py
+++ b/chirp/drivers/ts2000.py
@@ -143,6 +143,15 @@ class TS2000Radio(KenwoodLiveRadio):
         _p16 = spec[42:49]
 
         mem.number = int(_p2 + _p3)     # concat bank num and chan num
+
+        if _p5 == '0':
+            # NOTE(danms): Apparently some TS2000s will return unset
+            # memory records with all zeroes for the fields instead of
+            # NAKing the command with an N response. If that happens here,
+            # return an empty memory.
+            mem.empty = True
+            return mem
+
         mem.freq = int(_p4)
         mem.mode = TS2000_MODES[int(_p5)]
         mem.skip = ["", "S"][int(_p6)]

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -885,12 +885,21 @@ class ChirpMain(wx.Frame):
         self.open_file('Untitled.csv', exists=False)
 
     def _menu_open(self, event):
+        all_extensions = ['*.img']
         formats = [_('Chirp Image Files') + ' (*.img)|*.img',
                    _('All Files') + ' (*.*)|*.*']
         for name, pattern, readonly in directory.AUX_FORMATS:
             formats.insert(1, '%s %s (%s)|%s' % (
                 name, _('Files'), pattern, pattern))
+            all_extensions.append(pattern)
 
+        if CONF.get_bool('open_default_all_formats', 'prefs', True):
+            i_index = 0
+        else:
+            i_index = len(formats)
+        formats.insert(i_index,
+                       (_('All supported formats|') +
+                        ';'.join(all_extensions)))
         wildcard = '|'.join(formats)
         with wx.FileDialog(self, _('Open a file'),
                            chirp_platform.get_platform().get_last_dir(),

--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -179,7 +179,7 @@
 | <a name="Kenwood_TM-G707"></a> Kenwood_TM-G707 | [Probably works](https://github.com/kk7ds/chirp/blob/py3/chirp/drivers/kenwood_live.py) | 12-Dec-2022 | Yes | 0.01% |
 | <a name="Kenwood_TM-V7"></a> Kenwood_TM-V7 | [Probably works](https://github.com/kk7ds/chirp/blob/py3/chirp/drivers/kenwood_live.py) | 12-Dec-2022 | Yes | 0.01% |
 | <a name="Kenwood_TM-V71"></a> Kenwood_TM-V71 | [@kk7ds](https://github.com/kk7ds) | 21-Oct-2022 | Yes | 0.04% |
-| <a name="Kenwood_TS-2000"></a> Kenwood_TS-2000 |  |  | Yes | 0.03% |
+| <a name="Kenwood_TS-2000"></a> Kenwood_TS-2000 | ZS6CRW | 10-Jan-2022 | Yes | 0.03% |
 | <a name="Kenwood_TS-480_CloneMode"></a> Kenwood_TS-480_CloneMode |  |  |  | 0.00% |
 | <a name="Kenwood_TS-480_LiveMode"></a> Kenwood_TS-480_LiveMode |  |  | Yes | 0.00% |
 | <a name="Kenwood_TS-590SG_CloneMode"></a> Kenwood_TS-590SG_CloneMode |  |  |  | 0.00% |
@@ -364,7 +364,7 @@
 
 **Drivers:** 359
 
-**Tested:** 80% (288/71) (92% of usage stats)
+**Tested:** 80% (289/70) (92% of usage stats)
 
 **Byte clean:** 86% (312/47)
 

--- a/tests/py3_driver_testers.txt
+++ b/tests/py3_driver_testers.txt
@@ -155,6 +155,7 @@ Kenwood_TK-768,+Kenwood_TK-760,5-Dec-2022
 Kenwood_TK-860,+Kenwood_TK-760,5-Dec-2022
 Kenwood_TK-862,+Kenwood_TK-760,5-Dec-2022
 Kenwood_TK-868,+Kenwood_TK-760,5-Dec-2022
+Kenwood_TS-2000,ZS6CRW,10-Jan-2022
 Leixen_VV-898,+Jetstream_JT270MH,13-Dec-2022
 Leixen_VV-898S,@READ10,19-Dec-2022
 LUITON_LT-316,+Retevis_RT22,9-Dec-2022

--- a/tools/cpep8.py
+++ b/tools/cpep8.py
@@ -17,11 +17,19 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import warnings
+
 import os
 import sys
 import logging
 import argparse
-import pep8
+
+# pep8 has a FutureWarning about nested sets. This isn't our problem, so
+# squelch it here during import.
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    import pep8
+
 
 parser = argparse.ArgumentParser()
 parser.add_argument("-a", "--all", action="store_true",

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
     flake8
 commands =
     python ./tools/cpep8.py
-    flake8 --builtins="_" chirp/wxui
+    flake8 --builtins=_ chirp/wxui
 
 [textenv:py3clean]
 commands =


### PR DESCRIPTION
- Remove quotes from flake8 execution
- Squelch pep8.py warnings
- Fix TS-2000 driver empty memory weirdness
- Mark TS-2000 as tested in py3 by ZS6CRW
- Default File->Open box to all supported formats
