### PR TITLE
Trivial typo in FT-60 settings menu

### DIFF
--- a/chirp/drivers/ft60.py
+++ b/chirp/drivers/ft60.py
@@ -579,7 +579,7 @@ class FT60Radio(yaesu_clone.YaesuCloneModeRadio):
 
         # LOCK
         opts = ["LK KEY", "LKDIAL", "LK K+D", "LK PTT",
-                "LP P+K", "LK P+D", "LK ALL"]
+                "LK P+K", "LK P+D", "LK ALL"]
         rs = RadioSetting("lock", "Control Locking",
                           RadioSettingValueList(
                               opts, opts[_settings.lock - 1]))


### PR DESCRIPTION
See also page 16 of FT-60R/E Operating Manual.
