### PR TITLE
Fixes to Yaesu FT8x7 and some cleanups

### DIFF
--- a/chirp/directory.py
+++ b/chirp/directory.py
@@ -62,9 +62,10 @@ def register(cls):
             LOG.warn("Replacing existing driver id `%s'" % ident)
         else:
             raise Exception("Duplicate radio driver id `%s'" % ident)
+    elif ALLOW_DUPS:
+        LOG.info("Registered %s = %s" % (ident, cls.__name__))
     DRV_TO_RADIO[ident] = cls
     RADIO_TO_DRV[cls] = ident
-    LOG.info("Registered %s = %s" % (ident, cls.__name__))
 
     return cls
 

--- a/chirp/drivers/boblov_x3plus.py
+++ b/chirp/drivers/boblov_x3plus.py
@@ -131,17 +131,9 @@ class BoblovX3Plus(chirp_common.CloneModeRadio,
           this radio driver handles the represented model"""
 
         if len(filedata) != cls._memsize:
-            LOG.debug('Boblov_x3plus: match_model: size mismatch')
             return False
 
-        LOG.debug('Boblov_x3plus: match_model: size matches')
-
-        if b'P310' in filedata[0x03D0:0x03D8]:
-            LOG.debug('Boblov_x3plus: match_model: radio ID matches')
-            return True
-
-        LOG.debug('Boblov_x3plus: match_model: no radio ID match')
-        return False
+        return b'P310' in filedata[0x03D0:0x03D8]
 
     def get_features(self):
         """Return a RadioFeatures object for this radio"""

--- a/chirp/drivers/fd268.py
+++ b/chirp/drivers/fd268.py
@@ -280,13 +280,7 @@ def model_match(cls, data):
     # bytes it's like the model fingerprint, so we have to testing the
     # model type with this experimental method so far.
     fp = data[0:4]
-    if fp == cls._IDENT:
-        return True
-    else:
-        LOG.debug("Unknowd Feidaxing radio, ID:")
-        LOG.debug(util.hexprint(fp))
-
-        return False
+    return fp == cls._IDENT
 
 
 class FeidaxinFD2x8yRadio(chirp_common.CloneModeRadio):

--- a/chirp/drivers/ft817.py
+++ b/chirp/drivers/ft817.py
@@ -505,21 +505,21 @@ class FT817Radio(yaesu_clone.YaesuCloneModeRadio):
                                -1):
             _mem = self._memobj.vfoa[-self.LAST_VFOA_INDEX + mem.number]
             immutable = ["number", "skip", "extd_number",
-                         "name", "dtcs_polarity", "power", "comment"]
+                         "name", "dtcs_polarity", "power"]
         elif mem.number in range(self.FIRST_VFOB_INDEX,
                                  self.LAST_VFOB_INDEX - 1,
                                  -1):
             _mem = self._memobj.vfob[-self.LAST_VFOB_INDEX + mem.number]
             immutable = ["number", "skip", "extd_number",
-                         "name", "dtcs_polarity", "power", "comment"]
+                         "name", "dtcs_polarity", "power"]
         elif mem.number in range(-2, -6, -1):
             _mem = self._memobj.home[5 + mem.number]
             immutable = ["number", "skip", "extd_number",
-                         "name", "dtcs_polarity", "power", "comment"]
+                         "name", "dtcs_polarity", "power"]
         elif mem.number == -1:
             _mem = self._memobj.qmb
             immutable = ["number", "skip", "extd_number",
-                         "name", "dtcs_polarity", "power", "comment"]
+                         "name", "dtcs_polarity", "power"]
         elif mem.number in list(self.SPECIAL_PMS.values()):
             bitindex = -self.LAST_PMS_INDEX + mem.number
             used = (self._memobj.pmsvisible >> bitindex) & 0x01
@@ -532,7 +532,7 @@ class FT817Radio(yaesu_clone.YaesuCloneModeRadio):
             _mem = self._memobj.pms[-self.LAST_PMS_INDEX + mem.number]
             immutable = ["number", "skip", "rtone", "ctone", "extd_number",
                          "dtcs", "tmode", "cross_mode", "dtcs_polarity",
-                         "power", "duplex", "offset", "comment"]
+                         "power", "duplex", "offset"]
         else:
             raise Exception("Sorry, special memory index %i " % mem.number +
                             "unknown you hit a bug!!")
@@ -1166,7 +1166,7 @@ class FT817NDUSRadio(FT817Radio):
         mem.immutable = ["number", "rtone", "ctone",
                          "extd_number", "name", "dtcs", "tmode", "cross_mode",
                          "dtcs_polarity", "power", "duplex", "offset",
-                         "comment", "empty"]
+                         "empty"]
 
         return mem
 

--- a/chirp/drivers/ft817.py
+++ b/chirp/drivers/ft817.py
@@ -1190,9 +1190,9 @@ class FT817NDUSRadio(FT817Radio):
         self._set_memory(mem, _mem)
 
     def get_memory(self, number):
-        if number in list(self.SPECIAL_60M.keys()):
+        if number in self.SPECIAL_60M.keys():
             return self._get_special_60m(number)
-        elif (number < 0 and
+        elif (isinstance(number, int) and number < 0 and
               self.SPECIAL_MEMORIES_REV[number] in
               list(self.SPECIAL_60M.keys())):
             # I can't stop delete operation from losing extd_number but

--- a/chirp/drivers/ft857.py
+++ b/chirp/drivers/ft857.py
@@ -1150,7 +1150,7 @@ class FT857USRadio(FT857Radio):
         mem.immutable = ["number", "rtone", "ctone",
                          "extd_number", "name", "dtcs", "tmode", "cross_mode",
                          "dtcs_polarity", "power", "duplex", "offset",
-                         "comment", "empty"]
+                         "empty"]
 
         return mem
 

--- a/chirp/drivers/ftlx011.py
+++ b/chirp/drivers/ftlx011.py
@@ -254,16 +254,8 @@ def _model_match(cls, data):
     # It's hard to tell when this radio is really this radio.
     # I use the first byte, that appears to be the ID and the IF settings
 
-    LOG.debug("Drivers's ID string:")
-    LOG.debug(cls.finger)
-    LOG.debug("Radio's ID string:")
-    LOG.debug(util.hexprint(data[0:4]))
-
     radiod = [data[0], data[2:4]]
-    if cls.finger == radiod:
-        return True
-    else:
-        return False
+    return cls.finger == radiod
 
 
 def bcd_to_int(data):
@@ -747,15 +739,14 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
         # testing the file data size
         if len(filedata) == cls._memsize:
             match_size = True
-            print(("Comp: %i file / %i memzise" % (len(filedata), cls._memsize) ))
 
         # testing the firmware fingerprint, this experimental
-        match_model = _model_match(cls, filedata)
+        try:
+            match_model = _model_match(cls, filedata)
+        except Exception as e:
+            match_model = False
 
-        if match_size and match_model:
-            return True
-        else:
-            return False
+        return match_size and match_model
 
 
 @directory.register

--- a/chirp/drivers/id51.py
+++ b/chirp/drivers/id51.py
@@ -115,17 +115,12 @@ class ID51Radio(id31.ID31Radio):
         # Since the ID-51 and ID-51 Plus/Anniversary have exactly
         # the same memory size, we need to do a more detailed check.
         if len(filedata) == cls._memsize:
-            LOG.debug('File has correct memory size, '
-                      'checking 20 bytes at offset 0x1AF40')
             snip = bytes(filedata[0x1AF40:0x1AF60])
             if snip == bytes(b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
                              b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
                              b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
                              b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'):
-                LOG.debug('bytes matched ID-51 Signature')
                 return True
-            else:
-                LOG.debug('bytes did not match ID-51 Signature')
         return False
 
     def get_features(self):

--- a/chirp/drivers/id51plus.py
+++ b/chirp/drivers/id51plus.py
@@ -126,17 +126,12 @@ class ID51PLUSRadio(id31.ID31Radio):
         # Since the ID-51 and ID-51 Plus/Anniversary have exactly
         # the same memory size, we need to do a more detailed check.
         if len(filedata) == cls._memsize:
-            LOG.debug('File has correct memory size, '
-                      'checking 20 bytes at offset 0x1AF40')
             snip = bytes(filedata[0x1AF40:0x1AF60])
             if snip != bytes(b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
                              b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
                              b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
                              b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'):
-                LOG.debug('bytes matched ID-51 Plus Signature')
                 return True
-            else:
-                LOG.debug('bytes did not match ID-51 Plus Signature')
         return False
 
     def _get_bank(self, loc):

--- a/chirp/drivers/puxing_px888k.py
+++ b/chirp/drivers/puxing_px888k.py
@@ -1105,10 +1105,6 @@ class Puxing_PX888K_Radio(chirp_common.CloneModeRadio):
         if len(filedata) == UPPER_READ_BOUND:
             if filedata[FILE_MAGIC[0]:FILE_MAGIC[1]] == FILE_MAGIC[2]:
                 return True
-            else:
-                LOG.debug("The data at 0x0c40 does not match the PX-888K")
-        else:
-            LOG.debug("The file size does not match.")
         return False
 
     def get_features(self):

--- a/chirp/drivers/tk8102.py
+++ b/chirp/drivers/tk8102.py
@@ -424,7 +424,6 @@ class KenwoodTKx102Radio(chirp_common.CloneModeRadio):
     @classmethod
     def match_model(cls, filedata, filename):
         model = filedata[0x03D1:0x03D5]
-        LOG.debug(model)
         return model == cls.MODEL.encode().split(b"-")[1]
 
 

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -648,6 +648,7 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
             # If get_memory() failed, just refresh with the exception
             if isinstance(job.result, Exception):
                 self._refresh_memory(job.args[0], job.result)
+                return
 
             # Otherwise augment with extra fields and call refresh with that,
             # if appropriate

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -1,3 +1,9 @@
+import logging
+import sys
+from unittest import mock
+
+import pytest
+
 from chirp import directory
 from tests import base
 
@@ -15,3 +21,20 @@ class TestCaseDetect(base.DriverTest):
                                   "Image %s detected as %s but expected %s" % (
                                       self.TEST_IMAGE,
                                       radio._orig_rclass, self.RADIO_CLASS))
+
+    @pytest.mark.skipif(sys.version_info < (3, 10),
+                        reason="requires python3.10 or higher")
+    @mock.patch('builtins.print')
+    def test_match_model_is_quiet_no_match(self, mock_print):
+        with self.assertNoLogs(level=logging.DEBUG) as logs:
+            self.radio.match_model(b'', 'foo.img')
+        mock_print.assert_not_called()
+
+    @pytest.mark.skipif(sys.version_info < (3, 10),
+                        reason="requires python3.10 or higher")
+    @mock.patch('builtins.print')
+    def test_match_model_is_quiet_with_match(self, mock_print):
+        with self.assertNoLogs(level=logging.DEBUG) as logs:
+            with open(self.TEST_IMAGE, 'rb') as f:
+                self.radio.match_model(f.read(), self.TEST_IMAGE)
+        mock_print.assert_not_called()


### PR DESCRIPTION
- Fix 817ND US variant 60m channels
- Fix FT-817/857/897 immutable comment
- Fix proxying get_memory() exceptions
- Clean up extreme chattiness in match_model()
- Reduce log noise about registrations
