### PR TITLE
Generic mem.comment support

### DIFF
--- a/chirp/directory.py
+++ b/chirp/directory.py
@@ -130,7 +130,7 @@ def get_radio_by_image(image_file):
     else:
         filedata = b""
 
-    data, metadata = chirp_common.FileBackedRadio._strip_metadata(filedata)
+    data, metadata = chirp_common.CloneModeRadio._strip_metadata(filedata)
 
     # NOTE: See warning below
     if six.PY3:

--- a/chirp/drivers/fake.py
+++ b/chirp/drivers/fake.py
@@ -29,6 +29,8 @@ class FakeLiveRadio(chirp_common.LiveRadio):
         # We don't even implement this interface, but the point of this
         # is to make sure the GUI doesn't choke on live radios.
         rf.has_bank = True
+        rf.valid_name_length = 8
+        rf.valid_characters = chirp_common.CHARSET_ASCII
         return rf
 
     def get_memory(self, number):

--- a/chirp/drivers/ft450d.py
+++ b/chirp/drivers/ft450d.py
@@ -30,9 +30,6 @@ from textwrap import dedent
 LOG = logging.getLogger(__name__)
 
 CMD_ACK = 0x06
-# TBD: Enable some form of generated UI field, for the memory tags
-# That field wiould not be stored in img file, but generated in get_memory
-MEM_GRP_LBL = False     # To ignore Comment channel-tags for now
 EX_MODES = ["USER-L", "USER-U", "LSB+CW", "USB+CW", "RTTY-L", "RTTY-U", "N/A"]
 for i in EX_MODES:
     chirp_common.MODES.append(i)
@@ -521,8 +518,6 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         rf = chirp_common.RadioFeatures()
         rf.has_bank = False
         rf.has_dtcs= False
-        if MEM_GRP_LBL:
-            rf.has_comment = True   # Used for Mem-Grp number
         rf.valid_modes = list(set(self.MODES))
         rf.valid_tmodes = list(self.TMODES)
         rf.valid_duplexes = list(self.DUPLEX)
@@ -603,8 +598,6 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
             mx = (-self.LAST_PMS_INDEX) + mem.number
             _mem = self._memobj.pms[mx]
             mx = mx + 1
-            if MEM_GRP_LBL:
-                mem.comment = "M-11-%02i" % mx
             immutable = ["number", "rtone", "ctone", "extd_number",
                          "tmode", "cross_mode",
                          "power", "duplex", "offset"]
@@ -612,8 +605,6 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
             mx = (-self.LAST_60M_INDEX) + mem.number
             _mem = self._memobj.m60[mx]
             mx = mx + 1
-            if MEM_GRP_LBL:
-                mem.comment = "M-12-%02i" % mx
             immutable = ["number", "rtone", "ctone", "extd_number",
                          "tmode", "cross_mode",
                          "frequency", "power", "duplex", "offset"]
@@ -691,9 +682,6 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
                 return mem
         if mem.number == 1:
             mem.immutable = ['empty']
-        if MEM_GRP_LBL:
-            mgrp = int((number - 1) / 50)
-            mem.comment = "M-%02i-%02i" % (mgrp + 1, number - (mgrp * 50))
         return self._get_memory(mem, _mem)
 
     def _set_normal(self, mem):

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -111,6 +111,8 @@ class ChirpEditorSet(wx.Panel):
         if features.has_sub_devices:
             radios = radio.get_sub_devices()
             format = '%(type)s (%(variant)s)'
+            if isinstance(parent_radio, chirp_common.ExternalMemoryProperties):
+                parent_radio.link_device_metadata(radios)
         else:
             radios = [radio]
             format = '%(type)s'

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -421,6 +421,10 @@ class ChirpCommentColumn(ChirpMemoryColumn):
         return (self._features.has_comment or
                 isinstance(self._radio, chirp_common.CloneModeRadio))
 
+    def _digest_value(self, memory, input_value):
+        # Limit to 128 characters for sanity
+        return str(input_value)[:256]
+
 
 class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
     def __init__(self, radio, *a, **k):

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -469,7 +469,7 @@ class TestStepFunctions(base.BaseTest):
 
 class TestImageMetadata(base.BaseTest):
     def test_make_metadata(self):
-        class TestRadio(chirp_common.FileBackedRadio):
+        class TestRadio(chirp_common.CloneModeRadio):
             VENDOR = 'Dan'
             MODEL = 'Foomaster 9000'
             VARIANT = 'R'
@@ -486,7 +486,7 @@ class TestImageMetadata(base.BaseTest):
         self.assertEqual(expected, metadata)
 
     def test_strip_metadata(self):
-        class TestRadio(chirp_common.FileBackedRadio):
+        class TestRadio(chirp_common.CloneModeRadio):
             VENDOR = 'Dan'
             MODEL = 'Foomaster 9000'
             VARIANT = 'R'
