### PR TITLE
Fix ID-5100 Cross Mode handling

### DIFF
--- a/chirp/drivers/id5100.py
+++ b/chirp/drivers/id5100.py
@@ -117,7 +117,9 @@ class ID4100Radio(icf.IcomCloneModeRadio, chirp_common.IcomDstarSupport):
         rf.valid_modes = [x for x in MODES
                           if '?' not in x]
         rf.valid_tmodes = [x for x in TMODES
-                           if '-' not in x or '?' not in x]
+                           if '-' not in x and '?' not in x] + ['Cross']
+        rf.valid_cross_modes = [x for x in TMODES
+                                if '->' in x]
         rf.memory_bounds = (0, 999)
         rf.valid_bands = [(118000000, 174000000),
                           (375000000, 550000000)]
@@ -245,7 +247,10 @@ class ID4100Radio(icf.IcomCloneModeRadio, chirp_common.IcomDstarSupport):
         _mem.ctone = chirp_common.TONES.index(mem.ctone)
         _mem.dtcs = chirp_common.DTCS_CODES.index(mem.dtcs)
         _mem.dtcs_polarity = DTCS_POL.index(mem.dtcs_polarity)
-        _mem.tmode = TMODES.index(mem.tmode)
+        if mem.tmode == 'Cross':
+            _mem.tmode = TMODES.index(mem.cross_mode)
+        else:
+            _mem.tmode = TMODES.index(mem.tmode)
         _mem.duplex = DUPLEX.index(mem.duplex)
 
         _mem.unknown1 = 0

--- a/chirp/wxui/__init__.py
+++ b/chirp/wxui/__init__.py
@@ -100,9 +100,13 @@ def chirpmain():
         mainwindow.load_module(args.module)
 
     if args.restore or CONF.get_bool('restore_tabs', 'prefs'):
-        mainwindow.restore_tabs(None)
+        restored = mainwindow.restore_tabs(None)
 
     for fn in args.files:
+        if os.path.abspath(fn) in restored:
+            LOG.info('File %s on the command line is already being restored',
+                     fn)
+            continue
         mainwindow.open_file(fn, select=False)
 
     if args.page:

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -974,8 +974,9 @@ class ChirpMain(wx.Frame):
             if fn and os.path.exists(fn):
                 LOG.debug('Restoring tab for file %r' % fn)
                 self.open_file(fn)
-            else:
+            elif fn:
                 LOG.debug('Previous file %r no longer exists' % fn)
+        return last_files
 
     def _menu_open_recent(self, event):
         filename = self.OPEN_RECENT_MENU.FindItemById(


### PR DESCRIPTION
Somehow it went unnoticed that the ID-5100 driver exposed the
cross modes as tone modes instead of splitting them between the
two lists. This is likely because they're one list in the driver.
This fixes that, but also an issue noticed in the wxUI for this kind
of radio where has_rx_dtcs=False but ->DTCS cross modes are enabled
where the DTCS column was not revealed properly.

Fixes #10297
