### PR TITLE
Move alinco delays to earlier in the loop

### DIFF
--- a/chirp/drivers/alinco.py
+++ b/chirp/drivers/alinco.py
@@ -121,8 +121,8 @@ class AlincoStyleRadio(chirp_common.CloneModeRadio):
 
         data = b""
         for addr in range(0, limit, 16):
-            data += self._download_chunk(addr)
             time.sleep(0.1)
+            data += self._download_chunk(addr)
 
             if self.status_fn:
                 status = chirp_common.Status()
@@ -161,8 +161,8 @@ class AlincoStyleRadio(chirp_common.CloneModeRadio):
             raise Exception("I can't talk to this model")
 
         for addr in range(0x100, limit, 16):
-            self._upload_chunk(addr)
             time.sleep(0.1)
+            self._upload_chunk(addr)
 
             if self.status_fn:
                 status = chirp_common.Status()


### PR DESCRIPTION
The alinco radios are very sensitive to replying too quickly after
a response. We currently delay late in the loop to avoid requesting
blocks too quickly. However it seems like -next (probably due to
python 3.10 perf improvements) is too quick on the first block
request after the ident response. So this moves the delay to the top
of the loop so we get it after the ident, and after each block.

Fixes #10414
