### PR TITLE
Initial test of FT-818nd (US) 

### DIFF
--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -352,7 +352,7 @@
 | <a name="Yaesu_FT-817"></a> Yaesu_FT-817 | [@kk7ds](https://github.com/kk7ds) | 14-Feb-2019 | Yes | 0.04% |
 | <a name="Yaesu_FT-817ND"></a> Yaesu_FT-817ND | [Implied by Yaesu_FT-817](#user-content-Yaesu_FT-817) | 14-Feb-2019 | Yes | 0.07% |
 | <a name="Yaesu_FT-817ND_US"></a> Yaesu_FT-817ND_US | [Implied by Yaesu_FT-817](#user-content-Yaesu_FT-817) | 14-Feb-2019 | Yes | 0.02% |
-| <a name="Yaesu_FT-818"></a> Yaesu_FT-818 | [Implied by Yaesu_FT-817](#user-content-Yaesu_FT-817) | 14-Feb-2019 | Yes | 0.05% |
+| <a name="Yaesu_FT-818"></a> Yaesu_FT-818 | [@thomasrussellmurphy](https://github.com/thomasrussellmurphy) | 4-Feb-2023 | Yes | 0.05% |
 | <a name="Yaesu_FT-818ND_US"></a> Yaesu_FT-818ND_US | [Implied by Yaesu_FT-817](#user-content-Yaesu_FT-817) | 14-Feb-2019 | Yes | 0.02% |
 | <a name="Yaesu_FT-857_897"></a> Yaesu_FT-857_897 | [Implied by Yaesu_FT-817](#user-content-Yaesu_FT-817) | 14-Feb-2019 | Yes | 0.25% |
 | <a name="Yaesu_FT-857_897_US"></a> Yaesu_FT-857_897_US | [Implied by Yaesu_FT-817](#user-content-Yaesu_FT-817) | 14-Feb-2019 | Yes | 0.08% |

--- a/tests/py3_driver_testers.txt
+++ b/tests/py3_driver_testers.txt
@@ -303,7 +303,7 @@ Yaesu_FT-8900,+Yaesu_FT-8800,24-Oct-2022
 Yaesu_FT-817,@kk7ds,14-Feb-2019
 Yaesu_FT-817ND,+Yaesu_FT-817,14-Feb-2019
 Yaesu_FT-817ND_US,+Yaesu_FT-817,14-Feb-2019
-Yaesu_FT-818,+Yaesu_FT-817,14-Feb-2019
+Yaesu_FT-818,@thomasrussellmurphy,4-Feb-2023
 Yaesu_FT-818ND_US,+Yaesu_FT-817,14-Feb-2019
 Yaesu_FT-857_897,+Yaesu_FT-817,14-Feb-2019
 Yaesu_FT-857_897_US,+Yaesu_FT-817,14-Feb-2019


### PR DESCRIPTION
Initial test of FT-818nd (US) data operation. Successful operation of standard memories and settings. VFO a/b default frequencies and per-band "home" frequencies are not displayed in the new interface, but appear to be maintained inside the data saved from the radio.

Since I don't have the dev environment set up, will a maintainer please force-push with the updated Markdown output before merging?
