### PR TITLE
GridSelectNone not available before 4.2.0

### DIFF
--- a/chirp/wxui/bankedit.py
+++ b/chirp/wxui/bankedit.py
@@ -80,8 +80,9 @@ class ChirpBankEdit(common.ChirpEditor):
         self._grid.CreateGrid(
             self._features.memory_bounds[1] - self._features.memory_bounds[0] +
             1, len(self._col_defs))
-        # GridSelectNone only available in >=4.2.0, which is not in requirements.txt for Linux
-        #self._grid.SetSelectionMode(wx.grid.Grid.GridSelectNone)
+        # GridSelectNone only available in >=4.2.0
+        if hasattr(wx.grid.Grid.GridSelectNone):
+            self._grid.SetSelectionMode(wx.grid.Grid.GridSelectNone)
         self._grid.DisableDragRowSize()
         self._grid.SetFocus()
 

--- a/chirp/wxui/bankedit.py
+++ b/chirp/wxui/bankedit.py
@@ -80,7 +80,8 @@ class ChirpBankEdit(common.ChirpEditor):
         self._grid.CreateGrid(
             self._features.memory_bounds[1] - self._features.memory_bounds[0] +
             1, len(self._col_defs))
-        self._grid.SetSelectionMode(wx.grid.Grid.GridSelectNone)
+        # GridSelectNone only available in >=4.2.0, which is not in requirements.txt for Linux
+        #self._grid.SetSelectionMode(wx.grid.Grid.GridSelectNone)
         self._grid.DisableDragRowSize()
         self._grid.SetFocus()
 


### PR DESCRIPTION
requirements.txt for Linux shows >=4.0,<4.2.0 but GridSelectNone not available before 4.2.0.

This causes Yaesu FT-65R and ICOM IC-T70 (and probably other bank-based radios) to fail.