### PR TITLE
th_uv88.py: fix 'Can't modify channels 192-194' - fixes #10383

### DIFF
--- a/chirp/drivers/th_uv88.py
+++ b/chirp/drivers/th_uv88.py
@@ -52,7 +52,8 @@ struct chns {
        unk5:2;
   u8   unk6:2
        pttid:2
-       step:4;               // not required
+       unk7:1
+       step:3;               // not required
   u8   name[6];
 };
 
@@ -681,15 +682,15 @@ class THUV88Radio(chirp_common.CloneModeRadio):
         mem.mode = self.MODES[_mem.wide]
         mem.power = POWER_LEVELS[int(_mem.power)]
 
-        b_lock = RadioSetting("b_lock", "B_Lock",
-                              RadioSettingValueList(B_LOCK_LIST,
-                                                    B_LOCK_LIST[_mem.b_lock]))
+        rs = RadioSettingValueList(B_LOCK_LIST,
+                                   B_LOCK_LIST[min(_mem.b_lock, 0x02)])
+        b_lock = RadioSetting("b_lock", "B_Lock", rs)
         mem.extra.append(b_lock)
 
-        b_lock = RadioSetting("step", "Step",
-                              RadioSettingValueList(LIST_STEPS,
-                                                    LIST_STEPS[_mem.step]))
-        mem.extra.append(b_lock)
+        step = RadioSetting("step", "Step",
+                            RadioSettingValueList(LIST_STEPS,
+                                                  LIST_STEPS[_mem.step]))
+        mem.extra.append(step)
 
         scramble_value = _mem.scramble
         if scramble_value >= 8:     # Looks like OFF is 0x0f ** CONFIRM


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
