### PR TITLE
Make common master lists immutable

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -30,25 +30,27 @@ LOG = logging.getLogger(__name__)
 SEPCHAR = ","
 
 # 50 Tones
-TONES = [67.0, 69.3, 71.9, 74.4, 77.0, 79.7, 82.5,
-         85.4, 88.5, 91.5, 94.8, 97.4, 100.0, 103.5,
-         107.2, 110.9, 114.8, 118.8, 123.0, 127.3,
-         131.8, 136.5, 141.3, 146.2, 151.4, 156.7,
-         159.8, 162.2, 165.5, 167.9, 171.3, 173.8,
-         177.3, 179.9, 183.5, 186.2, 189.9, 192.8,
-         196.6, 199.5, 203.5, 206.5, 210.7, 218.1,
-         225.7, 229.1, 233.6, 241.8, 250.3, 254.1,
-         ]
+TONES = (
+    67.0, 69.3, 71.9, 74.4, 77.0, 79.7, 82.5,
+    85.4, 88.5, 91.5, 94.8, 97.4, 100.0, 103.5,
+    107.2, 110.9, 114.8, 118.8, 123.0, 127.3,
+    131.8, 136.5, 141.3, 146.2, 151.4, 156.7,
+    159.8, 162.2, 165.5, 167.9, 171.3, 173.8,
+    177.3, 179.9, 183.5, 186.2, 189.9, 192.8,
+    196.6, 199.5, 203.5, 206.5, 210.7, 218.1,
+    225.7, 229.1, 233.6, 241.8, 250.3, 254.1,
+)
 
-TONES_EXTRA = [56.0, 57.0, 58.0, 59.0, 60.0, 61.0, 62.0,
-               62.5, 63.0, 64.0]
+TONES_EXTRA = (56.0, 57.0, 58.0, 59.0, 60.0, 61.0, 62.0,
+               62.5, 63.0, 64.0)
 
 OLD_TONES = list(TONES)
 [OLD_TONES.remove(x) for x in [159.8, 165.5, 171.3, 177.3, 183.5, 189.9,
                                196.6, 199.5, 206.5, 229.1, 254.1]]
+OLD_TONES = tuple(OLD_TONES)
 
 # 104 DTCS Codes
