### PR TITLE
Fix column header translation from names

### DIFF
--- a/chirp/locale/de.po
+++ b/chirp/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2012-10-02 22:11+0100\n"
 "Last-Translator: Benjamin, HB9EUK <hb9euk@hb9d.org>\n"
 "Language-Team: German\n"
@@ -248,32 +248,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Ungültiger Wert für dieses Feld"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Frequenz"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frequenz"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Leistung"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Abstimmungsschritt"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -288,199 +293,212 @@ msgstr "Tone"
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Duplex"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Mode"
+
+#: ../wxui/memedit.py:462
 msgid "Cross mode"
 msgstr "Cross Mode"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "Kommentar"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Tone Mode"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross Mode"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Zeile oben einfügen"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 msgid "Show Raw Memory"
 msgstr "Zeige RAW Speicher"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 msgid "Diff Raw Memories"
 msgstr "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Zeile unten einfügen"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Überschreiben?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "Eingefügter Speicher {number} ist nicht mit diesem Gerät kompatibel weil:"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr "Digital Code"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 msgid "DV Memory"
 msgstr ""
 
@@ -1175,9 +1193,6 @@ msgstr ""
 #~ msgid "From"
 #~ msgstr "Von"
 
-#~ msgid "Comment"
-#~ msgstr "Kommentar"
-
 #~ msgid "Location memory will be imported into"
 #~ msgstr "Speicherstandort wird importiert nach"
 
@@ -1415,12 +1430,6 @@ msgstr ""
 
 #~ msgid "Edit Memory#{num}"
 #~ msgstr "Speiche editieren#{num}"
-
-#~ msgid "Duplex"
-#~ msgstr "Duplex"
-
-#~ msgid "Tune Step"
-#~ msgstr "Abstimmungsschritt"
 
 #~ msgid "Skip"
 #~ msgstr "Überspringen"

--- a/chirp/locale/en_US.po
+++ b/chirp/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2011-11-29 16:07-0800\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -242,30 +242,34 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, python-format
 msgid "Invalid value: %r"
 msgstr ""
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr ""
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr ""
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 msgid "Enter Frequency"
 msgstr ""
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
+msgstr ""
+
+#: ../wxui/memedit.py:272
+msgid "Tuning Step"
 msgstr ""
 
 #: ../wxui/memedit.py:304
@@ -280,194 +284,206 @@ msgstr ""
 msgid "Tone Squelch"
 msgstr ""
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr ""
+
+#: ../wxui/memedit.py:393
 msgid "DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr ""
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+msgid "Mode"
+msgstr ""
+
+#: ../wxui/memedit.py:462
 msgid "Cross mode"
 msgstr ""
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr ""
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 msgid "Insert Row Above"
 msgstr ""
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr ""
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr ""
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 #, fuzzy
 msgid "Delete"
 msgstr "_Delete"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 msgid "Delete and shift block up"
 msgstr ""
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "_Delete"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Show raw memory"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 msgid "No empty rows below!"
 msgstr ""
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 msgid "DV Memory"
 msgstr ""
 

--- a/chirp/locale/es.po
+++ b/chirp/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2023-02-08 02:11-0300\n"
 "Last-Translator: MELERIX\n"
 "Language-Team: \n"
@@ -254,31 +254,36 @@ msgstr ""
 "RadioReference Canadá requiere un inicio de sesión antes de que puedas "
 "consultar"
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr "Encontrado valor de lista vacía para %(name)s: %(value)r"
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, python-format
 msgid "Invalid value: %r"
 msgstr "Valor inválido: %r"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Desplazamiento"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Frecuencia"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 msgid "Enter Frequency"
 msgstr "Ingresar frecuencia"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Poder"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Paso de sintonización"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -292,15 +297,19 @@ msgstr "Tono"
 msgid "Tone Squelch"
 msgstr "Silenciador de tono"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Dúplex"
+
+#: ../wxui/memedit.py:393
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -308,25 +317,34 @@ msgstr ""
 "Polaridad\n"
 "DTCS"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Modos"
