### PR TITLE
Update uv5r.py driver to use mem.immutable - #10288

### DIFF
--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -715,10 +715,12 @@ class TestOverrideRules(base.BaseTest):
     # please ask permission first.
     IMMUTABLE_WHITELIST = [
         # Uncomment me when the time comes
+        'Baofeng_GT-5R',
         'BTECH_GMRS-20V2',
         'BTECH_GMRS-50X1',
         'BTECH_GMRS-V2',
         'Radioddity_DB25-G',
+        'Radioddity_UV-5G',
         'Retevis_RA85',
         'Retevis_RA685',
         'Retevis_RB17P',


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
