### PR TITLE
Fix opening command line images when no restore

### DIFF
--- a/chirp/wxui/__init__.py
+++ b/chirp/wxui/__init__.py
@@ -101,6 +101,8 @@ def chirpmain():
 
     if args.restore or CONF.get_bool('restore_tabs', 'prefs'):
         restored = mainwindow.restore_tabs(None)
+    else:
+        restored = []
 
     for fn in args.files:
         if os.path.abspath(fn) in restored:


### PR DESCRIPTION
If we don't restore anything from a previous session, we will fail to
process images from the command line.