+
+#: ../wxui/memedit.py:462
 msgid "Cross mode"
 msgstr "Modo cruzado"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "Comentario"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Modo de tono"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Elegir %s tono"
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Elegir %s código DTCS"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
@@ -334,151 +352,151 @@ msgstr ""
 "Canales con TX y RX equivalentes %s son representados por modo de tono de "
 "\"%s\""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 msgid "Information"
 msgstr "Información"
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 msgid "Choose Cross Mode"
 msgstr "Elegir modo cruzado"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr "Ingresar frecuencia TX (MHz)"
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr "Ingresar desplazamiento (MHz)"
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr "Elegir Dúplex"
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr "No se puede editar memoria antes de que la radio este cargada"
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Edición inválida: %s"
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr "Advertencia: %s"
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Memoria %i no es borrable"
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 msgid "Insert Row Above"
 msgstr "Insertar fila arriba"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, python-format
 msgid "Delete %i Memories"
 msgstr "Borrar %i memorias"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "Eliminar %i memorias y desplazar bloque hacia arriba"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr "Borrar %i memorias y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 msgid "Delete and shift block up"
 msgstr "Borrar y desplazar bloque hacia arriba"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 msgid "Delete and shift all up"
 msgstr "Borrar y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 msgid "Show Raw Memory"
 msgstr "Mostrar memoria en bruto"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 msgid "Diff Raw Memories"
 msgstr "Diferenciar memorias en bruto"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 msgid "No empty rows below!"
 msgstr "¡No hay filas vacías debajo!"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
 msgstr "Algunas memorias no son borrables"
 
-#: ../wxui/memedit.py:1308
+#: ../wxui/memedit.py:1317
 #, python-format
 msgid "Pasted memory will overwrite memory %i"
 msgstr "Memoria pegada sobrescribirá memoria %i"
 
-#: ../wxui/memedit.py:1311
+#: ../wxui/memedit.py:1320
 #, python-format
 msgid "Pasted memories will overwrite memory %i"
 msgstr "Memorias pegadas sobrescribirán memoria %i"
 
-#: ../wxui/memedit.py:1314
+#: ../wxui/memedit.py:1323
 #, python-format
 msgid "Pasted memories will overwrite %i existing memories"
 msgstr "Memorias pegadas sobrescribirán %i memorias existentes"
 
-#: ../wxui/memedit.py:1317
+#: ../wxui/memedit.py:1326
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Memorias pegadas sobrescribirán memorias %s"
 
-#: ../wxui/memedit.py:1320
+#: ../wxui/memedit.py:1329
 msgid "Overwrite memories?"
 msgstr "¿Sobrescribir memorias?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 msgid "Some memories are incompatible with this radio"
 msgstr "Algunas memorias son incompatibles con esta radio"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr "Exportar solo puede escribir archivos CSV"
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr "Código digital"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editar detalles para memoria %i"
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Editar detalles para %i memorias"
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr "Extra"
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 msgid "DV Memory"
 msgstr "Memoria DV"
 
@@ -1194,9 +1212,6 @@ msgstr "¡No hay resultados!"
 #~ msgid "From"
 #~ msgstr "Desde"
 
-#~ msgid "Comment"
-#~ msgstr "Comentario"
-
 #~ msgid "Location memory will be imported into"
 #~ msgstr "Localización de memoria será importada en"
 
@@ -1511,12 +1526,6 @@ msgstr "¡No hay resultados!"
 
 #~ msgid "DTCS Code"
 #~ msgstr "Código DTCS"
-
-#~ msgid "Duplex"
-#~ msgstr "Dúplex"
-
-#~ msgid "Tune Step"
-#~ msgstr "Paso de sintonización"
 
 #~ msgid "Skip"
 #~ msgstr "Omitir"

--- a/chirp/locale/fr.po
+++ b/chirp/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2014-04-05 22:18+0100\n"
 "Last-Translator: Matthieu Lapadu-Hargues <mlhpub@free.fr>\n"
 "Language-Team: French\n"
@@ -247,32 +247,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Valeur invalide pour ce champ"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Decalage"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Frequence"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frequence"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Puissance"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Pas"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -287,199 +292,212 @@ msgstr "Tone"
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Duplex"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Mode"
+
+#: ../wxui/memedit.py:462
 #, fuzzy
 msgid "Cross mode"
 msgstr "Cross mode"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "Commentaire"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Tone Mode"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Code DTCS"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross mode"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Inserer une ligne avant"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Comparaison memoires brutes"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "Supprimer (et remonter)"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr "Supprimer (et remonter)"
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "Supprimer (et remonter)"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "Supprimer (et remonter)"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 msgid "Show Raw Memory"
 msgstr "Afficher les donnees de memoires brutes"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 msgid "Diff Raw Memories"
 msgstr "Comparaison memoires brutes"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Inserer une ligne apres"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Ecraser ?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "La memoire collee {number} n'est pas compatible avec cette radio car :"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr "Digital code"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 msgid "DV Memory"
 msgstr ""
 
@@ -1096,9 +1114,6 @@ msgstr ""
 #~ msgid "From"
 #~ msgstr "De"
 
-#~ msgid "Comment"
-#~ msgstr "Commentaire"
-
 #~ msgid "Location memory will be imported into"
 #~ msgstr "L'emplacement memoire sera importe dans"
 
