### PR TITLE
Fix for old wxPython

### DIFF
--- a/chirp/sources/radioreference.py
+++ b/chirp/sources/radioreference.py
@@ -176,6 +176,7 @@ class RadioReferenceRadio(base.NetworkResultRadio):
         rf.memory_bounds = (0, len(self._freqs)-1)
         rf.has_bank = False
         rf.has_ctone = False
+        rf.has_comment = True
         rf.valid_tmodes = ["", "TSQL", "DTCS"]
         return rf
 

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -479,7 +479,11 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
                 attr.SetEditor(col_def.get_editor())
                 self._grid.SetColAttr(col, attr)
                 self._grid.SetColMinimalWidth(col, minwidth)
-                attr.SetFitMode(wx.grid.GridFitMode.Ellipsize())
+                try:
+                    attr.SetFitMode(wx.grid.GridFitMode.Ellipsize())
+                except AttributeError:
+                    # No SetFitMode() support on wxPython 4.0.7
+                    pass
         wx.CallAfter(self._grid.AutoSizeColumns, setAsMin=False)
 
     def _setup_columns(self):


### PR DESCRIPTION
- Fix RadioReference not showing comments
- Avoid using SetFitMode on older wxPython
