### PR TITLE
Add py3 test matrix entries for new ga510 models

### DIFF
--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -19,7 +19,7 @@
 | <a name="AnyTone_778UV_VOX"></a> AnyTone_778UV_VOX | [Implied by Retevis_RT95](#user-content-Retevis_RT95) | 13-Nov-2022 | Yes | 0.23% |
 | <a name="AnyTone_OBLTR-8R"></a> AnyTone_OBLTR-8R | [@KC9HI](https://github.com/KC9HI) | 17-Dec-2022 | Yes | 0.02% |
 | <a name="AnyTone_TERMN-8R"></a> AnyTone_TERMN-8R | [@KC9HI](https://github.com/KC9HI) | 17-Dec-2022 | Yes | 0.02% |
-| <a name="Anysecu_AC-580"></a> Anysecu_AC-580 |  |  | Yes |  |
+| <a name="Anysecu_AC-580"></a> Anysecu_AC-580 | [Implied by Radioddity_GS-5B](#user-content-Radioddity_GS-5B) | 17-Mar-2023 | Yes |  |
 | <a name="Anysecu_WP-9900"></a> Anysecu_WP-9900 | [@KC9HI](https://github.com/KC9HI) | 11-Nov-2022 | Yes | 0.03% |
 | <a name="BTECH_FRS-A1"></a> BTECH_FRS-A1 | [@KC9HI](https://github.com/KC9HI) | 30-Nov-2022 | Yes | 0.01% |
 | <a name="BTECH_FRS-B1"></a> BTECH_FRS-B1 | [@KC9HI](https://github.com/KC9HI) | 28-Nov-2022 | Yes | 0.04% |
@@ -231,7 +231,7 @@
 | <a name="Radioddity_DB25-G"></a> Radioddity_DB25-G | [@KC9HI](https://github.com/KC9HI) | 11-Nov-2022 | Yes | 0.17% |
 | <a name="Radioddity_GA-2S"></a> Radioddity_GA-2S | [@KC9HI](https://github.com/KC9HI) | 4-Dec-2022 | Yes | 0.19% |
 | <a name="Radioddity_GA-510"></a> Radioddity_GA-510 | [@kk7ds](https://github.com/kk7ds) | 21-Oct-2022 | Yes | 0.42% |
-| <a name="Radioddity_GS-5B"></a> Radioddity_GS-5B |  |  | Yes |  |
+| <a name="Radioddity_GS-5B"></a> Radioddity_GS-5B | [@lunapiercook](https://github.com/lunapiercook) | 5-Mar-2023 | Yes |  |
 | <a name="Radioddity_R2"></a> Radioddity_R2 | [@KC9HI](https://github.com/KC9HI) | 17-Dec-2022 | Yes | 0.04% |
 | <a name="Radioddity_UV-5G"></a> Radioddity_UV-5G | [@KC9HI](https://github.com/KC9HI) | 18-Nov-2022 | Yes | 0.47% |
 | <a name="Radioddity_UV-5RX3"></a> Radioddity_UV-5RX3 | [@KC9HI](https://github.com/KC9HI) | 18-Nov-2022 | Yes | 0.90% |
@@ -304,8 +304,8 @@
 | <a name="Retevis_RT98"></a> Retevis_RT98 | [@KC9HI](https://github.com/KC9HI) | 14-Dec-2022 | Yes | 0.05% |
 | <a name="Rugged_RH5R-V2"></a> Rugged_RH5R-V2 |  |  |  | 0.05% |
 | <a name="Sainsonic_AP510"></a> Sainsonic_AP510 |  |  |  | 0.00% |
-| <a name="SenhaiX_8800"></a> SenhaiX_8800 |  |  | Yes |  |
-| <a name="Signus_XTR-5"></a> Signus_XTR-5 |  |  | Yes |  |
+| <a name="SenhaiX_8800"></a> SenhaiX_8800 | [Implied by Radioddity_GS-5B](#user-content-Radioddity_GS-5B) | 17-Mar-2023 | Yes |  |
+| <a name="Signus_XTR-5"></a> Signus_XTR-5 | [Implied by Radioddity_GS-5B](#user-content-Radioddity_GS-5B) | 17-Mar-2023 | Yes |  |
 | <a name="TDXone_TD-Q8A"></a> TDXone_TD-Q8A | [@KC9HI](https://github.com/KC9HI) | 18-Dec-2022 |  | 0.02% |
 | <a name="TIDRADIO_TD-H6"></a> TIDRADIO_TD-H6 | [@kk7ds](https://github.com/kk7ds) | 21-Oct-2022 | Yes | 0.43% |
 | <a name="TIDRADIO_TD-H8"></a> TIDRADIO_TD-H8 | [@Sandmann34](https://github.com/Sandmann34) | 7-Feb-2023 | Yes |  |
@@ -399,7 +399,7 @@
 
 **Drivers:** 394
 
-**Tested:** 83% (329/65) (93% of usage stats)
+**Tested:** 84% (333/61) (93% of usage stats)
 
 **Byte clean:** 89% (352/42)
 

--- a/tests/py3_driver_testers.txt
+++ b/tests/py3_driver_testers.txt
@@ -19,6 +19,7 @@ Alinco_DR135T,+Alinco_DR235T,12-Dec-2022
 Alinco_DR235T,@kk7ds,12-Dec-2022
 Alinco_DR435T,+Alinco_DR235T,12-Dec-2022
 Anysecu_WP-9900,@KC9HI,11-Nov-2022
+Anysecu_AC-580,+Radioddity_GS-5B,17-Mar-2023
 AnyTone_778UV,+Retevis_RT95,13-Nov-2022
 AnyTone_778UV_VOX,+Retevis_RT95,13-Nov-2022
 AnyTone_5888UV,@kk7ds,9-Dec-2022
@@ -198,6 +199,7 @@ QYT_KT980PLUS,+BTECH_UV-25X2,11-Nov-2022
 Radioddity_DB25-G,@KC9HI,11-Nov-2022
 Radioddity_GA-2S,@KC9HI,4-Dec-2022
 Radioddity_GA-510,@kk7ds,21-Oct-2022
+Radioddity_GS-5B,@lunapiercook,5-Mar-2023
 Radioddity_R2,@KC9HI,17-Dec-2022
 Radioddity_UV-5G,@KC9HI,18-Nov-2022
 Radioddity_UV-5RX3,@KC9HI,18-Nov-2022
@@ -268,6 +270,8 @@ Retevis_RT9000D_136-174,@KC9HI,8-Dec-2022
 Retevis_RT9000D_220-260,@KC9HI,8-Dec-2022
 Retevis_RT9000D_400-490,@KC9HI,8-Dec-2022
 Retevis_RT9000D_66-88,@KC9HI,8-Dec-2022
+SenhaiX_8800,+Radioddity_GS-5B,17-Mar-2023
+Signus_XTR-5,+Radioddity_GS-5B,17-Mar-2023
 TDXone_TD-Q8A,@KC9HI,18-Dec-2022
 TIDRADIO_TD-H6,@kk7ds,21-Oct-2022
 TIDRADIO_TD-H8,@Sandmann34,7-Feb-2023


### PR DESCRIPTION
This was missed in the patch to add these models.
