### PR TITLE
GMRS-V2 update/streamline driver - fixes #10350

### DIFF
--- a/chirp/drivers/baofeng_common.py
+++ b/chirp/drivers/baofeng_common.py
@@ -367,7 +367,10 @@ class BaofengCommonHT(chirp_common.CloneModeRadio,
         rf.valid_modes = self.MODES
         rf.valid_characters = self.VALID_CHARS
         rf.valid_name_length = self.LENGTH_NAME
-        rf.valid_duplexes = ["", "-", "+", "split", "off"]
+        if self._gmrs:
+            rf.valid_duplexes = ["", "+", "off"]
+        else:
+            rf.valid_duplexes = ["", "-", "+", "split", "off"]
         rf.valid_tmodes = ['', 'Tone', 'TSQL', 'DTCS', 'Cross']
         rf.valid_cross_modes = [
             "Tone->Tone",
@@ -392,14 +395,12 @@ class BaofengCommonHT(chirp_common.CloneModeRadio,
         _msg_duplex = 'Duplex must be "off" for this frequency'
         _msg_offset = 'Only simplex or +5MHz offset allowed on GMRS'
 
-        if self.MODEL == "UV-9G":
+        if self.MODEL in ["UV-9G", "GMRS-V2"]:
             if mem.freq not in bandplan_na.ALL_GMRS_FREQS:
                 if mem.duplex != "off":
                     msgs.append(chirp_common.ValidationWarning(_msg_duplex))
             if mem.freq in bandplan_na.GMRS_HIRPT:
                 if mem.duplex and mem.offset != 5000000:
-                    msgs.append(chirp_common.ValidationWarning(_msg_offset))
-                if mem.duplex and mem.duplex != "+":
                     msgs.append(chirp_common.ValidationWarning(_msg_offset))
 
         return msgs
@@ -570,11 +571,10 @@ class BaofengCommonHT(chirp_common.CloneModeRadio,
                     if mem.freq in bandplan_na.GMRS_HIRPT:
                         # GMRS 462 MHz main frequencies
                         # GMRS 467 MHz main frequencies (repeater input)
+                        if mem.duplex == '':
+                            mem.offset = 0
                         if mem.duplex == '+':
                             mem.offset = 5000000
-                        else:
-                            mem.duplex = ''
-                            mem.offset = 0
                 else:
                     # Not a GMRS frequency - disable TX
                     mem.duplex = 'off'


### PR DESCRIPTION
This patch updates the gmrsv2.py driver by
* utilizing more code from the baofeng_common.py driver
* removing code from set_memory() that should be in get_memory()
* utilizing bandplan_na

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
