### PR TITLE
Update bf_t8.py driver to use mem.immutable - #10288

### DIFF
--- a/chirp/drivers/bf_t8.py
+++ b/chirp/drivers/bf_t8.py
@@ -483,6 +483,90 @@ class BFT8Radio(chirp_common.CloneModeRadio):
                       (_mem.lowpower, levels))
             mem.power = levels[0]
 
+        immutable = []
+
+        if self._frs:
+            if mem.freq in FRS_FREQS:
+                if mem.number >= 1 and mem.number <= 22:
+                    FRS_FREQ = FRS_FREQS[mem.number - 1]
+                    mem.freq = FRS_FREQ
+                mem.duplex == ''
+                mem.offset = 0
+                mem.mode = "NFM"
+                if mem.number >= 8 and mem.number <= 14:
+                    mem.power = self.POWER_LEVELS[1]
+                    immutable = ["empty", "freq", "duplex", "offset", "mode",
+                                 "power"]
+                else:
+                    immutable = ["empty", "freq", "duplex", "offset", "mode"]
+        elif self._murs:
+            if mem.freq in MURS_FREQS:
+                if mem.number >= 1 and mem.number <= 5:
+                    MURS_FREQ = MURS_FREQS[mem.number - 1]
+                    mem.freq = MURS_FREQ
+                mem.duplex = ''
+                mem.offset = 0
+                if mem.number <= 3:
+                    mem.mode = "NFM"
+                    immutable = ["empty", "freq", "duplex", "offset", "mode"]
+                else:
+                    immutable = ["empty", "freq", "duplex", "offset"]
+        elif self._pmr:
+            if mem.freq in PMR_FREQS:
+                if mem.number >= 1 and mem.number <= 16:
+                    PMR_FREQ = PMR_FREQS[mem.number - 1]
+                    mem.freq = PMR_FREQ
+                mem.duplex = ''
+                mem.offset = 0
+                mem.mode = "NFM"
+                mem.power = self.POWER_LEVELS[1]
+                immutable = ["empty", "freq", "duplex", "offset", "mode",
+                             "power"]
+        elif self._gmrs:
+            if mem.freq in GMRS_FREQS:
+                if mem.number >= 1 and mem.number <= 30:
+                    GMRS_FREQ = GMRS_FREQS[mem.number - 1]
+                    mem.freq = GMRS_FREQ
+                    immutable = ["empty", "freq"]
+                if mem.number >= 1 and mem.number <= 7:
+                    mem.duplex == ''
+                    mem.offset = 0
+                    immutable += ["duplex", "offset"]
+                elif mem.number >= 8 and mem.number <= 14:
+                    mem.duplex == ''
+                    mem.offset = 0
+                    mem.mode = "NFM"
+                    mem.power = self.POWER_LEVELS[1]
+                    immutable += ["duplex", "offset", "mode", "power"]
+                elif mem.number >= 15 and mem.number <= 22:
+                    mem.duplex == ''
+                    mem.offset = 0
+                    immutable += ["duplex", "offset"]
+                elif mem.number >= 23 and mem.number <= 30:
+                    mem.duplex == '+'
+                    mem.offset = 5000000
+                    immutable += ["duplex", "offset"]
+                elif mem.freq in FRS_FREQS1:
+                    mem.duplex == ''
+                    mem.offset = 0
+                    immutable += ["duplex", "offset"]
+                elif mem.freq in FRS_FREQS2:
+                    mem.duplex == ''
+                    mem.offset = 0
+                    mem.mode = "NFM"
+                    mem.power = self.POWER_LEVELS[1]
+                    immutable += ["duplex", "offset", "mode", "power"]
+                elif mem.freq in FRS_FREQS3:
+                    if mem.duplex == '':
+                        mem.offset = 0
+                    if mem.duplex == '+':
+                        mem.offset = 5000000
+            else:
+                if mem.freq not in GMRS_FREQS:
+                    immutable = ["duplex", "offset"]
+
+        mem.immutable = immutable
+
         return mem
 
     def _set_tone(self, mem, _mem):
@@ -526,62 +610,9 @@ class BFT8Radio(chirp_common.CloneModeRadio):
         _mem.set_raw("\x00" * 13 + "\xFF" * 3)
 
         if self._gmrs:
-            if mem.number >= 1 and mem.number <= 30:
-                GMRS_FREQ = GMRS_FREQS[mem.number - 1]
-                mem.freq = GMRS_FREQ
-                if mem.number <= 22:
-                    mem.duplex = ''
-                    mem.offset = 0
-                    if mem.number >= 8 and mem.number <= 14:
-                        mem.mode = "NFM"
-                        mem.power = self.POWER_LEVELS[1]
-                if mem.number > 22:
-                    mem.duplex = '+'
-                    mem.offset = 5000000
-            elif mem.freq in GMRS_FREQS:
-                if mem.freq in FRS_FREQS1:
-                    mem.duplex = ''
-                    mem.offset = 0
-                if mem.freq in FRS_FREQS2:
-                    mem.duplex = ''
-                    mem.offset = 0
-                    mem.mode = "NFM"
-                    mem.power = self.POWER_LEVELS[1]
-                if mem.freq in FRS_FREQS3:
-                    if mem.duplex == '+':
-                        mem.offset = 5000000
-                    else:
-                        mem.duplex = ''
-                        mem.offset = 0
-            else:
+            if mem.freq not in GMRS_FREQS:
                 mem.duplex = 'off'
                 mem.offset = 0
-        if self._frs:
-            if mem.number >= 1 and mem.number <= 22:
-                FRS_FREQ = FRS_FREQS[mem.number - 1]
-                mem.freq = FRS_FREQ
-                if mem.number <= 22:
-                    mem.duplex = ''
-                    mem.offset = 0
-                    mem.mode = "NFM"
-                    if mem.number >= 8 and mem.number <= 14:
-                        mem.power = self.POWER_LEVELS[1]
-        if self._murs:
-            if mem.number >= 1 and mem.number <= 5:
-                MURS_FREQ = MURS_FREQS[mem.number - 1]
-                mem.freq = MURS_FREQ
-                mem.duplex = ''
-                mem.offset = 0
-                if mem.number <= 3:
-                    mem.mode = "NFM"
-        if self._pmr:
-            if mem.number >= 1 and mem.number <= 16:
-                PMR_FREQ = PMR_FREQS[mem.number - 1]
-                mem.freq = PMR_FREQ
-                mem.duplex = ''
-                mem.offset = 0
-                mem.mode = "NFM"
-                mem.power = self.POWER_LEVELS[1]
 
         # frequency
         _mem.rxfreq = mem.freq / 10
@@ -862,6 +893,7 @@ class RetevisRB27B(BFT8Radio):
 class RetevisRB27(RetevisRB27B):
     VENDOR = "Retevis"
     MODEL = "RB27"
+    DUPLEXES = ["", "+", "off"]
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=5.00),
                     chirp_common.PowerLevel("Low", watts=0.50)]
     VALID_BANDS = [(136000000, 174000000),
@@ -905,7 +937,6 @@ class FRSA1Radio(BFT8Radio):
     NAME_LENGTH = 6
     SKIP_VALUES = ["", "S"]
     DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
-    DUPLEXES = ["", "-", "+", "off"]
 
     _fingerprint = b"BF-T8A" + b"\x2E"
     _upper = 22


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