@@ -1374,12 +1389,6 @@ msgstr ""
 
 #~ msgid "Priming memory"
 #~ msgstr "Memoire d'amorcage"
-
-#~ msgid "Duplex"
-#~ msgstr "Duplex"
-
-#~ msgid "Tune Step"
-#~ msgstr "Pas"
 
 #~ msgid "Skip"
 #~ msgstr "Ignorer"

--- a/chirp/locale/hu.po
+++ b/chirp/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2015-01-28 13:47+0100\n"
 "Last-Translator: Attila Joubert <joubert.attila@gmail.com>\n"
 "Language-Team: English\n"
@@ -247,32 +247,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Érvénytelen %s mezőérték"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Offszet"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Frekvencia"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frekvencia"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Teljesítmény"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Lépésköz"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -287,202 +292,215 @@ msgstr "CTCSS"
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Duplex"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS pol."
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 #, fuzzy
 msgid "RX DTCS"
 msgstr "RX DTCS kód"
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "DTCS pol."
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Mód"
+
+#: ../wxui/memedit.py:462
 msgid "Cross mode"
 msgstr "Kereszt-üzem"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "Megjegyzés"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Hang (CTCSS) mód"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "RX DTCS kód"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 #, fuzzy
 msgid "Information"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Kereszt-üzem"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "Érvénytelen érték %s"
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Memória beszúrása fölé"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr ""
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 msgid "Show Raw Memory"
 msgstr "Memóriasor mutatása"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 msgid "Diff Raw Memories"
 msgstr "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Memória beszúrása alá"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Felülírja?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "A beillesztett {number}. számú memória nem kompatibilis ezzel a rádióval, "
 "mert:"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr "Digitális kód"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, fuzzy, python-format
 msgid "Edit details for %i memories"
 msgstr "Több memória szerkesztése"
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 #, fuzzy
 msgid "DV Memory"
 msgstr "ez a memória"
@@ -1186,9 +1204,6 @@ msgstr ""
 #~ msgid "From"
 #~ msgstr "Forrás"
 
-#~ msgid "Comment"
-#~ msgstr "Megjegyzés"
-
 #~ msgid "Location memory will be imported into"
 #~ msgstr "Memória helye lesz beimportálva"
 
@@ -1469,12 +1484,6 @@ msgstr ""
 
 #~ msgid "DTCS Code"
 #~ msgstr "DTCS kód"
-
-#~ msgid "Duplex"
-#~ msgstr "Duplex"
-
-#~ msgid "Tune Step"
-#~ msgstr "Lépésköz"
 
 #~ msgid "Skip"
 #~ msgstr "Ugrás"

--- a/chirp/locale/it.po
+++ b/chirp/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2014-11-08 17:58+0100\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -247,32 +247,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Valore non valido per questo campo"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Frequenza"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frequenza"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Potenza"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Step sintonia"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -287,200 +292,213 @@ msgstr "Tone"
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Duplex"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Modulazione"
+
+#: ../wxui/memedit.py:462
 #, fuzzy
 msgid "Cross mode"
 msgstr "Cross Mode"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "Commento"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Modalita' tono"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross Mode"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Inserisci riga sopra"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Diff memorie Raw"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "Elimina (e sposta sopra)"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr "Elimina (e sposta sopra)"
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 msgid "Delete"
 msgstr "Elimina"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "Elimina (e sposta sopra)"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "Elimina (e sposta sopra)"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 msgid "Show Raw Memory"
 msgstr "Mostra memorie Raw"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 msgid "Diff Raw Memories"
 msgstr "Diff memorie Raw"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Inserisci riga sotto"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Sovrascrivere?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "La memoria incollata {number} non e' compatibile con questa radio perche':"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr "Digital Code"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 msgid "DV Memory"
 msgstr ""
 
@@ -1096,9 +1114,6 @@ msgstr ""
 #~ msgid "From"
 #~ msgstr "Da"
 
-#~ msgid "Comment"
-#~ msgstr "Commento"
-
 #~ msgid "Location memory will be imported into"
 #~ msgstr "La memoria verra' importata in"
 
@@ -1372,12 +1387,6 @@ msgstr ""
 
 #~ msgid "Priming memory"
 #~ msgstr "Preparazione memoria"
-
-#~ msgid "Duplex"
-#~ msgstr "Duplex"
-
-#~ msgid "Tune Step"
-#~ msgstr "Step sintonia"
 
 #~ msgid "Skip"
 #~ msgstr "Salta"

--- a/chirp/locale/nl.po
+++ b/chirp/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2012-03-18 12:01+0100\n"
 "Last-Translator: Michael Tel <m.tel@xs4all.nl>\n"
 "Language-Team: Dutch\n"
