### PR TITLE
Ellipsize cells when column is resized smaller

### DIFF
--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -479,6 +479,7 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
                 attr.SetEditor(col_def.get_editor())
                 self._grid.SetColAttr(col, attr)
                 self._grid.SetColMinimalWidth(col, minwidth)
+                attr.SetFitMode(wx.grid.GridFitMode.Ellipsize())
         wx.CallAfter(self._grid.AutoSizeColumns, setAsMin=False)
 
     def _setup_columns(self):


### PR DESCRIPTION
This avoids overlapping cells when shrinking a large column down to
fit more on the screen.