-DTCS_CODES = [
+DTCS_CODES = (
     23,  25,  26,  31,  32,  36,  43,  47,  51,  53,  54,
     65,  71,  72,  73,  74,  114, 115, 116, 122, 125, 131,
     132, 134, 143, 145, 152, 155, 156, 162, 165, 172, 174,
@@ -59,7 +61,7 @@ DTCS_CODES = [
     465, 466, 503, 506, 516, 523, 526, 532, 546, 565, 606,
     612, 624, 627, 631, 632, 654, 662, 664, 703, 712, 723,
     731, 732, 734, 743, 754,
-]
+)
 
 # 512 Possible DTCS Codes
 ALL_DTCS_CODES = []
@@ -67,8 +69,9 @@ for a in range(0, 8):
     for b in range(0, 8):
         for c in range(0, 8):
             ALL_DTCS_CODES.append((a * 100) + (b * 10) + c)
+ALL_DTCS_CODES = tuple(ALL_DTCS_CODES)
 
-CROSS_MODES = [
+CROSS_MODES = (
     "Tone->Tone",
     "DTCS->",
     "->DTCS",
@@ -77,13 +80,13 @@ CROSS_MODES = [
     "->Tone",
     "DTCS->DTCS",
     "Tone->"
-]
+)
 
-MODES = ["WFM", "FM", "NFM", "AM", "NAM", "DV", "USB", "LSB", "CW", "RTTY",
+MODES = ("WFM", "FM", "NFM", "AM", "NAM", "DV", "USB", "LSB", "CW", "RTTY",
          "DIG", "PKT", "NCW", "NCWR", "CWR", "P25", "Auto", "RTTYR",
-         "FSK", "FSKR", "DMR", "DN"]
+         "FSK", "FSKR", "DMR", "DN")
 
-TONE_MODES = [
+TONE_MODES = (
     "",
     "Tone",
     "TSQL",
@@ -91,19 +94,19 @@ TONE_MODES = [
     "DTCS-R",
     "TSQL-R",
     "Cross",
-]
+)
 
-TUNING_STEPS = [
+TUNING_STEPS = (
     5.0, 6.25, 10.0, 12.5, 15.0, 20.0, 25.0, 30.0, 50.0, 100.0,
     125.0, 200.0,
     # Need to fix drivers using this list as an index!
     9.0, 1.0, 2.5,
-]
+)
+
 # These are the default for RadioFeatures.valid_tuning_steps
-COMMON_TUNING_STEPS = [5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 50.0, 100.0]
+COMMON_TUNING_STEPS = (5.0, 10.0, 15.0, 20.0, 25.0, 30.0, 50.0, 100.0)
 
-
-SKIP_VALUES = ["", "S", "P"]
+SKIP_VALUES = ("", "S", "P")
 
 CHARSET_UPPER_NUMERIC = "ABCDEFGHIJKLMNOPQRSTUVWXYZ 1234567890"
 CHARSET_ALPHANUMERIC = \
@@ -731,7 +734,33 @@ class RadioPrompts:
     display_pre_upload_prompt_before_opening_port = True
 
 
-BOOLEAN = [True, False]
+def BOOLEAN(v):
+    assert v in (True, False)
+
+
+def LIST(v):
+    assert hasattr(v, '__iter__')
+
+
+def INT(min=0, max=None):
+    def checkint(v):
+        assert isinstance(v, int)
+        assert v >= min
+        if max is not None:
+            assert v <= max
+
+    return checkint
+
+
+def STRING(v):
+    assert isinstance(v, str)
+
+
+def NTUPLE(size):
+    def checktuple(v):
+        assert len(v) == size
+
+    return checktuple
 
 
 class RadioFeatures:
@@ -757,23 +786,23 @@ class RadioFeatures:
         "has_variable_power":   BOOLEAN,
 
         # Attributes
-        "valid_modes":          [],
-        "valid_tmodes":         [],
-        "valid_duplexes":       [],
-        "valid_tuning_steps":   [],
-        "valid_bands":          [],
-        "valid_skips":          [],
-        "valid_power_levels":   [],
-        "valid_characters":     "",
-        "valid_name_length":    0,
-        "valid_cross_modes":    [],
-        "valid_tones":          [],
-        "valid_dtcs_pols":      [],
-        "valid_dtcs_codes":     [],
-        "valid_special_chans":  [],
+        "valid_modes":          LIST,
+        "valid_tmodes":         LIST,
+        "valid_duplexes":       LIST,
+        "valid_tuning_steps":   LIST,
+        "valid_bands":          LIST,
+        "valid_skips":          LIST,
+        "valid_power_levels":   LIST,
+        "valid_characters":     STRING,
+        "valid_name_length":    INT(),
+        "valid_cross_modes":    LIST,
+        "valid_tones":          LIST,
+        "valid_dtcs_pols":      LIST,
+        "valid_dtcs_codes":     LIST,
+        "valid_special_chans":  LIST,
 
         "has_sub_devices":      BOOLEAN,
-        "memory_bounds":        (0, 0),
+        "memory_bounds":        NTUPLE(2),
         "can_odd_split":        BOOLEAN,
         "can_delete":           BOOLEAN,
 
@@ -789,28 +818,12 @@ class RadioFeatures:
         elif name not in list(self._valid_map.keys()):
             raise ValueError("No such attribute `%s'" % name)
 
-        if type(self._valid_map[name]) == tuple:
-            # Tuple, cardinality must match
-            if type(val) != tuple or len(val) != len(self._valid_map[name]):
-                raise ValueError("Invalid value `%s' for attribute `%s'" %
-                                 (val, name))
-        elif type(self._valid_map[name]) == list and not self._valid_map[name]:
-            # Empty list, must be another list
-            if type(val) != list:
-                raise ValueError("Invalid value `%s' for attribute `%s'" %
-                                 (val, name))
-        elif type(self._valid_map[name]) == str:
-            if type(val) != str:
-                raise ValueError("Invalid value `%s' for attribute `%s'" %
-                                 (val, name))
-        elif type(self._valid_map[name]) == int:
-            if type(val) != int:
-                raise ValueError("Invalid value `%s' for attribute `%s'" %
-                                 (val, name))
-        elif val not in self._valid_map[name]:
-            # Value not in the list of valid values
-            raise ValueError("Invalid value `%s' for attribute `%s'" % (val,
-                                                                        name))
+        try:
+            self._valid_map[name](val)
+        except AssertionError:
+            raise ValueError('Invalid value %r for attribute %r' % (
+                val, name))
+
         self.__dict__[name] = val
 
     def __getattr__(self, name):

--- a/chirp/drivers/alinco.py
+++ b/chirp/drivers/alinco.py
@@ -203,7 +203,7 @@ TMODES = ["", "Tone", "", "TSQL"] + [""] * 12
 TMODES[12] = "DTCS"
 DCS_CODES = {
     "Alinco": chirp_common.DTCS_CODES,
-    "Jetstream": [17] + chirp_common.DTCS_CODES,
+    "Jetstream": (17,) + chirp_common.DTCS_CODES,
 }
 
 CHARSET = (["\x00"] * 0x30) + \

--- a/chirp/drivers/anytone778uv.py
+++ b/chirp/drivers/anytone778uv.py
@@ -691,11 +691,12 @@ class AnyTone778UVBase(chirp_common.CloneModeRadio,
         try:
             rf.valid_bands = get_band_limits_Hz(
                 int(self._memobj.radio_settings.bandlimit))
-        except TypeError as e:
+        except AttributeError as e:
             # If we're asked without memory loaded, assume the most permissive
             rf.valid_bands = get_band_limits_Hz(1)
         except Exception as e:
-            LOG.error('Failed to get band limits for anytone778uv: %s' % e)
+            LOG.exception(
+                'Failed to get band limits for anytone778uv: %s' % e)
             rf.valid_bands = get_band_limits_Hz(1)
         rf.valid_modes = ['FM', 'NFM']
         rf.valid_power_levels = POWER_LEVELS

--- a/chirp/drivers/anytone_iii.py
+++ b/chirp/drivers/anytone_iii.py
@@ -713,7 +713,7 @@ T_MODES = ['', 'Tone', 'DTCS', '']
 TONE2_SLOTS = ['%d' % x for x in range(0, 24)]
 TONE5_SLOTS = ['%d' % x for x in range(0, 100)]
 # Future: chirp_common should present TONES instead of hard-coded list
-TONES = [62.5] + chirp_common.TONES
+TONES = (62.5,) + chirp_common.TONES
 TOT = ['Off'] + ['%s Minutes' % x for x in range(1, 31)]
 TUNING_STEPS = [2.5, 5, 6.25, 8.33, 10, 12.5, 15, 20, 25, 30]
 PTT_KEY_LOCKS = ["Off", "Right", "Left", "Both"]

--- a/chirp/drivers/baofeng_wp970i.py
+++ b/chirp/drivers/baofeng_wp970i.py
@@ -109,7 +109,7 @@ class WP970I(baofeng_common.BaofengCommonHT):
         "!@#$%^&*()+-=[]:\";'<>?,./"
     LENGTH_NAME = 6
     SKIP_VALUES = ["", "S"]
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=5.00),
                     chirp_common.PowerLevel("Med",  watts=3.00),
                     chirp_common.PowerLevel("Low",  watts=1.00)]

--- a/chirp/drivers/bf_t1.py
+++ b/chirp/drivers/bf_t1.py
@@ -55,7 +55,7 @@ ACK_CMD = b"\x06"
 MODES = ["NFM", "FM"]
 SKIP_VALUES = ["S", ""]
 TONES = chirp_common.TONES
-DTCS = sorted(chirp_common.DTCS_CODES + [645])
+DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 # Special channels
 SPECIALS = {

--- a/chirp/drivers/bf_t8.py
+++ b/chirp/drivers/bf_t8.py
@@ -883,7 +883,7 @@ class RetevisRT16(BFT8Radio):
 class RetevisRB27B(BFT8Radio):
     VENDOR = "Retevis"
     MODEL = "RB27B"
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
     HAS_NAMES = True
     NAME_LENGTH = 6
     VALID_CHARS = chirp_common.CHARSET_UPPER_NUMERIC + "-"
@@ -956,7 +956,7 @@ class FRSA1Radio(BFT8Radio):
     HAS_NAMES = True
     NAME_LENGTH = 6
     SKIP_VALUES = ["", "S"]
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
     DUPLEXES = ['', '-', '+', 'off']
 
     _fingerprint = b"BF-T8A" + b"\x2E"

--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -47,7 +47,7 @@ ACK_CMD = 0x06
 MODES = ["FM", "NFM"]
 SKIP_VALUES = ["S", ""]
 TONES = chirp_common.TONES
-DTCS = sorted(chirp_common.DTCS_CODES + [645])
+DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 # lists related to "extra" settings
 PTTID_LIST = ["OFF", "BOT", "EOT", "BOTH"]

--- a/chirp/drivers/ft450d.py
+++ b/chirp/drivers/ft450d.py
@@ -31,8 +31,6 @@ LOG = logging.getLogger(__name__)
 
 CMD_ACK = 0x06
 EX_MODES = ["USER-L", "USER-U", "LSB+CW", "USB+CW", "RTTY-L", "RTTY-U", "N/A"]
-for i in EX_MODES:
-    chirp_common.MODES.append(i)
 T_STEPS = sorted(list(chirp_common.TUNING_STEPS))
 T_STEPS.remove(30.0)
 T_STEPS.remove(100.0)
@@ -518,7 +516,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         rf = chirp_common.RadioFeatures()
         rf.has_bank = False
         rf.has_dtcs= False
-        rf.valid_modes = list(set(self.MODES))
+        rf.valid_modes = [x for x in self.MODES if x in chirp_common.MODES]
         rf.valid_tmodes = list(self.TMODES)
         rf.valid_duplexes = list(self.DUPLEX)
         rf.valid_tuning_steps = list(T_STEPS)
@@ -730,7 +728,10 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
                 vx = 6
             if _mem.mode2 == 2:      # USER-U
                 vx = 7
-        mem.mode = self.MODES[vx]
+        try:
+            mem.mode = self.MODES[vx]
+        except ValueError:
+            LOG.error('The FT-450 driver is broken for unsupported modes')
         if mem.mode == "FM" or mem.mode == "NFM":
             mem.tuning_step = self.STEPSFM[_mem.fm_step]
         elif mem.mode == "AM":

--- a/chirp/drivers/ga510.py
+++ b/chirp/drivers/ga510.py
@@ -22,7 +22,7 @@ except ImportError:
               '%s requires it' % __name__)
 
 # GA510 also has DTCS code 645
-DTCS_CODES = list(sorted(chirp_common.DTCS_CODES + [645]))
+DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 DTMFCHARS = '0123456789ABCD*#'
 

--- a/chirp/drivers/gmrsuv1.py
+++ b/chirp/drivers/gmrsuv1.py
@@ -122,7 +122,7 @@ class GMRSV1(baofeng_common.BaofengCommonHT):
         "!@#$%^&*()+-=[]:\";'<>?,./"
     LENGTH_NAME = 7
     SKIP_VALUES = ["", "S"]
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=5.00),
                     chirp_common.PowerLevel("Low", watts=2.00)]
     VALID_BANDS = [(130000000, 180000000),

--- a/chirp/drivers/gmrsv2.py
+++ b/chirp/drivers/gmrsv2.py
@@ -99,7 +99,7 @@ class GMRSV2(baofeng_common.BaofengCommonHT):
         "!@#$%^&*()+-=[]:\";'<>?,./"
     LENGTH_NAME = 7
     SKIP_VALUES = ["", "S"]
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=5.00),
                     chirp_common.PowerLevel("Low", watts=0.50)]
     VALID_BANDS = [(130000000, 180000000),

--- a/chirp/drivers/iradio_uv_5118.py
+++ b/chirp/drivers/iradio_uv_5118.py
@@ -138,7 +138,7 @@ struct {
 
 CMD_ACK = b"\x06"
 
-RB15_DTCS = sorted(chirp_common.DTCS_CODES + [645])
+RB15_DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 _STEP_LIST = [0.25, 1.25, 2.5, 5., 6.25, 10., 12.5, 25., 50., 100.]
 

--- a/chirp/drivers/kyd.py
+++ b/chirp/drivers/kyd.py
@@ -67,7 +67,7 @@ CMD_ACK = "\x06"
 NC630A_POWER_LEVELS = [chirp_common.PowerLevel("Low",  watts=1.00),
                        chirp_common.PowerLevel("High", watts=5.00)]
 
-NC630A_DTCS = sorted(chirp_common.DTCS_CODES + [645])
+NC630A_DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 BCL_LIST = ["Off", "Carrier", "QT/DQT"]
 TIMEOUTTIMER_LIST = [""] + ["%s seconds" % x for x in range(15, 615, 15)]

--- a/chirp/drivers/leixen.py
+++ b/chirp/drivers/leixen.py
@@ -226,10 +226,9 @@ PFKEYSHORT_LIST = ["OFF",
                    ]
 
 MODES = ["NFM", "FM"]
-WTFTONES = [float(x) for x in range(56, 64)]
+WTFTONES = tuple(float(x) for x in range(56, 64))
 TONES = WTFTONES + chirp_common.TONES
-DTCS_CODES = [17, 50, 645] + chirp_common.DTCS_CODES
-DTCS_CODES.sort()
+DTCS_CODES = tuple(sorted((17, 50, 645) + chirp_common.DTCS_CODES))
 TMODES = ["", "Tone", "DTCS", "DTCS"]
 
 

--- a/chirp/drivers/lt725uv.py
+++ b/chirp/drivers/lt725uv.py
@@ -455,7 +455,7 @@ class LT725UV(chirp_common.CloneModeRadio):
     NEEDS_COMPAT_SERIAL = False
     MODES = ["NFM", "FM"]
     TONES = chirp_common.TONES
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
     NAME_LENGTH = 7
     DTMF_CHARS = list("0123456789ABCD*#")
 

--- a/chirp/drivers/mursv1.py
+++ b/chirp/drivers/mursv1.py
@@ -110,7 +110,7 @@ class MURSV1(baofeng_common.BaofengCommonHT):
         "!@#$%^&*()+-=[]:\";'<>?,./"
     LENGTH_NAME = 7
     SKIP_VALUES = ["", "S"]
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=2.00),
                     chirp_common.PowerLevel("Low", watts=.50)]
     VALID_BANDS = [(151820000, 154600250)]

