### PR TITLE
Two duplex test fixes

### DIFF
--- a/chirp/drivers/bf_t8.py
+++ b/chirp/drivers/bf_t8.py
@@ -898,6 +898,7 @@ class RetevisRB27(RetevisRB27B):
                     chirp_common.PowerLevel("Low", watts=0.50)]
     VALID_BANDS = [(136000000, 174000000),
                    (400000000, 520000000)]
+    ODD_SPLIT = False
 
     _upper = 99
     _gmrs = True
@@ -937,6 +938,7 @@ class FRSA1Radio(BFT8Radio):
     NAME_LENGTH = 6
     SKIP_VALUES = ["", "S"]
     DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DUPLEXES = ['', '-', '+', 'off']
 
     _fingerprint = b"BF-T8A" + b"\x2E"
     _upper = 22

--- a/chirp/drivers/tk8160.py
+++ b/chirp/drivers/tk8160.py
@@ -538,7 +538,7 @@ class TKx160Radio(chirp_common.CloneModeRadio):
         if mem.duplex == '':
             _mem.tx_freq = mem.freq // 10
         elif mem.duplex == 'split':
-            _mem.rx_freq = mem.offset // 10
+            _mem.tx_freq = mem.offset // 10
         elif mem.duplex == 'off':
             _mem.tx_freq.set_raw(b'\xFF' * 4)
         elif mem.duplex == '-':


### PR DESCRIPTION
- Fix setting duplex=split on TK-8160
- Fix can_odd_split flag in FRS-A1 and RB27