@@ -247,32 +247,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Ongeldige waarde voor dit veld"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Frequentie"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frequentie"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Vermogen"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Kanaal-afstand"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -287,199 +292,212 @@ msgstr "Toon"
 msgid "Tone Squelch"
 msgstr "Toon squelch"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Duplex"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Mode"
+
+#: ../wxui/memedit.py:462
 #, fuzzy
 msgid "Cross mode"
 msgstr "Cross-mode"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "Opmerking"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Toonmodus"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS code"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross-mode"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Regel hierboven invoegen"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 msgid "Show Raw Memory"
 msgstr "Toon ruw kanaal"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 msgid "Diff Raw Memories"
 msgstr "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Regel hieronder invoegen"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Overschrijven?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Geplakt kanaal {number} is niet compatibel met deze radio omdat:"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr "Digitale code"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 msgid "DV Memory"
 msgstr ""
 
@@ -1095,9 +1113,6 @@ msgstr ""
 #~ msgid "From"
 #~ msgstr "Van"
 
-#~ msgid "Comment"
-#~ msgstr "Opmerking"
-
 #~ msgid "Location memory will be imported into"
 #~ msgstr "Geheugenplaatsen zullen ook gemporteerd worden naar"
 
@@ -1374,12 +1389,6 @@ msgstr ""
 
 #~ msgid "Priming memory"
 #~ msgstr "Voorbereiden van geheugen"
-
-#~ msgid "Duplex"
-#~ msgstr "Duplex"
-
-#~ msgid "Tune Step"
-#~ msgstr "Kanaal-afstand"
 
 #~ msgid "Skip"
 #~ msgstr "Overslaan"

--- a/chirp/locale/pl.po
+++ b/chirp/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2011-12-07 11:35+0100\n"
 "Last-Translator: Grzegorz Błoński-Kubiak <mancymonek@wp.pl>\n"
 "Language-Team: Polish\n"
@@ -248,32 +248,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Niewłaściwa wartość"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Przesunięcie"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Częstotliwość"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Częstotliwość"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Moc"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Krok strojenia"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -288,204 +293,217 @@ msgstr "Ton"
 msgid "Tone Squelch"
 msgstr "Blokada tonu"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Dupleks"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "Polaryzacja DTCS"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "Polaryzacja DTCS"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Tryb"
+
+#: ../wxui/memedit.py:462
 #, fuzzy
 msgid "Cross mode"
 msgstr "Tryb krzyżowy"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr ""
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Tryb tonu"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Kod DTCS"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 #, fuzzy
 msgid "Information"
 msgstr "Lokalizacja"
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Tryb krzyżowy"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Umieść wiersz wyżej"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Porównaj surowe pamięci"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "Skasuj (i skocz wyżej)"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr "Skasuj (i skocz wyżej)"
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 #, fuzzy
 msgid "Delete"
 msgstr "_Usuń"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "Skasuj (i skocz wyżej)"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "Skasuj (i skocz wyżej)"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Pokaż surową pamięć"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Porównaj surowe pamięci"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Umieść wiersz niżej"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Nadpisać ?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "Wklejona komórka pamięci {number} jest nie kompatybilna z tym urządzeniem:"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 msgid "DV Memory"
 msgstr ""
 
@@ -1356,12 +1374,6 @@ msgstr ""
 #, fuzzy
 #~ msgid "Priming memory"
 #~ msgstr "Zapisywanie pamięci {number}"
-
-#~ msgid "Duplex"
-#~ msgstr "Dupleks"
-
-#~ msgid "Tune Step"
-#~ msgstr "Krok strojenia"
 
 #~ msgid "Skip"
 #~ msgstr "Przeskocz"

--- a/chirp/locale/pt_BR.po
+++ b/chirp/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2013-03-30 22:04-0300\n"
 "Last-Translator: Crezivando <crezivando@gmail.com>\n"
 "Language-Team: Language pt-BR\n"
@@ -246,32 +246,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Valor Inválido para este campo"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Frequência"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frequência"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Power"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Tune Step"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -286,199 +291,212 @@ msgstr "Tom"
 msgid "Tone Squelch"
 msgstr "TomSql"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Duplex"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Modo"
+
+#: ../wxui/memedit.py:462
 #, fuzzy
 msgid "Cross mode"
 msgstr "Modo Cross"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "Comentário"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Modo Tom"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Modo Cross"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Inserir row acima"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 msgid "Show Raw Memory"
 msgstr "Mostrar Memória Raw"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 msgid "Diff Raw Memories"
 msgstr "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Inserir row abaixo"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Sobrescrever?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Memória colada {number} não é compatível com este rádio porque:"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr "Código Digital"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 msgid "DV Memory"
 msgstr ""
 
