### PR TITLE
Variable power support (for CSV)

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -209,6 +209,29 @@ class PowerLevel:
         return "%s (%i dBm)" % (self._label, self._power)
 
 
+class AutoNamedPowerLevel(PowerLevel):
+    """A power level that is simply named by its value in watts"""
+    def __init__(self, watts):
+        fmt = ('%iW' if watts >= 10 else '%.1fW')
+        super().__init__(fmt % watts, watts=watts)
+
+
+def parse_power(powerstr):
+    if powerstr.isdigit():
+        # All digits means watts
+        watts = int(powerstr)
+    else:
+        match = re.match('^\s*([0-9.]+)\s*([Ww]?)\s*$', powerstr)
+        if not match:
+            raise ValueError('Invalid power specification: %r' % powerstr)
+        if match.group(2).lower() in ('', 'w'):
+            watts = float(match.group(1))
+        else:
+            raise ValueError('Unknown power units in %r' % powerstr)
+
+    return AutoNamedPowerLevel(watts)
+
+
 def parse_freq(freqstr):
     """Parse a frequency string and return the value in integral Hz"""
     freqstr = freqstr.strip()

--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -750,6 +750,7 @@ class RadioFeatures:
         "has_nostep_tuning":    BOOLEAN,
         "has_comment":          BOOLEAN,
         "has_settings":         BOOLEAN,
+        "has_variable_power":   BOOLEAN,
 
         # Attributes
         "valid_modes":          [],
@@ -861,6 +862,9 @@ class RadioFeatures:
                   "with each memory")
         self.init("has_settings", False,
                   "Indicates that the radio supports general settings")
+        self.init("has_variable_power", False,
+                  "Indicates the radio supports any power level between the "
+                  "min and max in valid_powe_levels")
 
         self.init("valid_modes", list(MODES),
                   "Supported emission (or receive) modes")
@@ -999,11 +1003,18 @@ class RadioFeatures:
                      "of supported range").format(freq=format_freq(freq)))
                 msgs.append(msg)
 
-        if mem.power and \
-                self.valid_power_levels and \
-                mem.power not in self.valid_power_levels:
-            msg = ValidationWarning("Power level %s not supported" % mem.power)
-            msgs.append(msg)
+        if mem.power and self.valid_power_levels:
+            if self.has_variable_power:
+                if (mem.power < min(self.valid_power_levels) or
+                        mem.power > max(self.valid_power_levels)):
+                    msg = ValidationWarning(
+                        "Power level %s is out of radio's range" % mem.power)
+                    msgs.append(msg)
+            else:
+                if mem.power not in self.valid_power_levels:
+                    msg = ValidationWarning(
+                        "Power level %s not supported" % mem.power)
+                    msgs.append(msg)
 
         if self.valid_tuning_steps and not self.has_nostep_tuning:
             try:

--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -159,12 +159,12 @@ APRS_SYMBOLS = (
 
 def watts_to_dBm(watts):
     """Converts @watts in watts to dBm"""
-    return round(10 * math.log10(watts) + 30, 1)
+    return 10 * math.log10(watts) + 30
 
 
 def dBm_to_watts(dBm):
     """Converts @dBm from dBm to watts"""
-    return round(math.pow(10, dBm / 10) / 1000)
+    return round(math.pow(10, dBm / 10) / 1000, 1)
 
 
 class PowerLevel:
@@ -173,31 +173,34 @@ class PowerLevel:
     def __init__(self, label, watts=0, dBm=0):
         if watts:
             dBm = watts_to_dBm(watts)
-        self._power = int(dBm)
+        self._power = float(dBm)
         self._label = label
 
     def __str__(self):
         return str(self._label)
 
     def __int__(self):
+        return int(self._power)
+
+    def __float__(self):
         return self._power
 
     def __sub__(self, val):
-        return int(self) - int(val)
+        return float(self) - float(val)
 
     def __add__(self, val):
-        return int(self) + int(val)
+        return float(self) + float(val)
 
     def __eq__(self, val):
         if val is not None:
-            return int(self) == int(val)
+            return float(self) == float(val)
         return False
 
     def __lt__(self, val):
-        return int(self) < int(val)
+        return float(self) < float(val)
 
     def __gt__(self, val):
-        return int(self) > int(val)
+        return float(self) > float(val)
 
     def __bool__(self):
         return int(self) != 0

--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -265,7 +265,7 @@ class CSVRadio(chirp_common.FileBackedRadio):
 
     def get_memory(self, number):
         try:
-            return self.memories[number]
+            return self.memories[number].dupe()
         except:
             raise errors.InvalidMemoryLocation("No such memory %s" % number)
 
@@ -291,7 +291,7 @@ class CSVRadio(chirp_common.FileBackedRadio):
             newmem.power = chirp_common.AutoNamedPowerLevel(
                 chirp_common.dBm_to_watts(float(newmem.power)))
         self._grow(newmem.number)
-        self.memories[newmem.number] = newmem
+        self.memories[newmem.number] = newmem.dupe()
 
     def erase_memory(self, number):
         mem = chirp_common.Memory()

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -231,6 +231,18 @@ class ChirpFrequencyColumn(ChirpMemoryColumn):
             self._wants_split.discard(memory.number)
 
 
+class ChirpVariablePowerColumn(ChirpMemoryColumn):
+    def __init__(self, name, radio, power_levels):
+        super().__init__(name, radio)
+
+    @property
+    def level(self):
+        return _('Power')
+
+    def _digest_value(self, memory, value):
+        return chirp_common.parse_power(value)
+
+
 class ChirpChoiceEditor(wx.grid.GridCellChoiceEditor):
     """A locking GridCellChoiceEditor.
 
@@ -510,6 +522,10 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
         valid_duplexes = filter_unknowns(self._features.valid_duplexes)
         valid_power_levels = self._features.valid_power_levels
         valid_tuning_steps = self._features.valid_tuning_steps
+        if self._features.has_variable_power:
+            power_col_cls = ChirpVariablePowerColumn
+        else:
+            power_col_cls = ChirpChoiceColumn
         defs = [
             ChirpFrequencyColumn('freq', self._radio),
             ChirpMemoryColumn('name', self._radio),
@@ -530,8 +546,8 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
                               valid_tuning_steps),
             ChirpChoiceColumn('skip', self._radio,
                               valid_skips),
-            ChirpChoiceColumn('power', self._radio,
-                              valid_power_levels),
+            power_col_cls('power', self._radio,
+                          valid_power_levels),
             ChirpCommentColumn('comment', self._radio),
         ]
         return defs

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -261,6 +261,29 @@ class TestUtilityFunctions(base.BaseTest):
         self.assertEqual('[146.520000/D025/D025]', txt)
         chirp_common.mem_from_text(txt)
 
+    def test_parse_power(self):
+        valid = [
+            ('0.1', 0.1),
+            ('0.1W', 0.1),
+            ('0.25', 0.2),
+            ('0.25W', 0.2),
+            ('11.0', 11),
+            ('11', 11),
+            ('11.0W', 11),
+            ('11w', 11),
+            ('1500', 1500),
+            ('2500', 2500),
+            ('2500W', 2500),
+            ('2500.0W', 2500)]
+        for s, v in valid:
+            power = chirp_common.parse_power(s)
+            self.assertEqual(v, chirp_common.dBm_to_watts(float(power)))
+
+    def test_parse_power_invalid(self):
+        invalid = ['2500d', '2d1', 'aaa', 'a', '']
+        for s in invalid:
+            self.assertRaises(ValueError, chirp_common.parse_power, s)
+
 
 class TestSplitTone(base.BaseTest):
     def _test_split_tone_decode(self, tx, rx, **vals):

--- a/tests/unit/test_csv.py
+++ b/tests/unit/test_csv.py
@@ -157,3 +157,12 @@ class TestCSV(unittest.TestCase):
         self.assertEqual('DTCS->DTCS', m2.cross_mode)
         self.assertEqual(25, m2.dtcs)
         self.assertEqual(73, m2.rx_dtcs)
+
+    def test_csv_memories_are_private(self):
+        m = chirp_common.Memory(name='foo')
+        radio = generic_csv.CSVRadio(None)
+        radio.set_memory(m)
+        # If CSVRadio maintains a reference to m, then this will modify
+        # its internal state and the following assertion will fail.
+        m.name = 'bar'
+        self.assertEqual('foo', radio.get_memory(0).name)

--- a/tests/unit/test_csv.py
+++ b/tests/unit/test_csv.py
@@ -19,7 +19,7 @@ CHIRP_CSV_MINIMAL = (
 CHIRP_CSV_MODERN = (
 """Location,Name,Frequency,Duplex,Offset,Tone,rToneFreq,cToneFreq,DtcsCode,DtcsPolarity,RxDtcsCode,CrossMode,Mode,TStep,Skip,Power,Comment,URCALL,RPT1CALL,RPT2CALL,DVCODE
 0,Nat Simplex,146.520000,,0.600000,TSQL,88.5,88.5,023,NN,023,Tone->Tone,FM,5.00,,50W,This is the national calling frequency on 2m,,,,
-1,National Simp,446.000000,-,5.000000,DTCS,88.5,88.5,023,NN,023,Tone->Tone,FM,5.00,,5W,This is NOT the UHF calling frequency,,,,
+1,National Simp,446.000000,-,5.000000,DTCS,88.5,88.5,023,NN,023,Tone->Tone,FM,5.00,,5.0W,This is NOT the UHF calling frequency,,,,
 """)
 
 
@@ -70,7 +70,7 @@ class TestCSV(unittest.TestCase):
         self.assertEqual('NN', mem.dtcs_polarity)
         self.assertEqual('FM', mem.mode)
         self.assertEqual(5.0, mem.tuning_step)
-        self.assertEqual(generic_csv.POWER_LEVELS[5], mem.power)
+        self.assertEqual('5.0W', str(mem.power))
         self.assertIn('UHF calling', mem.comment)
 
     def test_parse_minimal(self):
@@ -100,14 +100,16 @@ class TestCSV(unittest.TestCase):
         self.assertEqual(1, mem.number)
         self.assertEqual(146520000, mem.freq)
 
-    def test_invalid_power(self):
+    def test_foreign_power(self):
         csv = generic_csv.CSVRadio(None)
         m = chirp_common.Memory()
         m.number = 1
         m.freq = 146520000
         m.power = chirp_common.PowerLevel('Low', watts=17)
-        self.assertRaises(errors.InvalidValueError,
-                          csv.set_memory, m)
+        csv.set_memory(m)
+        m = csv.get_memory(1)
+        self.assertEqual('17W', str(m.power))
+        self.assertEqual(int(chirp_common.watts_to_dBm(17)), int(m.power))
 
     def test_default_power(self):
         m = chirp_common.Memory()


### PR DESCRIPTION
- Fix (again) power conversions
- Add generic power level parsing and a helper
- Add a has_variable_power feature flag
- Make CSVRadio support variable power
- Make memedit support radios with variable power