--- a/chirp/drivers/radtel_t18.py
+++ b/chirp/drivers/radtel_t18.py
@@ -444,7 +444,7 @@ class T18Radio(chirp_common.CloneModeRadio):
         rf.has_name = False
         rf.memory_bounds = (1, self._upper)
         rf.valid_bands = self.VALID_BANDS
-        rf.valid_tuning_steps = chirp_common.TUNING_STEPS + [6.25, 12.5]
+        rf.valid_tuning_steps = chirp_common.TUNING_STEPS
 
         return rf
 

--- a/chirp/drivers/retevis_rb15.py
+++ b/chirp/drivers/retevis_rb15.py
@@ -79,7 +79,7 @@ struct {
 
 CMD_ACK = b"\x06"
 
-RB15_DTCS = sorted(chirp_common.DTCS_CODES + [645])
+RB15_DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 LIST_BACKLIGHT = ["Off", "On", "Auto"]
 LIST_BCL = ["None", "Carrier", "QT/DQT Match"]

--- a/chirp/drivers/retevis_rt1.py
+++ b/chirp/drivers/retevis_rt1.py
@@ -90,7 +90,7 @@ CMD_ACK = b"\x06"
 RT1_POWER_LEVELS = [chirp_common.PowerLevel("Low",  watts=5.00),
                     chirp_common.PowerLevel("High", watts=9.00)]
 
-RT1_DTCS = sorted(chirp_common.DTCS_CODES + [645])
+RT1_DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 LIST_LPT = ["0.5", "1.0", "1.5", "2.0", "2.5"]
 LIST_SHORT_PRESS = ["Off", "Monitor On/Off", "Power High/Low", "Alarm", "Volt"]

--- a/chirp/drivers/retevis_rt21.py
+++ b/chirp/drivers/retevis_rt21.py
@@ -534,6 +534,8 @@ PMR_FREQS2 = [446106250, 446118750, 446131250, 446143750, 446156250,
               446168750, 446181250, 446193750]
 PMR_FREQS = PMR_FREQS1 + PMR_FREQS2
 
+DTCS_EXTRA = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
+
 
 def _enter_programming_mode(radio):
     serial = radio.pipe
@@ -713,7 +715,7 @@ class RT21Radio(chirp_common.CloneModeRadio):
     BLOCK_SIZE = 0x10
     BLOCK_SIZE_UP = 0x10
 
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [17, 50, 645])
+    DTCS_CODES = sorted(chirp_common.DTCS_CODES + (17, 50, 645))
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=2.50),
                     chirp_common.PowerLevel("Low", watts=1.00)]
 
