### PR TITLE
Force UTF-8 encoding for CSV on windows

### DIFF
--- a/.github/workflows/check-patch.yaml
+++ b/.github/workflows/check-patch.yaml
@@ -6,10 +6,6 @@ jobs:
         name: No new legacy code
         runs-on: ubuntu-22.04
         steps:
-            - name: Install deps
-              run: |
-                  apt-get update
-                  apt-get install -y diffstat
             - name: Checkout
               uses: actions/checkout@v2
             - name: Run check_commit.sh

--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -183,7 +183,7 @@ class CSVRadio(chirp_common.FileBackedRadio):
 
         self._blank()
 
-        with open(self._filename) as f:
+        with open(self._filename, newline='', encoding='utf-8') as f:
             header = f.readline().strip()
             f.seek(0, 0)
             return self._load(f)
@@ -232,7 +232,7 @@ class CSVRadio(chirp_common.FileBackedRadio):
         if filename:
             self._filename = filename
 
-        with open(self._filename, "w") as f:
+        with open(self._filename, "w", newline='', encoding='utf-8') as f:
             writer = csv.writer(f, delimiter=chirp_common.SEPCHAR)
             writer.writerow(chirp_common.Memory.CSV_FORMAT)
 

--- a/tools/check_commit.sh
+++ b/tools/check_commit.sh
@@ -34,8 +34,8 @@ if grep -E 'MemoryMap\(' added_lines; then
     fail New uses of MemoryMap should be MemoryMapBytes
 fi
 
-for file in $(git diff ${BASE}.. '*.py' | diffstat -l); do
-    if grep -qE '\r' $file; then
+for file in $(git diff ${BASE}.. | grep '^+++' | sed 's#^+++ b/##'); do
+    if file $file | grep -q CRLF; then
         fail "$file : Files should be LF (Unix) format, not CR (Mac) or CRLF (Windows)"
     fi
 done


### PR DESCRIPTION
Without this, windows defaults to non-UTF-8 encoding which breaks
writing (and then re-reading) unicode strings.

Also set newline='' per csv module recommendations, as the recent
universal-newline fix for 3.11 introduced blank lines in CSV files
on windows.

Fixes #10276
