### PR TITLE
Immutable Properties Dialog

### DIFF
--- a/chirp/drivers/thd74.py
+++ b/chirp/drivers/thd74.py
@@ -427,14 +427,16 @@ class THD74Radio(chirp_common.CloneModeRadio):
 
         mem.skip = _flg.lockout and 'S' or ''
 
-        mem.dv_urcall = decode_call(_mem.dv_urcall)
-        mem.dv_rpt1call = decode_call(_mem.dv_rpt1call)
-        mem.dv_rpt2call = decode_call(_mem.dv_rpt2call)
-        mem.dv_code = int(_mem.dv_code)
-
         if mem.extd_number:
             mem.immutable.append('empty')
+        else:
+            mem.dv_urcall = decode_call(_mem.dv_urcall)
+            mem.dv_rpt1call = decode_call(_mem.dv_rpt1call)
+            mem.dv_rpt2call = decode_call(_mem.dv_rpt2call)
+            mem.dv_code = int(_mem.dv_code)
+
         if 'WX' in mem.extd_number:
+            mem.tmode = ''
             mem.immutable.extend(['rtone', 'ctone', 'dtcs', 'rx_dtcs',
                                   'tmode', 'cross_mode', 'dtcs_polarity',
                                   'skip', 'power', 'offset', 'mode',

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -607,7 +607,10 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
         if not CONF.get_bool('auto_edits', 'state', True):
             return
         if not only:
-            only = ('offset', 'duplex', 'tuning_step', 'mode', 'rtone')
+            only = ['offset', 'duplex', 'tuning_step', 'mode', 'rtone']
+        for prop in mem.immutable:
+            if prop in only:
+                only.remove(prop)
 
         defaults = self.bandplan.get_defaults_for_frequency(mem.freq)
         features = self._features

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -1009,7 +1009,7 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
         # Now schedule UI refreshes
         for memory in memories:
             self.do_radio(self.refresh_memory_from_job,
-                          'get_memory', memory.number)
+                          'get_memory', memory.extd_number or memory.number)
 
         wx.PostEvent(self, common.EditorChanged(self.GetId()))
 


### PR DESCRIPTION
- Fix TH-D74 editing of WX memories
- Fix refreshing special channels losing labels
- Fix setting defaults on immutable memory fields
- Make memory properties dialog honor immutable