@@ -1750,7 +1752,7 @@ class RB26Radio(RT21Radio):
     BLOCK_SIZE = 0x20
     BLOCK_SIZE_UP = 0x10
 
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = DTCS_EXTRA
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=3.00),
                     chirp_common.PowerLevel("Low", watts=0.50)]
 
@@ -1780,7 +1782,7 @@ class RT76Radio(RT21Radio):
     BLOCK_SIZE = 0x20
     BLOCK_SIZE_UP = 0x10
 
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = DTCS_EXTRA
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=5.00),
                     chirp_common.PowerLevel("Low", watts=0.50)]
 
@@ -1975,7 +1977,7 @@ class RT40BRadio(RT21Radio):
     BLOCK_SIZE = 0x20
     BLOCK_SIZE_UP = 0x10
 
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = DTCS_EXTRA
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=2.00),
                     chirp_common.PowerLevel("Low", watts=0.50)]
 
@@ -2010,7 +2012,7 @@ class RB28BRadio(RT21Radio):
     BLOCK_SIZE = 0x20
     BLOCK_SIZE_UP = 0x10
 
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = DTCS_EXTRA
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=2.00),
                     chirp_common.PowerLevel("Low", watts=0.50)]
 

--- a/chirp/drivers/retevis_rt22.py
+++ b/chirp/drivers/retevis_rt22.py
@@ -80,7 +80,7 @@ CMD_ACK = b"\x06"
 RT22_POWER_LEVELS = [chirp_common.PowerLevel("Low",  watts=2.00),
                      chirp_common.PowerLevel("High", watts=5.00)]
 
