### PR TITLE
Attempt to catch illegal set_memory() behavior

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -1151,7 +1151,17 @@ class Radio(Alias):
         self.pipe = pipe
 
     def get_memory(self, number):
-        """Return a Memory object for the memory at location @number"""
+        """Return a Memory object for the memory at location @number
+
+        Constructs and returns a generic Memory object for the given location
+        in the radio's memory. The memory should accurately represent what is
+        actually stored in the radio as closely as possible. If the radio
+        does not support changing some attributes of the location in question,
+        the Memory.immutable list should be set approproately.
+
+        NB: No changes to the radio's memory should occur as a result of
+        calling get_memory().
+        """
         pass
 
     def erase_memory(self, number):
@@ -1166,7 +1176,16 @@ class Radio(Alias):
         pass
 
     def set_memory(self, memory):
-        """Set the memory object @memory"""
+        """Set the memory object @memory
+
+        This method should copy generic attributes from @memory to the
+        radio's memory. It should not modify @memory and it should reproduce
+        the generic attributes on @memory in the radio's memory as faithfully
+        as the radio allows. Attributes that can't be copied exactly should
+        be warned in validate_memory() with ValidationWarnings if a
+        substitution will be made, or ValidationError if truly incompatible.
+        In the latter case, set_memory() will not be called.
+        """
         pass
 
     def get_mapping_models(self):

--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -283,6 +283,7 @@ class CSVRadio(chirp_common.FileBackedRadio):
             self.memories.append(mem)
 
     def set_memory(self, newmem):
+        newmem = newmem.dupe()
         if newmem.power is None:
             newmem.power = DEFAULT_POWER_LEVEL
         else:
@@ -291,7 +292,7 @@ class CSVRadio(chirp_common.FileBackedRadio):
             newmem.power = chirp_common.AutoNamedPowerLevel(
                 chirp_common.dBm_to_watts(float(newmem.power)))
         self._grow(newmem.number)
-        self.memories[newmem.number] = newmem.dupe()
+        self.memories[newmem.number] = newmem
         self.memories[newmem.number].name = newmem.name.rstrip()
 
     def erase_memory(self, number):

--- a/chirp/drivers/puxing_px888k.py
+++ b/chirp/drivers/puxing_px888k.py
@@ -1227,7 +1227,6 @@ class Puxing_PX888K_Radio(chirp_common.CloneModeRadio):
             isregular, isvfo, iscall) = self._get_memory_structs(number)
 
         mem.number = index
-        mem.extd_number = designator
 
         # handle empty channels
         if isregular:
@@ -1242,6 +1241,7 @@ class Puxing_PX888K_Radio(chirp_common.CloneModeRadio):
         else:
             mem.empty = False
             mem.name = ''
+            mem.extd_number = designator
 
         # get frequency data
         mem.freq = int(_data.rx_freq)*10
@@ -1376,8 +1376,6 @@ class Puxing_PX888K_Radio(chirp_common.CloneModeRadio):
         (index, designator,
          _data, _name, _present, _priority,
          isregular, isvfo, iscall) = self._get_memory_structs(mem.number)
-        mem.number = index
-        mem.extd_number = designator
 
         # handle empty channels
         if mem.empty:

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -730,7 +730,9 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
                 else:
                     extra_cb(job)
 
-        self.do_radio(set_cb, 'set_memory', mem)
+        # Use a FrozenMemory for the actual set to catch potential attempts
+        # to modify the memory during set_memory().
+        self.do_radio(set_cb, 'set_memory', chirp_common.FrozenMemory(mem))
 
     def erase_memory(self, number, refresh=True):
         """Erase a memory in the radio and refresh our view on success"""

--- a/tests/test_brute_force.py
+++ b/tests/test_brute_force.py
@@ -16,7 +16,7 @@ class TestCaseBruteForce(base.DriverTest):
             # store, don't fail
             return
 
-        self.radio.set_memory(m)
+        self.radio.set_memory(chirp_common.FrozenMemory(m))
         ret_m = self.radio.get_memory(m.number)
 
         # Damned Baofeng radios don't seem to properly store

--- a/tools/check_commit.sh
+++ b/tools/check_commit.sh
@@ -41,7 +41,7 @@ if grep -E 'MemoryMap\(' added_lines; then
     fail New uses of MemoryMap should be MemoryMapBytes
 fi
 
-if grep -E "_\([^\"']" added_lines; then
+if grep -E "[^_]_\([^\"']" added_lines; then
     fail 'Translated strings must be literals!'
 fi
 


### PR DESCRIPTION
It has become apparent that some radios are making changes to the
Memory during set_memory(). That is not technically harmful, but
may indicate an attempt to change something of what the user provided,
or to reflect changes back to the user which will never be seen.

For now, define a FrozenMemory object that just logs this problem and
use that when setting memories from the UI. In the future, this should
turn into an error.
