### PR TITLE
Use a PEP440/PEP508 compatible version to avoid errors on recent versions of setuptools

### DIFF
--- a/chirp/__init__.py
+++ b/chirp/__init__.py
@@ -17,7 +17,7 @@ import os
 import sys
 from glob import glob
 
-CHIRP_VERSION = "py3dev"
+CHIRP_VERSION = "1.0.0"
 
 module_dir = os.path.dirname(sys.modules["chirp"].__file__)
 __all__ = []


### PR DESCRIPTION
[Setuptools 67.0.0](https://setuptools.pypa.io/en/stable/history.html#v67-0-0) introduces some breaking changes which prevent chirp from installing.

Because chirp uses `pydev3` as a version placeholder, this aborts the installation process because the version is invalid.

Opening this as a PR with a dummy `1.0.0` version since issues are disabled on the project (it fixes the build, but I'm not sure how you want to handle versioning)