-RT22_DTCS = sorted(chirp_common.DTCS_CODES + [645])
+RT22_DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 PF2KEY_LIST = ["Scan", "Local Alarm", "Remote Alarm"]
 TIMEOUTTIMER_LIST = ["Off"] + ["%s seconds" % x for x in range(15, 615, 15)]

--- a/chirp/drivers/retevis_rt23.py
+++ b/chirp/drivers/retevis_rt23.py
@@ -143,8 +143,8 @@ RT23_POWER_LEVELS = [chirp_common.PowerLevel("Low", watts=1.00),
                      chirp_common.PowerLevel("High", watts=2.50)]
 
 
-RT23_DTCS = sorted(chirp_common.DTCS_CODES +
-                   [17, 50, 55, 135, 217, 254, 305, 645, 765])
+RT23_DTCS = tuple(sorted(chirp_common.DTCS_CODES +
+                  (17, 50, 55, 135, 217, 254, 305, 645, 765)))
 
 RT23_CHARSET = chirp_common.CHARSET_UPPER_NUMERIC + \
     ":;<=>?@ !\"#$%&'()*+,-./"

--- a/chirp/drivers/retevis_rt26.py
+++ b/chirp/drivers/retevis_rt26.py
@@ -121,7 +121,7 @@ DTMF_CHARSET = NUMERIC_CHARSET + list("ABCD*#")
 RT26_POWER_LEVELS = [chirp_common.PowerLevel("Low",  watts=5.00),
                      chirp_common.PowerLevel("High", watts=10.00)]
 
