### PR TITLE
Update radioddity_r2.py to use mem.immutable - #10288

### DIFF
--- a/chirp/drivers/radioddity_r2.py
+++ b/chirp/drivers/radioddity_r2.py
@@ -513,6 +513,31 @@ class RadioddityR2(chirp_common.CloneModeRadio):
         compand.set_doc("Compress Audio for TX")
         mem.extra.append(compand)
 
+        immutable = []
+
+        if self._frs16:
+            if mem.freq in FRS16_FREQS:
+                if mem.number >= 1 and mem.number <= 16:
+                    FRS_FREQ = FRS16_FREQS[mem.number - 1]
+                    mem.freq = FRS_FREQ
+                mem.duplex == ''
+                mem.offset = 0
+                mem.mode = "NFM"
+                immutable = ["empty", "freq", "duplex", "offset"]
+        elif self._pmr:
+            if mem.freq in PMR_FREQS:
+                if mem.number >= 1 and mem.number <= 16:
+                    PMR_FREQ = PMR_FREQS[mem.number - 1]
+                    mem.freq = PMR_FREQ
+                mem.duplex = ''
+                mem.offset = 0
+                mem.mode = "NFM"
+                mem.power = POWER_LEVELS[0]
+                immutable = ["empty", "freq", "duplex", "offset", "mode",
+                             "power"]
+
+        mem.immutable = immutable
+
         return mem
 
     def set_memory(self, mem):
@@ -529,26 +554,6 @@ class RadioddityR2(chirp_common.CloneModeRadio):
         if mem.empty:
             _mem.set_raw("\xFF" * 13 + _rsvd)
             return
-
-        if self._frs16:
-            if _mem.rx_freq.get_raw() == "\xFF\xFF\xFF\xFF":
-                FRS_FREQ = FRS16_FREQS[mem.number - 1]
-                mem.freq = FRS_FREQ
-                mem.power = POWER_LEVELS[1]
-            if mem.freq in FRS16_FREQS:
-                mem.mode = "NFM"
-                mem.duplex == ''
-                mem.offset = 0
-
-        if self._pmr:
-            if _mem.rx_freq.get_raw() == "\xFF\xFF\xFF\xFF":
-                PMR_FREQ = PMR_FREQS[mem.number - 1]
-                mem.freq = PMR_FREQ
-            if mem.freq in PMR_FREQS:
-                mem.mode = "NFM"
-                mem.duplex == ''
-                mem.offset = 0
-                mem.power = POWER_LEVELS[0]
 
         _mem.rx_freq = mem.freq / 10
 


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