@@ -1094,9 +1112,6 @@ msgstr ""
 #~ msgid "From"
 #~ msgstr "De"
 
-#~ msgid "Comment"
-#~ msgstr "Comentário"
-
 #~ msgid "Location memory will be imported into"
 #~ msgstr "Memória de localização será importada para"
 
@@ -1371,12 +1386,6 @@ msgstr ""
 
 #~ msgid "Priming memory"
 #~ msgstr "Memória de escorva"
-
-#~ msgid "Duplex"
-#~ msgstr "Duplex"
-
-#~ msgid "Tune Step"
-#~ msgstr "Tune Step"
 
 #~ msgid "Skip"
 #~ msgstr "Skip"

--- a/chirp/locale/ru.po
+++ b/chirp/locale/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -238,32 +238,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Неверное значение для этого поля"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Смещение"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Частота"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Частота"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Мощность"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Шаг"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -278,202 +283,215 @@ msgstr "ТонПРД"
 msgid "Tone Squelch"
 msgstr "ТонШПД"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Дуплекс"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Режим"
+
+#: ../wxui/memedit.py:462
 #, fuzzy
 msgid "Cross mode"
 msgstr "Кроссрежим"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "Комментарий"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Вид субтона"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCSПРД"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Кроссрежим"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Вставка строки выше"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "Удалить (и сдвинуть вверх)"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr "Удалить (и сдвинуть вверх)"
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 #, fuzzy
 msgid "Delete"
 msgstr "_Удалить"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "Удалить (и сдвинуть вверх)"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "Удалить (и сдвинуть вверх)"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Show Raw Memory\t"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Вставка строки ниже"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Перезаписать?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Вставленная память {number} не совместима с этой станцией, потому что:"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr "Цифровой код"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 msgid "DV Memory"
 msgstr ""
 
@@ -1094,9 +1112,6 @@ msgstr ""
 #~ msgid "From"
 #~ msgstr "От"
 
-#~ msgid "Comment"
-#~ msgstr "Комментарий"
-
 #~ msgid "Location memory will be imported into"
 #~ msgstr "Позиция памяти будет импортирована в"
 
@@ -1374,12 +1389,6 @@ msgstr ""
 
 #~ msgid "Priming memory"
 #~ msgstr "Первичная память"
-
-#~ msgid "Duplex"
-#~ msgstr "Дуплекс"
-
-#~ msgid "Tune Step"
-#~ msgstr "Шаг"
 
 #~ msgid "Skip"
 #~ msgstr "Пропуск"

--- a/chirp/locale/tr_TR.po
+++ b/chirp/locale/tr_TR.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2022-09-25 01:05+0300\n"
 "Last-Translator: Abdullah YILMAZ (TA1AUB) <h.abdullahyilmaz@hotmail.com>\n"
 "Language-Team: TURKISH\n"
@@ -254,32 +254,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "%s için geçersiz değer"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Ofset"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Frekans"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frekans"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Güç"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Adımı Ayarla"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -294,201 +299,214 @@ msgstr "Ton"
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Duplex"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 #, fuzzy
 msgid "RX DTCS"
 msgstr "RX DTCS Kodu"
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Mod"
+
+#: ../wxui/memedit.py:462
 msgid "Cross mode"
 msgstr "Çapraz mod"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "Yorum"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Ton Modu"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, fuzzy, python-format
 msgid "Choose %s Tone"
 msgstr "Dil Seçin"
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "RX DTCS Kodu"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 #, fuzzy
 msgid "Information"
 msgstr "{information}"
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Çapraz Mod"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 #, fuzzy
 msgid "Choose duplex"
 msgstr "Dil Seçin"
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "Geçersiz ayar değeri: %s"
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr "Özellikler"
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Yukarıya satır ekle"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Farklı Ham kayıtlar"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "Sil (ve yukarı kaydır)"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr "Sil (ve yukarı kaydır)"
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 msgid "Delete"
 msgstr "Sil"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "Sil (ve yukarı kaydır)"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "Sil (ve yukarı kaydır)"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 msgid "Show Raw Memory"
 msgstr "Ham Kaydı Göster"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 msgid "Diff Raw Memories"
 msgstr "Farklı Ham kayıtlar"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Aşağıya satır ekle"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Üzerine yazılsın mı?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Yapıştırılan {number} kaydı bu telsizle uyumlu değil çünkü:"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr "Dijital Kod"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, fuzzy, python-format
 msgid "Edit details for %i memories"
 msgstr "Birden Fazla Kaydı Düzenle"
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 #, fuzzy
 msgid "DV Memory"
 msgstr "bu kaydı"
