### PR TITLE
uv5r.py: allow full-band programming support for UV-5G - fixes #10444

### DIFF
--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -748,7 +748,6 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
     _uhf_range = (400000000, 520000000)
     _aux_block = True
     _tri_power = False
-    _gmrs = False
     _bw_shift = False
     _mem_params = (0x1828  # poweron_msg offset
                    )
@@ -985,33 +984,6 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
 
         immutable = []
 
-        if self._gmrs:
-            if mem.number >= 1 and mem.number <= 30:
-                GMRS_FREQ = GMRS_FREQS[mem.number - 1]
-                mem.freq = GMRS_FREQ
-                immutable = ["empty", "freq"]
-            if mem.number >= 1 and mem.number <= 7:
-                mem.duplex == ''
-                mem.offset = 0
-                immutable += ["duplex", "offset"]
-            elif mem.number >= 8 and mem.number <= 14:
-                mem.duplex == ''
-                mem.offset = 0
-                mem.mode = "NFM"
-                mem.power = UV5R_POWER_LEVELS[1]
-                immutable += ["duplex", "offset", "mode", "power"]
-            elif mem.number >= 15 and mem.number <= 22:
-                mem.duplex == ''
-                mem.offset = 0
-                immutable += ["duplex", "offset"]
-            elif mem.number >= 23 and mem.number <= 30:
-                mem.duplex == '+'
-                mem.offset = 5000000
-                immutable += ["duplex", "offset"]
-            else:
-                mem.duplex = 'off'
-                mem.offset = 0
-                immutable = ["duplex", "offset"]
         if self.MODEL == "GT-5R":
             if not ((mem.freq >= self.vhftx[0] and mem.freq < self.vhftx[1]) or
                     (mem.freq >= self.uhftx[0] and mem.freq < self.uhftx[1])):
@@ -2118,23 +2090,6 @@ class RadioddityUV5GRadio(BaofengUV5R):
 
     _basetype = BASETYPE_UV5R
     _idents = [UV5R_MODEL_UV5G]
-    _gmrs = True
-
-    def validate_memory(self, mem):
-        msgs = super().validate_memory(mem)
-
-        _msg_duplex = 'Duplex must be "off" for this frequency'
-        _msg_offset = 'Only simplex or +5MHz offset allowed on GMRS'
-
-        if not (mem.number >= 1 and mem.number <= 30):
-            if mem.duplex != "off":
-                msgs.append(chirp_common.ValidationWarning(_msg_duplex))
-
-        return msgs
-
-    def check_set_memory_immutable_policy(self, existing, new):
-        existing.immutable = []
-        super().check_set_memory_immutable_policy(existing, new)
 
     @classmethod
     def match_model(cls, filename, filedata):

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -750,7 +750,6 @@ class TestOverrideRules(base.BaseTest):
         'BTECH_GMRS-V2',
         'BTECH_MURS-V2',
         'Radioddity_DB25-G',
-        'Radioddity_UV-5G',
         'Retevis_RA85',
         'Retevis_RA685',
         'Retevis_RB17P',


### PR DESCRIPTION
The UV-5G (aka UV-5X) GMRS radios are preset from the factory (and after a RESET) with 30 GMRS channels and 11 NOAA WX radio channels. The programmed channels are not firmware locked from being changed or erased, TX is not firmware blocked for unsanctioned frequencies. In respect to channel programming, they are essentially the same as any common UV-5R (136-174 MHz & 400-520 MHz and TX/RX on all 128 channels).

This patch gives CHIRP the ability to match the radio's factory provided programming capability.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
