### PR TITLE
Python le sigh

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(name='chirp',
       description='A cross-platform cross-radio programming tool',
       packages=find_packages(include=["chirp*"]),
       include_package_data=True,
-      version=CHIRP_VERSION,
+      version=0,
       url='https://chirp.danplanet.com',
       python_requires=">=3.7,<4",
       install_requires=[


### PR DESCRIPTION
I have no idea why the python community is so obsessed over breaking
things with version numbers it doesn't like, especially for things
that have no public interface and never need to be depended on.
Regardless, setuptools 67 breaks our test environment setup because
we don't have a compliant version number in our unreleased source
tree. So, just don't use setuptools >=67 for the moment.
