### PR TITLE
Make directory honor metadata VARIANT on load

### DIFF
--- a/chirp/directory.py
+++ b/chirp/directory.py
@@ -154,13 +154,15 @@ def get_radio_by_image(image_file):
 
         meta_vendor = metadata.get('vendor')
         meta_model = metadata.get('model')
+        meta_variant = metadata.get('variant')
 
         meta_vendor, meta_model = MODEL_COMPAT.get((meta_vendor, meta_model),
                                                    (meta_vendor, meta_model))
 
         # If metadata, then it has to match one of the aliases or the parent
         for alias in rclass.ALIASES + [rclass]:
-            if (alias.VENDOR == meta_vendor and alias.MODEL == meta_model):
+            if (alias.VENDOR == meta_vendor and alias.MODEL == meta_model and
+                    (meta_variant is None or alias.VARIANT == meta_variant)):
 
                 class DynamicRadioAlias(rclass):
                     _orig_rclass = rclass


### PR DESCRIPTION
The metadata-based file identification has ignored VARIANT so far,
but not for any good reason. This makes us load and match the
variant on a radio class, if present, so that we can distinguish
between files intended for each.
