### PR TITLE
Various fixes and tests

### DIFF
--- a/chirp/drivers/alinco.py
+++ b/chirp/drivers/alinco.py
@@ -841,7 +841,7 @@ class AlincoDJG7(AlincoStyleRadio):
                         "This radio does not support tone %.1fHz" % mem.ctone)
             _mem.dcs = DCS_CODES[self.VENDOR].index(mem.dtcs)
             _mem.skip = (mem.skip == "S")
-            _mem.name = "\x00".join(mem.name).ljust(32, "\x00")
+            _mem.name = "\x00".join(mem.name.rstrip()).ljust(32, "\x00")
             _mem.unknown1 = 0x3e001c
             _mem.unknown2 = 0x0000000a
             _mem.unknown3 = 0x00000000

--- a/chirp/drivers/anytone_iii.py
+++ b/chirp/drivers/anytone_iii.py
@@ -1102,7 +1102,9 @@ class AnyTone5888UVIIIRadio(chirp_common.CloneModeRadio,
                                            "band.")
 
         _mem.set_raw("\x00" * 32)
-        _flg.unused = 0
+        if _flg:
+            # Only non-special memories track this
+            _flg.unused = 0
 
         _mem.freq = mem.freq
 
@@ -1112,7 +1114,9 @@ class AnyTone5888UVIIIRadio(chirp_common.CloneModeRadio,
                 _mem.band = band_idx
                 break
 
-        _flg.left_only = 0
+        if _flg:
+            # Only non-special memories have this
+            _flg.left_only = 0
         if (not is_hyper_chan):
             if mem.mode == "AM":
                 _flg.left_only = 1

--- a/chirp/drivers/ft4.py
+++ b/chirp/drivers/ft4.py
@@ -1128,7 +1128,7 @@ class YaesuSC35GenericRadio(chirp_common.CloneModeRadio,
         Raise an exception to cause UI to pop up an error message
         """
         first_vfo_num = self.MAX_MEM_SLOT + len(PMSNAMES) + 1
-        band = BAND_ASSIGNMENTS[mem_num - first_vfo_num]
+        band = self.BAND_ASSIGNMENTS[mem_num - first_vfo_num]
         frange = self.valid_bands[band]
         if freq >= frange[0] and freq <= frange[1]:
             memloc.freq = freq / 10

--- a/chirp/drivers/ft450d.py
+++ b/chirp/drivers/ft450d.py
@@ -620,7 +620,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
     def _set_special(self, mem):
         if mem.empty and mem.number not in self.SPECIAL_PMS.values():
             # can't delete special memories!
-            raise Exception("Sorry, special memory can't be deleted")
+            raise errors.RadioError("Sorry, special memory can't be deleted")
 
         cur_mem = self._get_special(self.SPECIAL_MEMORIES_REV[mem.number])
 
@@ -656,8 +656,8 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
             self._memobj.pmsfilled = self._memobj.pmsfilled | 1 << bitindex
             _mem = self._memobj.pms[-self.LAST_PMS_INDEX + mem.number]
         else:
-            raise Exception("Sorry, you can't edit"
-                            " that special memory.")
+            raise errors.RadioError("Sorry, you can't edit"
+                                    " that special memory.")
 
         for key in cur_mem.immutable:
             if key != "extd_number":

--- a/chirp/drivers/ft7100.py
+++ b/chirp/drivers/ft7100.py
@@ -597,7 +597,7 @@ class FT7100Radio(YaesuCloneModeRadio):
         mem = chirp_common.Memory()
 
         # Get a low-level memory object mapped to the image
-        if number < 0:
+        if isinstance(number, int) and number < 0:
             number = SPECIAL_CHANS[number + 10]
         if isinstance(number, str):
             mem.number = -10 + SPECIAL_CHANS.index(number)
@@ -1171,16 +1171,15 @@ class FT7100RadioVHF(FT7100Radio):
 
     def set_memory(self, mem):
         LOG.debug("set_memory VHF Number: {}".format(mem.number))
-        # mem is used further in test by tox. So save the modified members.
-        _number = mem.number
+        # We modify memory, so dupe() it to avoid changing our caller's
+        # version
+        mem = mem.dupe()
         if isinstance(mem.number, int):
             if mem.number >= 0:
                 mem.number += -1
         else:
             mem.number += '-VHF'
         super(FT7100RadioVHF, self).set_memory(mem)
-        # Restore modified members
-        mem.number = _number
         return
 
 
@@ -1217,8 +1216,9 @@ class FT7100RadioUHF(FT7100Radio):
 
     def set_memory(self, mem):
         LOG.debug("set_memory UHF Number: {}".format(mem.number))
-        # mem is used further in test by tox. So save the modified members.
-        _number = mem.number
+        # We modify memory, so dupe() it to avoid changing our caller's
+        # version
+        mem = mem.dupe()
         upper_vhf_limit = self._get_upper_vhf_limit()
         if isinstance(mem.number, int):
             if mem.number >= 0:
@@ -1226,6 +1226,4 @@ class FT7100RadioUHF(FT7100Radio):
         else:
             mem.number += '-UHF'
         super(FT7100RadioUHF, self).set_memory(mem)
-        # Restore modified members
-        mem.number = _number
         return

--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -292,6 +292,7 @@ class CSVRadio(chirp_common.FileBackedRadio):
                 chirp_common.dBm_to_watts(float(newmem.power)))
         self._grow(newmem.number)
         self.memories[newmem.number] = newmem.dupe()
+        self.memories[newmem.number].name = newmem.name.rstrip()
 
     def erase_memory(self, number):
         mem = chirp_common.Memory()

--- a/chirp/drivers/ic2100.py
+++ b/chirp/drivers/ic2100.py
@@ -244,12 +244,13 @@ class IC2100Radio(icf.IcomCloneModeRadio):
         return mem
 
     def set_memory(self, mem):
-        if mem.number == "C":
+        number = mem.extd_number or mem.number
+        if number == "C":
             _mem = self._memobj.call[0]
-        elif isinstance(mem.number, str):
-            _mem = self._memobj.special[_get_special[mem.number] - 500]
+        elif isinstance(number, str):
+            _mem = self._memobj.special[_get_special()[number] - 500]
         else:
-            number = mem.number - 1
+            number = number - 1
             _mem = self._memobj.memory[number]
             _emt = self._memobj.usedflags[number / 8].flagbits
             mask = 1 << (number % 8)

--- a/chirp/drivers/ic2820.py
+++ b/chirp/drivers/ic2820.py
@@ -268,7 +268,8 @@ class IC2820Radio(icf.IcomCloneModeRadio, chirp_common.IcomDstarSupport):
         if mem.empty:
             _used |= bitpos
             _wipe_memory(_mem, "\xFF")
-            self._set_bank(mem.number, None)
+            if mem.number < 500:
+                self._set_bank(mem.number, None)
             return
 
         _used &= ~bitpos

--- a/chirp/drivers/icx8x.py
+++ b/chirp/drivers/icx8x.py
@@ -83,7 +83,11 @@ class ICx8xRadio(icf.IcomCloneModeRadio, chirp_common.IcomDstarSupport):
             rf.valid_bands = [(118000000, 176000000)]
         rf.valid_skips = ["", "S"]
         rf.valid_name_length = 5
-        rf.valid_special_chans = sorted(icx8x_ll.ICx8x_SPECIAL.keys())
+        # This driver, as it is, is basically unmaintainable. The sepecials
+        # test shows that our handling of special channels here is broken,
+        # so disable this until the driver can be rewritten into bitwise
+        # form.
+        # rf.valid_special_chans = sorted(icx8x_ll.ICx8x_SPECIAL.keys())
 
         return rf
 

--- a/chirp/drivers/icx90.py
+++ b/chirp/drivers/icx90.py
@@ -705,7 +705,8 @@ class ICx90Radio(icf.IcomCloneModeRadio):
         return mem
 
     def set_memory(self, memory):
-        (mem_item, special, unique_idx) = self.get_mem_item(memory.number)
+        (mem_item, special, unique_idx) = self.get_mem_item(
+            memory.extd_number or memory.number)
         if memory.empty:
             mem_item.set_raw("\x00" * MEM_ITEM_SIZE)
             self.clear_bank(memory.number)

--- a/chirp/drivers/id800.py
+++ b/chirp/drivers/id800.py
@@ -50,7 +50,7 @@ struct {
   u8 unknown7:1,
      mode:3,
      unknown8:4;
-} memory[500];
+} memory[512];
 
 #seekto 0x2BF4;
 struct {
@@ -59,7 +59,7 @@ struct {
      pskip:1,
      skip:1,
      bank:4;
-} flags[500];
+} flags[512];
 
 #seekto 0x3220;
 struct {
@@ -77,7 +77,7 @@ struct {
 } rptcalls[59];
 """
 
-MODES = ["FM", "NFM", "AM", "NAM", "DV"]
+MODES = ["FM", "NFM", "AM", "NAM", "DV", "FM", "FM", "FM"]
 TMODES = ["", "Tone", "TSQL", "DTCS"]
 DUPLEX = ["", "", "-", "+"]
 DTCS_POL = ["NN", "NR", "RN", "RR"]
@@ -220,7 +220,7 @@ class ID800v2Radio(icf.IcomCloneModeRadio, chirp_common.IcomDstarSupport):
         rf.has_implicit_calls = True
         rf.has_settings = True
         rf.has_bank = True
-        rf.valid_modes = list(MODES)
+        rf.valid_modes = [x for x in MODES if x]
         rf.valid_tmodes = ["", "Tone", "TSQL", "DTCS"]
         rf.valid_duplexes = ["", "-", "+"]
         rf.valid_tuning_steps = list(STEPS)

--- a/chirp/drivers/lt725uv.py
+++ b/chirp/drivers/lt725uv.py
@@ -754,7 +754,7 @@ class LT725UV(chirp_common.CloneModeRadio):
         else:
             _mem.txfreq = mem.freq / 10
 
-        _mem.namelen = len(mem.name)
+        _mem.namelen = len(mem.name.rstrip())
         _namelength = self.get_features().valid_name_length
         for i in range(_namelength):
             try:

--- a/chirp/drivers/puxing_px888k.py
+++ b/chirp/drivers/puxing_px888k.py
@@ -1396,7 +1396,8 @@ class Puxing_PX888K_Radio(chirp_common.CloneModeRadio):
             if not bool(_present):
                 self._set_sane_defaults(_data)
             _name.set_value(
-                    encode_ffstring(self.filter_name(mem.name), len(_name)))
+                    encode_ffstring(self.filter_name(mem.name.rstrip()),
+                                    len(_name)))
             _present.set_value(True)
             _priority.set_value(1-SKIP_MODES.index(mem.skip))
 

--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -329,6 +329,7 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
                 _map = self._memobj.chmap[mem.number]
             else:                        # Call chans
                 _mem = self._memobj.call[mem.number - 1030]
+            _nam = None
         else:
             _mem = self._memobj.ch_mem[mem.number]
             _nam = self._memobj.ch_nam[mem.number]
@@ -351,8 +352,9 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
             _mem.dtcs = 0x0ff
             _map.skip = 0x0ff
             _map.band = 0x0ff
-            for ix in range(8):
-                _nam.name[ix] = chr(0x0ff)
+            if _nam:
+                for ix in range(8):
+                    _nam.name[ix] = chr(0x0ff)
             return
         if _mem.rxfreq == 0x0ffffffff:    # New Channel needs defaults
             _mem.rxfreq = 144000000

--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -270,7 +270,7 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
             for char in _nam.name:
                 if int(char) < 127:
                     mnx += chr(int(char))
-            mem.name = mnx
+            mem.name = mnx.rstrip()
         if _mem.rxfreq == 0x0ffffffff or _mem.rxfreq == 0:
             mem.empty = True
             return mem

--- a/chirp/drivers/uvb5.py
+++ b/chirp/drivers/uvb5.py
@@ -388,7 +388,7 @@ class BaofengUVB5(chirp_common.CloneModeRadio,
         if isinstance(number, str):
             return (getattr(self._memobj, number.lower()), None)
         elif number < 0:
-            for k, v in list(SPECIALS.items()):
+            for k, v in list(self.SPECIALS.items()):
                 if number == v:
                     return (getattr(self._memobj, k.lower()), None)
         else:

--- a/chirp/drivers/vgc.py
+++ b/chirp/drivers/vgc.py
@@ -842,7 +842,7 @@ class VGCStyleRadio(chirp_common.CloneModeRadio,
         self.encode_tone(_mem.rxtone, rxmode, rxtone, rxpol)
 
         # name TAG of the channel
-        _names.name = mem.name.ljust(6, "\xFF")
+        _names.name = mem.name.rstrip().ljust(6, "\xFF")
 
         # power level, # default power level is low
         _mem.txp = 0 if mem.power is None else POWER_LEVELS.index(mem.power)

--- a/chirp/drivers/vx8.py
+++ b/chirp/drivers/vx8.py
@@ -669,7 +669,7 @@ class VX8Radio(yaesu_clone.YaesuCloneModeRadio):
         mem.skip = flag.pskip and "P" or flag.skip and "S" or ""
 
         charset = ''.join(CHARSET).ljust(256, '.')
-        mem.name = str(_mem.label).rstrip("\xFF").translate(charset)
+        mem.name = str(_mem.label).rstrip("\xFF").translate(charset).rstrip()
 
         return mem
 

--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -335,6 +335,10 @@ class ChirpSettingGrid(wx.Panel):
                         _('Value must be at most %.4f' % value.get_max()))
                     return False
                 return True
+
+            def ValueToString(self, _value, flags=0):
+                return value.format(_value)
+
         return ChirpFloatProperty(setting.get_shortname(),
                                   setting.get_name(),
                                   value=float(value))

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -133,3 +133,14 @@ class TestCaseEdges(base.DriverTest):
             self.assertEqual(m.name.rstrip(), m.name,
                              'Radio returned a memory with trailing '
                              'whitespace in the name')
+
+    def test_memory_name_stripped(self):
+        if ' ' not in self.rf.valid_characters:
+            self.skipTest('Radio does not support space characters')
+        m1 = self.get_mem()
+        m1.name = 'FOO '
+        self.radio.set_memory(m1)
+        m2 = self.radio.get_memory(m1.number)
+        self.assertEqual(m2.name.rstrip(), m2.name,
+                         'Radio set and returned a memory with trailing '
+                         'whitespace in the name')

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -1,3 +1,5 @@
+import pytest
+
 from chirp import chirp_common
 from chirp import errors
 from tests import base
@@ -121,3 +123,13 @@ class TestCaseEdges(base.DriverTest):
                 continue
             m2 = self.radio.get_memory(name)
             self.assertEqualMem(m1, m2, ignore=['name'])
+
+    def test_get_memory_name_trailing_whitespace(self):
+        if self.radio.MODEL == 'KG-UV8E':
+            self.skipTest('The UV8E driver is so broken it does not even '
+                          'parse its own test image cleanly')
+        for i in range(*self.rf.memory_bounds):
+            m = self.radio.get_memory(i)
+            self.assertEqual(m.name.rstrip(), m.name,
+                             'Radio returned a memory with trailing '
+                             'whitespace in the name')


### PR DESCRIPTION
- Fix Icom IC-E90 special memory editing
- Fix editing specials with negative indexes
- Add special memories test and fix issues
- Add a test to check for memory name whitespace
- Add a test and fixes for trailing name whitespace
- Make FloatProperty honor precision
