### PR TITLE
Several fixes

### DIFF
--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -19,6 +19,7 @@ import logging
 import re
 
 from chirp import chirp_common, errors, directory
+from chirp import import_logic
 
 LOG = logging.getLogger(__name__)
 POWER_LEVELS_WATTS = [
@@ -64,13 +65,12 @@ def parse_power(value):
     if not match:
         raise ValueError('Invalid power specification: %r' % value)
     if match.group(2).lower() == 'w':
-        dbm = chirp_common.watts_to_dBm(float(match.group(1)))
+        watts = float(match.group(1))
     else:
         LOG.debug('Unknown power units in %r' % value)
-        dbm = chirp_common.watts_to_dBm(50)
+        watts = chirp_common.dBm_to_watts(int(DEFAULT_POWER_LEVEL))
     # Find the closest matching power level to what was provided and use that
-    diffs = [abs(int(p) - dbm) for p in POWER_LEVELS]
-    return POWER_LEVELS[diffs.index(min(diffs))]
+    return import_logic.find_closest_power(watts, POWER_LEVELS)
 
 
 @directory.register

--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -300,6 +300,8 @@ class CSVRadio(chirp_common.FileBackedRadio):
     def set_memory(self, newmem):
         if newmem.power is None:
             newmem.power = DEFAULT_POWER_LEVEL
+        elif newmem.power not in POWER_LEVELS:
+            raise errors.InvalidValueError('Unsupported power level')
         self._grow(newmem.number)
         self.memories[newmem.number] = newmem
 

--- a/chirp/sources/repeaterbook.py
+++ b/chirp/sources/repeaterbook.py
@@ -8,7 +8,7 @@ import tempfile
 import requests
 
 from chirp import chirp_common
-from chirp.drivers import generic_csv
+from chirp import errors
 from chirp import platform as chirp_platform
 from chirp.sources import base
 from chirp.wxui import fips
@@ -161,6 +161,10 @@ class RepeaterBook(base.NetworkResultRadio):
         m = chirp_common.Memory()
         m.number = number
         m.freq = chirp_common.parse_freq(item['Frequency'])
+        try:
+            m.tuning_step = chirp_common.required_step(m.freq)
+        except errors.InvalidDataError as e:
+            LOG.debug(e)
         txf = chirp_common.parse_freq(item['Input Freq'])
         chirp_common.split_to_offset(m, m.freq, txf)
         txm, tx = parse_tone(item['PL'])

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -1309,8 +1309,12 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
         # zero, so delete it before we go to export.
         r.erase_memory(0)
         for row in selected:
-            r.set_memory(self._memory_cache[row])
+            m = self._memory_cache[row]
+            if not m.empty:
+                m = import_logic.import_mem(r, self._features, m)
+            r.set_memory(m)
         r.save(filename)
+        LOG.info('Wrote exported CSV to %s' % filename)
 
     def get_selected_memories(self, or_all=True):
         rows = self._grid.GetSelectedRows()

--- a/tests/unit/test_import_logic.py
+++ b/tests/unit/test_import_logic.py
@@ -190,6 +190,19 @@ class ImportFieldTests(base.BaseTest):
         import_logic._import_power(radio, src_rf, mem)
         self.assertEqual(mem.power, radio.POWER_LEVELS[0])
 
+    def test_import_power_closest_watts(self):
+        radio = FakeRadio(None)
+        src_rf = chirp_common.RadioFeatures()
+        src_rf.valid_power_levels = [
+            chirp_common.PowerLevel('foo', watts=20),
+            chirp_common.PowerLevel('bar', watts=51),
+            chirp_common.PowerLevel('baz', watts=1),
+            ]
+        mem = chirp_common.Memory()
+        mem.power = src_rf.valid_power_levels[0]
+        import_logic._import_power(radio, src_rf, mem)
+        self.assertEqual(mem.power, radio.POWER_LEVELS[0])
+
     def test_import_tone_diffA_tsql(self):
         radio = FakeRadio(None)
         src_rf = chirp_common.RadioFeatures()

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,8 @@ passenv =
   HOME
   CHIRP_TESTS
   CHIRP_TESTIMG
+  PIP_INDEX_URL
+  PIP_TRUSTED_HOST
 allowlist_externals = bash
 deps = future
 


### PR DESCRIPTION
- Set tuning_step on RepeaterBook results
- Allow pip caching for tox environments
- Run CSV export through import_logic
- Fix a bug in choosing the closest power level