@@ -1125,9 +1143,6 @@ msgstr ""
 #~ msgid "Columns"
 #~ msgstr "Sütunlar"
 
-#~ msgid "Comment"
-#~ msgstr "Yorum"
-
 #~ msgid "Confirm overwrites"
 #~ msgstr "Üzerine yazmayı onayla"
 
@@ -1214,9 +1229,6 @@ msgstr ""
 
 #~ msgid "Downloading URCALL list"
 #~ msgstr "URCALL (sizin çağrı) listesi indiriliyor"
-
-#~ msgid "Duplex"
-#~ msgstr "Duplex"
 
 #~ msgid "EVE"
 #~ msgstr "EVE"
@@ -1688,9 +1700,6 @@ msgstr ""
 
 #~ msgid "Travel Plus Files"
 #~ msgstr "Seyahat Artı Dosyaları"
-
-#~ msgid "Tune Step"
-#~ msgstr "Adımı Ayarla"
 
 #~ msgid "URCALL"
 #~ msgstr "URCALL"

--- a/chirp/locale/uk_UA.po
+++ b/chirp/locale/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2015-11-30 10:36+0200\n"
 "Last-Translator: laser <student.laser@gmail.com>\n"
 "Language-Team: laser <student.laser@gmail.com>\n"
@@ -246,32 +246,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Неприпустиме значення для цього поля"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "Зсув"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "Частота"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Частота"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "Потужність"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "Крок настройки"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -286,202 +291,215 @@ msgstr "Тон"
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "Дуплекс"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "Режим"
+
+#: ../wxui/memedit.py:462
 #, fuzzy
 msgid "Cross mode"
 msgstr "Кросрежим"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "Коментар"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "Тоновий режим"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS код"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Кросрежим"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Додати рядок зверху"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 #, fuzzy
 msgid "Delete"
 msgstr "Видалити"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Показати Raw пам'ять"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Додати рядок знизу"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Перезаписати?"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Вставлена пам'ять {number} несумісна із цією радіостанцією тому що:"
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 msgid "Digital Code"
 msgstr "Цифровий код"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 msgid "DV Memory"
 msgstr ""
 
@@ -1102,9 +1120,6 @@ msgstr ""
 #~ msgid "From"
 #~ msgstr "З"
 
-#~ msgid "Comment"
-#~ msgstr "Коментар"
-
 #~ msgid "Location memory will be imported into"
 #~ msgstr "Розташування пам'яті буде імпортовано до"
 
@@ -1384,12 +1399,6 @@ msgstr ""
 
 #~ msgid "Priming memory"
 #~ msgstr "Первинна пам'ять"
-
-#~ msgid "Duplex"
-#~ msgstr "Дуплекс"
-
-#~ msgid "Tune Step"
-#~ msgstr "Крок настройки"
 
 #~ msgid "Skip"
 #~ msgstr "Пропустити"

--- a/chirp/locale/zh_CN.po
+++ b/chirp/locale/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-07 13:35-0800\n"
+"POT-Creation-Date: 2023-02-09 14:53-0800\n"
 "PO-Revision-Date: 2022-06-04 02:01+0800\n"
 "Last-Translator: DuckSoft, BH2UEP <realducksoft@gmail.com>\n"
 "Language: zh_CN\n"
@@ -245,32 +245,37 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/memedit.py:116
+#: ../wxui/memedit.py:113
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:151 ../wxui/memedit.py:157
+#: ../wxui/memedit.py:148 ../wxui/memedit.py:154
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "%s 值无效"
 
-#: ../wxui/memedit.py:180
+#: ../wxui/memedit.py:177
 msgid "Offset"
 msgstr "频差"
 
-#: ../wxui/memedit.py:182
+#: ../wxui/memedit.py:179
 msgid "Frequency"
 msgstr "频率"
 
-#: ../wxui/memedit.py:221
+#: ../wxui/memedit.py:218
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "频率"
 
-#: ../wxui/memedit.py:245
+#: ../wxui/memedit.py:242
 msgid "Power"
 msgstr "功率"
+
+#: ../wxui/memedit.py:272
+#, fuzzy
+msgid "Tuning Step"
+msgstr "调谐间隔"
 
 #: ../wxui/memedit.py:304
 msgid "Choice Required"
@@ -285,201 +290,214 @@ msgstr "亚音频"
 msgid "Tone Squelch"
 msgstr "接收亚音频"
 
-#: ../wxui/memedit.py:390
+#: ../wxui/memedit.py:355
+msgid "Duplex"
+msgstr "差频方向"
+
+#: ../wxui/memedit.py:393
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS 策略"
 
-#: ../wxui/memedit.py:392
+#: ../wxui/memedit.py:395
 #, fuzzy
 msgid "RX DTCS"
 msgstr "DTCS 接收代码"
 
