### PR TITLE
th_uv88.py: fix 'Scan Type in wrong order" - fixes #10419

### DIFF
--- a/chirp/drivers/th_uv88.py
+++ b/chirp/drivers/th_uv88.py
@@ -868,7 +868,7 @@ class THUV88Radio(chirp_common.CloneModeRadio):
         if self.MODEL == "QRZ-1":
             options = ["Time", "Carrier", "Stop"]
         else:
-            options = ["CO", "TO", "SE"]
+            options = ["TO", "CO", "SE"]
         rx = RadioSettingValueList(options, options[_settings.scanType])
         rset = RadioSetting("basicsettings.scanType", "Scan Type", rx)
         basic.append(rset)


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
