### PR TITLE
Upgrade gmrsv2.py to use mem.immutable (revisited) - #10288

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -1067,6 +1067,12 @@ class ValidationError(ValidationMessage):
     pass
 
 
+def split_validation_msgs(msgs):
+    """Split a list of msgs into warnings,errors"""
+    return ([x for x in msgs if isinstance(x, ValidationWarning)],
+            [x for x in msgs if isinstance(x, ValidationError)])
+
+
 class Alias(object):
     VENDOR = "Unknown"
     MODEL = "Unknown"

--- a/chirp/drivers/gmrsv2.py
+++ b/chirp/drivers/gmrsv2.py
@@ -392,6 +392,22 @@ class GMRSV2(baofeng_common.BaofengCommonHT):
         """Process the mem map into the mem object"""
         self._memobj = bitwise.parse(self.MEM_FORMAT, self._mmap)
 
+    def validate_memory(self, mem):
+        msgs = baofeng_common.BaofengCommonHT.validate_memory(self, mem)
+
+        _mem = self._memobj.memory[mem.number]
+        _msg_duplex = 'Duplex must be "off" for this frequency'
+        _msg_offset = 'Only simplex or +5MHz offset allowed on GMRS'
+
+        if self.MODEL == "GMRS-V2":
+            if mem.freq not in GMRS_FREQS:
+                if mem.duplex != "off":
+                    msgs.append(chirp_common.ValidationWarning(_msg_duplex))
+            elif mem.duplex and mem.offset != 5000000:
+                msgs.append(chirp_common.ValidationWarning(_msg_offset))
+
+        return msgs
+
     def get_memory(self, number):
         _mem = self._memobj.memory[number]
         _nam = self._memobj.names[number]

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -716,6 +716,7 @@ class TestOverrideRules(base.BaseTest):
     IMMUTABLE_WHITELIST = [
         # Uncomment me when the time comes
         'BTECH_GMRS-V2',
+        'Retevis_RB17P',
     ]
 
     def _test_radio_override_immutable_policy(self, rclass):


### PR DESCRIPTION
This model supports "fully customizable channels" which created some additional challenges.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