@@ -494,7 +494,7 @@ class TestImageMetadata(base.BaseTest):
         raw_metadata = TestRadio._make_metadata()
         raw_data = (b'foooooooooooooooooooooo' + TestRadio.MAGIC +
                     TestRadio._make_metadata())
-        data, metadata = chirp_common.FileBackedRadio._strip_metadata(raw_data)
+        data, metadata = chirp_common.CloneModeRadio._strip_metadata(raw_data)
         self.assertEqual(b'foooooooooooooooooooooo', data)
         expected = {
             'vendor': 'Dan',
@@ -512,7 +512,7 @@ class TestImageMetadata(base.BaseTest):
             f.flush()
 
         with mock.patch('chirp.memmap.MemoryMap') as mock_mmap:
-            chirp_common.FileBackedRadio(None).load_mmap(fn)
+            chirp_common.CloneModeRadio(None).load_mmap(fn)
             mock_mmap.assert_called_once_with(b'thisisrawdata')
         os.remove(fn)
 
@@ -520,18 +520,18 @@ class TestImageMetadata(base.BaseTest):
         fn = os.path.join(tempfile.gettempdir(), 'testfile')
         with open(fn, 'wb') as f:
             f.write(b'thisisrawdata')
-            f.write(chirp_common.FileBackedRadio.MAGIC + b'bad')
+            f.write(chirp_common.CloneModeRadio.MAGIC + b'bad')
             f.flush()
 
         with mock.patch('chirp.memmap.MemoryMap') as mock_mmap:
-            chirp_common.FileBackedRadio(None).load_mmap(fn)
+            chirp_common.CloneModeRadio(None).load_mmap(fn)
             mock_mmap.assert_called_once_with(b'thisisrawdata')
         os.remove(fn)
 
     def test_save_mmap_includes_metadata(self):
         # Make sure that a file saved with a .img extension includes
         # the metadata blob
-        class TestRadio(chirp_common.FileBackedRadio):
+        class TestRadio(chirp_common.CloneModeRadio):
             VENDOR = 'Dan'
             MODEL = 'Foomaster 9000'
             VARIANT = 'R'
@@ -545,7 +545,7 @@ class TestImageMetadata(base.BaseTest):
         with open(fn, 'rb') as f:
             filedata = f.read()
         os.remove(fn)
-        data, metadata = chirp_common.FileBackedRadio._strip_metadata(filedata)
+        data, metadata = chirp_common.CloneModeRadio._strip_metadata(filedata)
         self.assertEqual(b'thisisrawdata', data)
         expected = {
             'vendor': 'Dan',
@@ -559,7 +559,7 @@ class TestImageMetadata(base.BaseTest):
     def test_save_mmap_no_metadata_not_img_file(self):
         # Make sure that if we save without a .img extension we do
         # not include the metadata blob
-        class TestRadio(chirp_common.FileBackedRadio):
+        class TestRadio(chirp_common.CloneModeRadio):
             VENDOR = 'Dan'
             MODEL = 'Foomaster 9000'
             VARIANT = 'R'
@@ -574,12 +574,12 @@ class TestImageMetadata(base.BaseTest):
         with open(fn, 'rb') as f:
             filedata = f.read()
         os.remove(fn)
-        data, metadata = chirp_common.FileBackedRadio._strip_metadata(filedata)
+        data, metadata = chirp_common.CloneModeRadio._strip_metadata(filedata)
         self.assertEqual(b'thisisrawdata', data)
         self.assertEqual({}, metadata)
 
     def test_load_mmap_saves_metadata_on_radio(self):
-        class TestRadio(chirp_common.FileBackedRadio):
+        class TestRadio(chirp_common.CloneModeRadio):
             VENDOR = 'Dan'
             MODEL = 'Foomaster 9000'
             VARIANT = 'R'

--- a/tests/unit/test_directory.py
+++ b/tests/unit/test_directory.py
@@ -58,7 +58,7 @@ class TestDirectory(base.BaseTest):
         with open(fn, 'wb') as f:
             f.write(b'thisisrawdata')
             f.write(self.test_class.MAGIC + b'-')
-            f.write(self.test_class._make_metadata())
+            f.write(self.test_class(None)._make_metadata())
             f.flush()
         self._test_detect_finds_our_class(fn)
 

--- a/tests/unit/test_directory.py
+++ b/tests/unit/test_directory.py
@@ -29,7 +29,7 @@ class TestDirectory(base.BaseTest):
             VARIANT = 'A'
 
         @directory.register
-        class FakeRadio(chirp_common.FileBackedRadio):
+        class FakeRadio(chirp_common.CloneModeRadio):
             VENDOR = 'Dan'
             MODEL = 'Foomaster 9000'
             VARIANT = 'R'


### PR DESCRIPTION
- Move mmap and metadata code to CloneModeRadio
- Refactor get, set, erase memory ops in memedit
- Add interface for storing extra memory fields
- Make wxui support ExternalMemoryProperties
- Limit comment input to 256 characters
- Remove FT-450's abuse of the comment field