-#: ../wxui/memedit.py:436
+#: ../wxui/memedit.py:439
 #, fuzzy
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "DTCS 策略"
 
-#: ../wxui/memedit.py:456
+#: ../wxui/memedit.py:448
+#, fuzzy
+msgid "Mode"
+msgstr "制式"
+
+#: ../wxui/memedit.py:462
 msgid "Cross mode"
 msgstr "收发使用不同亚音频"
 
-#: ../wxui/memedit.py:568
+#: ../wxui/memedit.py:471
+msgid "Comment"
+msgstr "备注"
+
+#: ../wxui/memedit.py:577
 msgid "Tone Mode"
 msgstr "亚音频制式"
 
-#: ../wxui/memedit.py:838
+#: ../wxui/memedit.py:847
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:841
+#: ../wxui/memedit.py:850
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS 接收代码"
 
-#: ../wxui/memedit.py:862
+#: ../wxui/memedit.py:871
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/memedit.py:864
+#: ../wxui/memedit.py:873
 #, fuzzy
 msgid "Information"
 msgstr "{information}"
 
-#: ../wxui/memedit.py:872
+#: ../wxui/memedit.py:881
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "收发使用不同亚音频"
 
-#: ../wxui/memedit.py:881
+#: ../wxui/memedit.py:890
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:889
+#: ../wxui/memedit.py:898
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:902
+#: ../wxui/memedit.py:911
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:929
+#: ../wxui/memedit.py:938
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/memedit.py:1006 ../wxui/memedit.py:1630
+#: ../wxui/memedit.py:1015 ../wxui/memedit.py:1639
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "设置值无效：%s"
 
-#: ../wxui/memedit.py:1012
+#: ../wxui/memedit.py:1021
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1013
+#: ../wxui/memedit.py:1022
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1045
+#: ../wxui/memedit.py:1054
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1111
+#: ../wxui/memedit.py:1120
 msgid "Properties"
 msgstr "属性"
 
-#: ../wxui/memedit.py:1117
+#: ../wxui/memedit.py:1126
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "上方插入一行"
 
-#: ../wxui/memedit.py:1126
+#: ../wxui/memedit.py:1135
 #, fuzzy, python-format
 msgid "Delete %i Memories"
 msgstr "对比原始存储"
 
-#: ../wxui/memedit.py:1129
+#: ../wxui/memedit.py:1138
 #, fuzzy, python-format
 msgid "Delete %i Memories and shift block up"
 msgstr "...并将区块上移"
 
-#: ../wxui/memedit.py:1133
+#: ../wxui/memedit.py:1142
 #, python-format
 msgid "Delete %i Memories and shift all up"
 msgstr ""
 
-#: ../wxui/memedit.py:1136
+#: ../wxui/memedit.py:1145
 msgid "Delete"
 msgstr "删除"
 
-#: ../wxui/memedit.py:1138
+#: ../wxui/memedit.py:1147
 #, fuzzy
 msgid "Delete and shift block up"
 msgstr "...并将区块上移"
 
-#: ../wxui/memedit.py:1140
+#: ../wxui/memedit.py:1149
 #, fuzzy
 msgid "Delete and shift all up"
 msgstr "...并将区块上移"
 
-#: ../wxui/memedit.py:1166
+#: ../wxui/memedit.py:1175
 msgid "Show Raw Memory"
 msgstr "显示原始存储"
 
-#: ../wxui/memedit.py:1174
+#: ../wxui/memedit.py:1183
 msgid "Diff Raw Memories"
 msgstr "对比原始存储"
 
-#: ../wxui/memedit.py:1210
+#: ../wxui/memedit.py:1219
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "下方插入一行"
 
-#: ../wxui/memedit.py:1282
+#: ../wxui/memedit.py:1291
 msgid "Some memories are not deletable"
-msgstr ""
-
-#: ../wxui/memedit.py:1308
-#, python-format
-msgid "Pasted memory will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1311
-#, python-format
-msgid "Pasted memories will overwrite memory %i"
-msgstr ""
-
-#: ../wxui/memedit.py:1314
-#, python-format
-msgid "Pasted memories will overwrite %i existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:1317
 #, python-format
-msgid "Pasted memories will overwrite memories %s"
+msgid "Pasted memory will overwrite memory %i"
 msgstr ""
 
 #: ../wxui/memedit.py:1320
+#, python-format
+msgid "Pasted memories will overwrite memory %i"
+msgstr ""
+
+#: ../wxui/memedit.py:1323
+#, python-format
+msgid "Pasted memories will overwrite %i existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1326
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1329
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "要覆盖吗？"
 
