### PR TITLE
Fixes for bug 10312

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -109,6 +109,9 @@ CHARSET_UPPER_NUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890"
 CHARSET_ALPHANUMERIC = \
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz 1234567890"
 CHARSET_ASCII = "".join([chr(x) for x in range(ord(" "), ord("~") + 1)])
+CHARSET_1252 = bytes(
+    [x for x in range(0x21, 0x100)
+     if x not in [0x81, 0x8D, 0x8F, 0x90, 0x9D]]).decode('cp1252')
 
 # http://aprs.org/aprs11/SSIDs.txt
 APRS_SSID = (

--- a/chirp/drivers/fake.py
+++ b/chirp/drivers/fake.py
@@ -113,6 +113,31 @@ class FakeCloneFail(chirp_common.CloneModeRadio):
         raise errors.RadioError('This always fails')
 
 
+class FakeKenwoodSerial:
+    def __init__(self, *a, **k):
+        self._rbuf = b''
+
+    def write(self, buffer):
+        LOG.debug('Write: %r' % buffer)
+        if buffer.startswith(b'ID'):
+            self._rbuf += b'ID TH-F7\r'
+        elif buffer.startswith(b'MR 0,001'):
+            self._rbuf += b'MR 0,001,00146520000,0,0,0,0,0,0,00,00,000,000000000,0,0\r'
+        elif buffer.startswith(b'MNA 001\r'):
+            self._rbuf += b'MNA 001,Foo\r'
+        elif buffer.startswith(b'MNA 0'):
+            self._rbuf += buffer
+        elif buffer.startswith(b'MW 0'):
+            self._rbuf += b'MW\r'
+        else:
+            self._rbuf += b'N\r'
+
+    def read(self, n):
+        ret = self._rbuf[:n]
+        self._rbuf = self._rbuf[n:]
+        return ret
+
+
 def register_fakes():
     directory.register(FakeLiveRadio)
     directory.register(FakeLiveSlowRadio)

--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -124,7 +124,7 @@ class CSVRadio(chirp_common.FileBackedRadio):
         rf.valid_tuning_steps = list(chirp_common.TUNING_STEPS)
         rf.valid_bands = [(1, 10000000000)]
         rf.valid_skips = ["", "S"]
-        rf.valid_characters = chirp_common.CHARSET_ASCII
+        rf.valid_characters = chirp_common.CHARSET_1252
         rf.valid_name_length = 999
         rf.valid_power_levels = [chirp_common.AutoNamedPowerLevel(0.1),
                                  DEFAULT_POWER_LEVEL,

--- a/chirp/drivers/kenwood_live.py
+++ b/chirp/drivers/kenwood_live.py
@@ -78,11 +78,11 @@ def _command(ser, cmd, *args):
     cmd += LAST_DELIMITER[0]
 
     LOG.debug("PC->RADIO: %s" % cmd.strip())
-    ser.write(cmd.encode())
+    ser.write(cmd.encode('cp1252'))
 
     result = ""
     while not result.endswith(LAST_DELIMITER[0]):
-        result += ser.read(COMMAND_RESP_BUFSIZE).decode()
+        result += ser.read(COMMAND_RESP_BUFSIZE).decode('cp1252')
         if (time.time() - start) > 0.5:
             LOG.error("Timeout waiting for data")
             break

--- a/chirp/drivers/kenwood_live.py
+++ b/chirp/drivers/kenwood_live.py
@@ -882,6 +882,7 @@ class THF6ARadio(KenwoodLiveRadio):
     """Kenwood TH-F6"""
     MODEL = "TH-F6"
 
+    _charset = chirp_common.CHARSET_ASCII
     _upper = 399
     _kenwood_split = True
     _kenwood_valid_tones = list(KENWOOD_TONES)
@@ -897,7 +898,7 @@ class THF6ARadio(KenwoodLiveRadio):
         rf.valid_bands = [(1000, 1300000000)]
         rf.valid_skips = ["", "S"]
         rf.valid_duplexes = list(THF6A_DUPLEX.values())
-        rf.valid_characters = chirp_common.CHARSET_ASCII
+        rf.valid_characters = self._charset
         rf.valid_name_length = 8
         rf.memory_bounds = (0, self._upper)
         rf.has_settings = True
@@ -1070,6 +1071,7 @@ class THF6ARadio(KenwoodLiveRadio):
 class THF7ERadio(THF6ARadio):
     """Kenwood TH-F7"""
     MODEL = "TH-F7"
+    _charset = chirp_common.CHARSET_1252
 
 
 D710_DUPLEX = ["", "+", "-", "split"]


### PR DESCRIPTION
- Use cp1252 codec for kenwood_live comms
- Add CHARSET_1252 and make TH-D7 use it
- Add a fake TH-F7 serial fixture for testing
- Expand the CSV character set to include cp1252
