### PR TITLE
GMRS-50V2: tolerate factory out-of-band vfo frequencies - fixes #10408

### DIFF
--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -2061,6 +2061,9 @@ class BTechMobileCommon(chirp_common.CloneModeRadio,
                 obj.freq[i] = value % 10
                 value /= 10
 
+        _vhf_upper = (convert_bytes_to_limit(_ranges.vhf_high))
+        _uhf_lower = (convert_bytes_to_limit(_ranges.uhf_low))
+
         val1a = RadioSettingValueString(0, 10, convert_bytes_to_freq(
                                         _mem.vfo.a.freq))
         val1a.set_validate_callback(my_validate)
@@ -2068,8 +2071,11 @@ class BTechMobileCommon(chirp_common.CloneModeRadio,
         vfoafreq.set_apply_callback(apply_freq, _mem.vfo.a)
         work.append(vfoafreq)
 
-        val1b = RadioSettingValueString(0, 10, convert_bytes_to_freq(
-                                        _mem.vfo.b.freq))
+        val = convert_bytes_to_freq(_mem.vfo.b.freq)
+        if self.MODEL in ["GMRS-50V2", "GMRS-50X1"]:
+            if val[:3] > _vhf_upper and val[:3] < _uhf_lower:
+                val = "462.562500"
+        val1b = RadioSettingValueString(0, 10, val)
         val1b.set_validate_callback(my_validate)
         vfobfreq = RadioSetting("vfo.b.freq", "VFO B frequency", val1b)
         vfobfreq.set_apply_callback(apply_freq, _mem.vfo.b)
@@ -2084,8 +2090,11 @@ class BTechMobileCommon(chirp_common.CloneModeRadio,
             work.append(vfocfreq)
 
             if not self.COLOR_LCD4:
-                val1d = RadioSettingValueString(0, 10, convert_bytes_to_freq(
-                                                _mem.vfo.d.freq))
+                val = convert_bytes_to_freq(_mem.vfo.d.freq)
+                if self.MODEL in ["GMRS-50V2", "GMRS-50X1"]:
+                    if val[:3] > _vhf_upper and val[:3] < _uhf_lower:
+                        val = "462.562500"
+                val1d = RadioSettingValueString(0, 10, val)
                 val1d.set_validate_callback(my_validate)
                 vfodfreq = RadioSetting("vfo.d.freq", "VFO D frequency", val1d)
                 vfodfreq.set_apply_callback(apply_freq, _mem.vfo.d)


### PR DESCRIPTION
This patch has CHIRP automatically switch the out-of-band frequencies that the factory accidentally left in VFO B and VFO D to in-band frequencies (462.562500).

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