-RT26_DTCS = sorted(chirp_common.DTCS_CODES + [645])
+RT26_DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 LIST_PTTID = ["Off", "BOT", "EOT", "Both"]
 LIST_SHORT_PRESS = ["Off", "Monitor On/Off", "", "Scan", "Alarm",

--- a/chirp/drivers/retevis_rt76p.py
+++ b/chirp/drivers/retevis_rt76p.py
@@ -171,7 +171,7 @@ struct {
 
 CMD_ACK = b"\x06"
 
-RT76P_DTCS = sorted(chirp_common.DTCS_CODES + [645])
+RT76P_DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 DTMF_CHARS = "0123456789 *#ABCD"
 

--- a/chirp/drivers/retevis_rt87.py
+++ b/chirp/drivers/retevis_rt87.py
@@ -204,7 +204,7 @@ POWER_LEVELS = [chirp_common.PowerLevel('Low', watts=1),
 VALID_BANDS = [(136000000, 174000000),
                (400000000, 480000000)]
 
-RT87_DTCS = sorted(chirp_common.DTCS_CODES + [645])
+RT87_DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 NUMERIC_CHARSET = list("0123456789")
 DTMF_CHARSET = NUMERIC_CHARSET + list("ABCD*#")

--- a/chirp/drivers/th_uv8000.py
+++ b/chirp/drivers/th_uv8000.py
@@ -499,7 +499,7 @@ class THUV8000Radio(chirp_common.CloneModeRadio):
     NEEDS_COMPAT_SERIAL = False
     MODES = ["NFM", "FM"]
     TONES = chirp_common.TONES
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
     NAME_LENGTH = 7
     DTMF_CHARS = list("0123456789ABCD*#")
     # NOTE: SE Model supports 220-260 MHz

--- a/chirp/drivers/ts480.py
+++ b/chirp/drivers/ts480.py
@@ -106,9 +106,6 @@ TS480_SKIP = ["", "S"]
 # start at 0:LSB
 TS480_MODES = ["LSB", "USB", "CW", "FM", "AM", "FSK", "CW-R", "FSK-R"]
 EX_MODES = ["FSK-R", "CW-R"]
-for ix in EX_MODES:
-    if ix not in chirp_common.MODES:
-        chirp_common.MODES.append(ix)
 
 TS480_TONES = list(chirp_common.TONES)
 TS480_TONES.append(1750.0)
@@ -505,7 +502,7 @@ class TS480_CRadio(chirp_common.CloneModeRadio):
         rf.valid_bands = TS480_BANDS
         rf.valid_characters = chirp_common.CHARSET_UPPER_NUMERIC + "*+-/"
         rf.valid_duplexes = TS480_DUPLEX
-        rf.valid_modes = TS480_MODES
+        rf.valid_modes = [x for x in TS480_MODES if x in chirp_common.MODES]
         rf.valid_skips = TS480_SKIP
         rf.valid_tuning_steps = TS480_TUNE_STEPS
         rf.valid_tmodes = ["", "Tone", "TSQL"]

--- a/chirp/drivers/ts590.py
+++ b/chirp/drivers/ts590.py
@@ -142,9 +142,6 @@ TS590_SKIP = ["", "S"]
 TS590_MODES = ["LSB", "USB", "CW", "FM", "AM", "FSK", "CW-R",
                "FSK-R", "Data+LSB", "Data+USB", "Data+FM"]
 EX_MODES = ["FSK-R", "CW-R", "Data+LSB", "Data+USB", "Data+FM"]
-for ix in EX_MODES:
-    if ix not in chirp_common.MODES:
-        chirp_common.MODES.append(ix)
 
 TS590_TONES = list(chirp_common.TONES)
 TS590_TONES.append(1750.0)

--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -711,7 +711,7 @@ UV5R_POWER_LEVELS3 = [chirp_common.PowerLevel("High", watts=8.00),
                       chirp_common.PowerLevel("Med",  watts=4.00),
                       chirp_common.PowerLevel("Low",  watts=1.00)]
 
-UV5R_DTCS = sorted(chirp_common.DTCS_CODES + [645])
+UV5R_DTCS = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
 
 UV5R_CHARSET = chirp_common.CHARSET_UPPER_NUMERIC + \
     "!@#$%^&*()+-=[]:\";'<>?,./"

--- a/chirp/drivers/uv5x3.py
+++ b/chirp/drivers/uv5x3.py
@@ -130,7 +130,7 @@ class UV5X3(baofeng_common.BaofengCommonHT):
         "!@#$%^&*()+-=[]:\";'<>?,./"
     LENGTH_NAME = 7
     SKIP_VALUES = ["", "S"]
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=5.00),
                     chirp_common.PowerLevel("Low", watts=1.00)]
     VALID_BANDS = [(130000000, 180000000),

--- a/chirp/drivers/uv6r.py
+++ b/chirp/drivers/uv6r.py
@@ -119,7 +119,7 @@ class UV6R(baofeng_common.BaofengCommonHT):
         "!@#$%^&*()+-=[]:\";'<>?,./"
     LENGTH_NAME = 7  # older radios may only support 6 character names
     SKIP_VALUES = ["", "S"]
-    DTCS_CODES = sorted(chirp_common.DTCS_CODES + [645])
+    DTCS_CODES = tuple(sorted(chirp_common.DTCS_CODES + (645,)))
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=5.00),
                     chirp_common.PowerLevel("Low", watts=1.00)]
     VALID_BANDS = [(136000000, 174000000),

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -310,8 +310,9 @@ class ChirpChoiceColumn(ChirpMemoryColumn):
 
 class ChirpToneColumn(ChirpChoiceColumn):
     def __init__(self, name, radio):
-        tones = [str(x) for x in chirp_common.TONES]
         self.rf = radio.get_features()
+        tones = self.rf.valid_tones or chirp_common.TONES
+        tones = [str(x) for x in tones]
         super(ChirpToneColumn, self).__init__(name, radio,
                                               tones)
 
@@ -383,7 +384,9 @@ class ChirpDuplexColumn(ChirpChoiceColumn):
 
 class ChirpDTCSColumn(ChirpChoiceColumn):
     def __init__(self, name, radio):
-        dtcs_codes = ['%03i' % code for code in chirp_common.DTCS_CODES]
+        rf = radio.get_features()
+        codes = rf.valid_dtcs_codes or chirp_common.DTCS_CODES
+        dtcs_codes = ['%03i' % code for code in codes]
         super(ChirpDTCSColumn, self).__init__(name, radio,
                                               dtcs_codes)
 


### PR DESCRIPTION
This makes several of our master lists of things immutable by making
them tuplex instead of lists. This will help to avoid accidental (or
intentional) modification of those lists. As it turns out, the
ft450 and ts580 drivers were doing this, so this removes that
mutilation from those drivers. That means they are a little broken
now for memories with those modes, but those drivers are broken for
python3 anyway.

The rest of the drivers changed here just needed some minimal tweakage
to use tuples when adding things to the base lists.

This also (necessarily) simplifies the RadioFeatures type checking,
which relied on special behaviors for tuples.
