### PR TITLE
Log information about pasted data

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -315,7 +315,7 @@ class Memory:
     }
 
     def __repr__(self):
-        return "Memory[%i]" % self.number
+        return str(self)
 
     def dupe(self):
         """Return a deep copy of @self"""

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1030,11 +1030,14 @@ class ChirpMain(wx.Frame):
     def _menu_exit(self, event):
         self.Close(True)
 
+    @common.error_proof(Exception)
     def _menu_copy(self, event, cut=False):
         data = self.current_editorset.cb_copy(cut=cut)
         if wx.TheClipboard.Open():
             wx.TheClipboard.SetData(data)
             wx.TheClipboard.Close()
+        else:
+            raise Exception(_('Unable to open the clipboard'))
 
     def _menu_paste(self, event):
         memdata = wx.CustomDataObject(common.CHIRP_DATA_MEMORY)

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -1178,6 +1178,7 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
     def cb_paste(self, data):
         if common.CHIRP_DATA_MEMORY in data.GetAllFormats():
             payload = pickle.loads(data.GetData().tobytes())
+            LOG.debug('CHIRP-native paste: %r' % payload)
             self._cb_paste_memories(payload)
         elif wx.DF_UNICODETEXT in data.GetAllFormats():
             try:
@@ -1191,10 +1192,13 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
             # set the offset, if a rule exists.
             if mem.duplex in ('-', '+'):
                 self._set_memory_defaults(mem, 'offset')
+            LOG.debug('Generic text paste %r: %s' % (
+                data.GetText(), mem))
             self._cb_paste_memories({'mems': [mem],
                                      'features': self._features})
         else:
-            LOG.warning('Unknown data format %s' % data.GetFormat().Type)
+            LOG.warning('Unknown data format %s paste' % (
+                data.GetFormat().Type))
 
     def cb_delete(self):
         selected_rows = self._grid.GetSelectedRows()


### PR DESCRIPTION
This makes it easier to know which kind of data we got from the
clipboard and what we're doing with it.

Maybe helpful in debugging #10241
