### PR TITLE
fix UV-9R Pro FM preset bug - fixes #10318

### DIFF
--- a/chirp/drivers/baofeng_common.py
+++ b/chirp/drivers/baofeng_common.py
@@ -323,6 +323,7 @@ class BaofengCommonHT(chirp_common.CloneModeRadio,
                    462675000, 462700000, 462725000]
     GMRS_FREQS = GMRS_FREQS1 + GMRS_FREQS2 + GMRS_FREQS3 * 2
     _gmrs = False
+    _bw_shift = False
 
     def sync_in(self):
         """Download from radio"""
@@ -673,6 +674,8 @@ class BaofengCommonHT(chirp_common.CloneModeRadio,
                 else:
                     value = int(val.get_value() * 10)
                 LOG.debug("Setting fm_presets = %s" % (value))
+                if self._bw_shift:
+                    value = ((value & 0x00FF) << 8) | ((value & 0xFF00) >> 8)
                 self._memobj.fm_presets = value
             except Exception as e:
                 LOG.debug(element.get_name())


### PR DESCRIPTION
Add support for a 3rd method of storing the broadcast FM frequency

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
