### PR TITLE
Tolerate null fields in repeaterbook responses

### DIFF
--- a/chirp/sources/repeaterbook.py
+++ b/chirp/sources/repeaterbook.py
@@ -222,7 +222,7 @@ class RepeaterBook(base.NetworkResultRadio):
         def match(item):
             search_fields = ('County', 'State', 'Landmark', 'Nearest City',
                              'Callsign', 'Region', 'Notes')
-            content = ' '.join(item[k] for k in search_fields
+            content = ' '.join(item.get(k) or '' for k in search_fields
                                if k in item)
             return not search_filter or search_filter.lower() in content.lower()
 


### PR DESCRIPTION
Lately some of the repeaterbook item fields are coming back null since
the JSON reformat a week or so ago. This makes us tolerant of that.

Fixes: #10353
