### PR TITLE
Update bf_t8.py driver to use mem.immutable (revisited) - #10288

### DIFF
--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -87,7 +87,7 @@
 | <a name="Icom_IC-7100"></a> Icom_IC-7100 |  |  | Yes | 0.06% |
 | <a name="Icom_IC-7200"></a> Icom_IC-7200 | [@kk7ds](https://github.com/kk7ds) | 22-Oct-2022 | Yes |  |
 | <a name="Icom_IC-7300"></a> Icom_IC-7300 | [@kk7ds](https://github.com/kk7ds) | 22-Oct-2022 | Yes | 0.03% |
-| <a name="Icom_IC-746"></a> Icom_IC-746 |  |  | Yes |  |
+| <a name="Icom_IC-746"></a> Icom_IC-746 | [Reported working](https://chirp.danplanet.com/issues/10346) | 3-Feb-2023 | Yes |  |
 | <a name="Icom_IC-7610"></a> Icom_IC-7610 | [@kk7ds](https://github.com/kk7ds) | 24-Oct-2022 | Yes | 0.00% |
 | <a name="Icom_IC-910"></a> Icom_IC-910 | [@mfncooper](https://github.com/mfncooper) | 1-Oct-2021 | Yes | 0.00% |
 | <a name="Icom_IC-91_92AD"></a> Icom_IC-91_92AD | [@kk7ds](https://github.com/kk7ds) | 23-Nov-2022 | Yes | 0.03% |
@@ -130,7 +130,7 @@
 | <a name="Kenwood_TH-F7"></a> Kenwood_TH-F7 | [@sv1](https://github.com/sv1) | 19-Oct-2022 | Yes | 0.03% |
 | <a name="Kenwood_TH-G71"></a> Kenwood_TH-G71 | [Probably works](https://github.com/kk7ds/chirp/blob/py3/chirp/drivers/kenwood_live.py) | 12-Dec-2022 | Yes | 0.01% |
 | <a name="Kenwood_TH-K2"></a> Kenwood_TH-K2 | [Probably works](https://github.com/kk7ds/chirp/blob/py3/chirp/drivers/kenwood_live.py) | 12-Dec-2022 | Yes | 0.00% |
-| <a name="Kenwood_TK-2140K"></a> Kenwood_TK-2140K | [Implied by Kenwood_TK-3140K](#user-content-Kenwood_TK-3140K) | 2-Feb-2022 | Yes |  |
+| <a name="Kenwood_TK-2140K"></a> Kenwood_TK-2140K | [Implied by Kenwood_TK-3140K](#user-content-Kenwood_TK-3140K) | 2-Feb-2023 | Yes |  |
 | <a name="Kenwood_TK-2180"></a> Kenwood_TK-2180 | [@kk7ds](https://github.com/kk7ds) | 4-Dec-2022 | Yes | 0.04% |
 | <a name="Kenwood_TK-260"></a> Kenwood_TK-260 |  |  |  | 0.02% |
 | <a name="Kenwood_TK-260G"></a> Kenwood_TK-260G | [Implied by Kenwood_TK-762G](#user-content-Kenwood_TK-762G) | 5-Dec-2022 | Yes | 0.02% |
@@ -140,9 +140,9 @@
 | <a name="Kenwood_TK-272G"></a> Kenwood_TK-272G | [Implied by Kenwood_TK-762G](#user-content-Kenwood_TK-762G) | 5-Dec-2022 | Yes | 0.02% |
 | <a name="Kenwood_TK-278"></a> Kenwood_TK-278 |  |  |  | 0.02% |
 | <a name="Kenwood_TK-278G"></a> Kenwood_TK-278G | [Implied by Kenwood_TK-762G](#user-content-Kenwood_TK-762G) | 5-Dec-2022 | Yes | 0.01% |
-| <a name="Kenwood_TK-3140K"></a> Kenwood_TK-3140K | [@kk7ds](https://github.com/kk7ds) | 2-Feb-2022 | Yes |  |
-| <a name="Kenwood_TK-3140K2"></a> Kenwood_TK-3140K2 | [Implied by Kenwood_TK-3140K](#user-content-Kenwood_TK-3140K) | 2-Feb-2022 | Yes |  |
-| <a name="Kenwood_TK-3140K3"></a> Kenwood_TK-3140K3 | [Implied by Kenwood_TK-3140K](#user-content-Kenwood_TK-3140K) | 2-Feb-2022 | Yes |  |
+| <a name="Kenwood_TK-3140K"></a> Kenwood_TK-3140K | [@kk7ds](https://github.com/kk7ds) | 2-Feb-2023 | Yes |  |
+| <a name="Kenwood_TK-3140K2"></a> Kenwood_TK-3140K2 | [Implied by Kenwood_TK-3140K](#user-content-Kenwood_TK-3140K) | 2-Feb-2023 | Yes |  |
+| <a name="Kenwood_TK-3140K3"></a> Kenwood_TK-3140K3 | [Implied by Kenwood_TK-3140K](#user-content-Kenwood_TK-3140K) | 2-Feb-2023 | Yes |  |
 | <a name="Kenwood_TK-3180K"></a> Kenwood_TK-3180K | [@kk7ds](https://github.com/kk7ds) | 4-Dec-2022 | Yes | 0.03% |
 | <a name="Kenwood_TK-3180K2"></a> Kenwood_TK-3180K2 | [Implied by Kenwood_TK-3180K](#user-content-Kenwood_TK-3180K) | 4-Dec-2022 | Yes | 0.01% |
 | <a name="Kenwood_TK-360"></a> Kenwood_TK-360 |  |  |  | 0.02% |
@@ -305,7 +305,7 @@
 | <a name="TYT_TH-UV8000"></a> TYT_TH-UV8000 | [@KC9HI](https://github.com/KC9HI) | 6-Jan-2023 | Yes | 0.31% |
 | <a name="TYT_TH-UV88"></a> TYT_TH-UV88 | [@KC9HI](https://github.com/KC9HI) | 5-Dec-2022 | Yes | 0.51% |
 | <a name="TYT_TH-UVF1"></a> TYT_TH-UVF1 | [@kk7ds](https://github.com/kk7ds) | 13-Dec-2022 | Yes | 0.06% |
-| <a name="TYT_TH-UVF8D"></a> TYT_TH-UVF8D | [@MELERIX](https://github.com/MELERIX) | 2-Feb-2022 | Yes | 0.05% |
+| <a name="TYT_TH-UVF8D"></a> TYT_TH-UVF8D | [@MELERIX](https://github.com/MELERIX) | 2-Feb-2023 | Yes | 0.05% |
 | <a name="TYT_TH9000_144"></a> TYT_TH9000_144 | [Implied by Retevis_RT9000D_136-174](#user-content-Retevis_RT9000D_136-174) | 8-Dec-2022 | Yes | 0.06% |
 | <a name="TYT_TH9000_220"></a> TYT_TH9000_220 | [Implied by Retevis_RT9000D_220-260](#user-content-Retevis_RT9000D_220-260) | 8-Dec-2022 | Yes | 0.04% |
 | <a name="TYT_TH9000_440"></a> TYT_TH9000_440 | [Implied by Retevis_RT9000D_400-490](#user-content-Retevis_RT9000D_400-490) | 8-Dec-2022 | Yes | 0.04% |
@@ -380,7 +380,7 @@
 
 **Drivers:** 375
 
-**Tested:** 82% (309/66) (92% of usage stats)
+**Tested:** 82% (310/65) (92% of usage stats)
 
 **Byte clean:** 88% (332/43)
 

--- a/tests/py3_driver_testers.txt
+++ b/tests/py3_driver_testers.txt
@@ -76,6 +76,7 @@ Icom_IC-2730A,#10261,17-Dec-2022
 Icom_IC-2820H,@kk7ds,22-Oct-2022
 Icom_IC-7200,@kk7ds,22-Oct-2022
 Icom_IC-7300,@kk7ds,22-Oct-2022
+Icom_IC-746,#10346,3-Feb-2023
 Icom_IC-7610,@kk7ds,24-Oct-2022
 Icom_IC-91_92AD,@kk7ds,23-Nov-2022
 Icom_IC-910,@mfncooper,1-Oct-2021
@@ -125,11 +126,11 @@ Kenwood_TM-D710G_CloneMode,@kk7ds,22-Oct-2022
 Kenwood_TM-G707,*kenwood_live,12-Dec-2022
 Kenwood_TM-V7,*kenwood_live,12-Dec-2022
 Kenwood_TM-V71,@kk7ds,21-Oct-2022
-Kenwood_TK-2140K,+Kenwood_TK-3140K,2-Feb-2022
+Kenwood_TK-2140K,+Kenwood_TK-3140K,2-Feb-2023
 Kenwood_TK-2180,@kk7ds,4-Dec-2022
-Kenwood_TK-3140K,@kk7ds,2-Feb-2022
-Kenwood_TK-3140K2,+Kenwood_TK-3140K,2-Feb-2022
-Kenwood_TK-3140K3,+Kenwood_TK-3140K,2-Feb-2022
+Kenwood_TK-3140K,@kk7ds,2-Feb-2023
+Kenwood_TK-3140K2,+Kenwood_TK-3140K,2-Feb-2023
+Kenwood_TK-3140K3,+Kenwood_TK-3140K,2-Feb-2023
 Kenwood_TK-3180K,@kk7ds,4-Dec-2022
 Kenwood_TK-3180K2,+Kenwood_TK-3180K,4-Dec-2022
 Kenwood_TK-7102,@kk7ds,15-Feb-2019
@@ -258,7 +259,7 @@ TDXone_TD-Q8A,@KC9HI,18-Dec-2022
 TIDRADIO_TD-H6,@kk7ds,21-Oct-2022
 TID_TD-M8,+Retevis_RT22,9-Dec-2022
 TYT_TH-UVF1,@kk7ds,13-Dec-2022
-TYT_TH-UVF8D,@MELERIX,2-Feb-2022
+TYT_TH-UVF8D,@MELERIX,2-Feb-2023
 TYT_TH-UV8000,@KC9HI,6-Jan-2023
 TYT_TH-UV88,@KC9HI,5-Dec-2022
 TYT_TH9000_144,+Retevis_RT9000D_136-174,8-Dec-2022

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -724,6 +724,7 @@ class TestOverrideRules(base.BaseTest):
         'Retevis_RA85',
         'Retevis_RA685',
         'Retevis_RB17P',
+        'Retevis_RB27',
     ]
 
     def _test_radio_override_immutable_policy(self, rclass):


### PR DESCRIPTION
Adds validate_memory() to notify user when Duplex is forced to a particular value.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
