### PR TITLE
Allow KG-UV9D Plus driver to open more radio revision numbers using 9D Plus memory map

### DIFF
--- a/chirp/drivers/kguv9dplus.py
+++ b/chirp/drivers/kguv9dplus.py
@@ -1171,12 +1171,11 @@ class KGUV9DPlusRadio(chirp_common.CloneModeRadio,
         raise Exception("All retries to identify failed")
 
     def process_mmap(self):
-        if self._rev == b"02" or self._rev == b"00":
-            self._memobj = bitwise.parse(_MEM_FORMAT02, self._mmap)
-        else:  # this is where you elif the other variants and non-Plus  radios
-            raise errors.RadioError(
-                "Unrecognized model variation (%s). No memory map for it" %
-                self._rev)
+        if self._rev != b"02" and self._rev != b"00":
+            # new revision found - log it and assume same map and proceed
+            LOG.debug("Unrecognized model variation (%s) Using default Map" %
+                      self._rev)
+        self._memobj = bitwise.parse(_MEM_FORMAT02, self._mmap)
 
     def sync_in(self):
         """ Public sync_in


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