-#: ../wxui/memedit.py:1365
+#: ../wxui/memedit.py:1374
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "粘贴的存储 {number} 与此电台不兼容，原因："
 
-#: ../wxui/memedit.py:1440
+#: ../wxui/memedit.py:1449
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/memedit.py:1477
+#: ../wxui/memedit.py:1486
 #, fuzzy
 msgid "Digital Code"
 msgstr "数字代码"
 
-#: ../wxui/memedit.py:1505
+#: ../wxui/memedit.py:1514
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/memedit.py:1507
+#: ../wxui/memedit.py:1516
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1541
+#: ../wxui/memedit.py:1550
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1561
 #, fuzzy
 msgid "DV Memory"
 msgstr "该存储"
@@ -1447,9 +1465,6 @@ msgstr ""
 #~ msgid "From"
 #~ msgstr "从"
 
-#~ msgid "Comment"
-#~ msgstr "备注"
-
 #~ msgid "Location memory will be imported into"
 #~ msgstr "位置存储将被导入到"
 
@@ -1468,12 +1483,6 @@ msgstr ""
 
 #~ msgid "DTCS Code"
 #~ msgstr "DTCS 代码"
-
-#~ msgid "Duplex"
-#~ msgstr "差频方向"
-
-#~ msgid "Tune Step"
-#~ msgstr "调谐间隔"
 
 #~ msgid "Skip"
 #~ msgstr "跳过"

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -70,7 +70,6 @@ class ChirpRowLabelRenderer(glr.GridDefaultRowLabelRenderer):
 
 
 class ChirpMemoryColumn(object):
-    NAME = None
     DEFAULT = ''
 
     def __init__(self, name, radio, label=None):
@@ -79,7 +78,7 @@ class ChirpMemoryColumn(object):
         :param label: Static label override
         """
         self._name = name
-        self._label = label
+        self._label = label or _(name.title())
         self._radio = radio
         self._features = radio.get_features()
 
@@ -89,9 +88,7 @@ class ChirpMemoryColumn(object):
 
     @property
     def label(self):
-        return (self.NAME or
-                self._label or
-                self._name.title().replace('_', '\n'))
+        return self._label.replace('_', ' ').replace(' ', '\n', 1)
 
     def hidden_for(self, memory):
         return False
@@ -271,6 +268,9 @@ class ChirpChoiceEditor(wx.grid.GridCellChoiceEditor):
 
 
 class ChirpChoiceColumn(ChirpMemoryColumn):
+    # This is just here so it is marked for translation
+    __TITLE1 = _('Tuning Step')
+
     def __init__(self, name, radio, choices, **k):
         super(ChirpChoiceColumn, self).__init__(name, radio, **k)
         self._choices = choices
@@ -320,7 +320,7 @@ class ChirpToneColumn(ChirpChoiceColumn):
         if self._name == 'rtone':
             return _('Tone')
         else:
-            return _('Tone Squelch').replace(' ', '\n')
+            return _('Tone Squelch').replace(' ', '\n', 1)
 
     def rtone_visible(self, memory):
         if not self._features.has_ctone:
@@ -351,6 +351,9 @@ class ChirpToneColumn(ChirpChoiceColumn):
 
 
 class ChirpDuplexColumn(ChirpChoiceColumn):
+    # This is just here so it is marked for translation
+    __TITLE = _('Duplex')
+
     def __init__(self, *a, **k):
         super().__init__(*a, **k)
         self._wants_split = set()
@@ -441,6 +444,9 @@ class ChirpDTCSPolColumn(ChirpChoiceColumn):
 
 
 class ChirpCrossModeColumn(ChirpChoiceColumn):
+    # This is just here so it is marked for translation
+    __TITLE = _('Mode')
+
     def __init__(self, name, radio):
         rf = radio.get_features()
         super(ChirpCrossModeColumn, self).__init__(name, radio,
@@ -460,6 +466,9 @@ class ChirpCrossModeColumn(ChirpChoiceColumn):
 
 
 class ChirpCommentColumn(ChirpMemoryColumn):
+    # This is just here so it is marked for translation
+    __TITLE = _('Comment')
+
     @property
     def valid(self):
         return (self._features.has_comment or
@@ -565,7 +574,7 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
             ChirpMemoryColumn('name', self._radio),
             ChirpChoiceColumn('tmode', self._radio,
                               valid_tmodes,
-                              label=_('Tone Mode').replace(' ', '\n')),
+                              label=_('Tone Mode')),
             ChirpToneColumn('rtone', self._radio),
             ChirpToneColumn('ctone', self._radio),
             ChirpDTCSColumn('dtcs', self._radio),


### PR DESCRIPTION
- Rename es_ES translation to es
- Fix translating name-inherited column headers
