### PR TITLE
Rename Signus to Cignus for XTR-5

### DIFF
--- a/chirp/directory.py
+++ b/chirp/directory.py
@@ -114,6 +114,7 @@ def get_driver(rclass):
 MODEL_COMPAT = {
     ('Retevis', 'RT-5R'): ('Retevis', 'RT5R'),
     ('Retevis', 'RT-5RV'): ('Retevis', 'RT5RV'),
+    ('Signus', 'XTR-5'): ('Cignus', 'XTR-5'),
 }
 
 

--- a/chirp/drivers/ga510.py
+++ b/chirp/drivers/ga510.py
@@ -1103,10 +1103,11 @@ class RadioddityGS5BRadio(Senhaix8800Radio):
     MODEL = "GS-5B"
 
 
+# NOTE: This was added as Signus originally in 18295675
 @directory.register
-class SignusXTR5Radio(Senhaix8800Radio):
-    """Signus XTR-5"""
-    VENDOR = "Signus"
+class CignusXTR5Radio(Senhaix8800Radio):
+    """Cignus XTR-5"""
+    VENDOR = "Cignus"
     MODEL = "XTR-5"
 
 

--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -66,6 +66,7 @@
 | <a name="Boblov_X3Plus"></a> Boblov_X3Plus |  |  |  | 0.02% |
 | <a name="CRT_Micron_UV"></a> CRT_Micron_UV | [Implied by Retevis_RT95](#user-content-Retevis_RT95) | 13-Nov-2022 | Yes | 0.08% |
 | <a name="CRT_Micron_UV_V2"></a> CRT_Micron_UV_V2 | [Implied by Retevis_RT95](#user-content-Retevis_RT95) | 13-Nov-2022 | Yes | 0.10% |
+| <a name="Cignus_XTR-5"></a> Cignus_XTR-5 | [Implied by Radioddity_GS-5B](#user-content-Radioddity_GS-5B) | 17-Mar-2023 | Yes |  |
 | <a name="Commander_KG-UV"></a> Commander_KG-UV |  |  |  | 0.00% |
 | <a name="Explorer_QRZ-1"></a> Explorer_QRZ-1 | [Implied by TYT_TH-UV88](#user-content-TYT_TH-UV88) | 5-Dec-2022 | Yes | 0.04% |
 | <a name="Feidaxin_FD-150A"></a> Feidaxin_FD-150A |  |  |  | 0.02% |
@@ -306,7 +307,6 @@
 | <a name="Ruyage_UV58Plus"></a> Ruyage_UV58Plus | [@KC9HI](https://github.com/KC9HI) | 18-Mar-2023 | Yes |  |
 | <a name="Sainsonic_AP510"></a> Sainsonic_AP510 |  |  |  | 0.00% |
 | <a name="SenhaiX_8800"></a> SenhaiX_8800 | [Implied by Radioddity_GS-5B](#user-content-Radioddity_GS-5B) | 17-Mar-2023 | Yes |  |
-| <a name="Signus_XTR-5"></a> Signus_XTR-5 | [Implied by Radioddity_GS-5B](#user-content-Radioddity_GS-5B) | 17-Mar-2023 | Yes |  |
 | <a name="TDXone_TD-Q8A"></a> TDXone_TD-Q8A | [@KC9HI](https://github.com/KC9HI) | 18-Dec-2022 |  | 0.02% |
 | <a name="TIDRADIO_TD-H6"></a> TIDRADIO_TD-H6 | [@kk7ds](https://github.com/kk7ds) | 21-Oct-2022 | Yes | 0.43% |
 | <a name="TIDRADIO_TD-H8"></a> TIDRADIO_TD-H8 | [@Sandmann34](https://github.com/Sandmann34) | 7-Feb-2023 | Yes |  |

--- a/tests/py3_driver_testers.txt
+++ b/tests/py3_driver_testers.txt
@@ -66,6 +66,7 @@ Baofeng_UV-9R,@KC9HI,3-Dec-2022
 Baofeng_UV-B5,@KC9HI,18-Nov-2022
 Baojie_BJ-218,+LUITON_LT-725UV,16-Feb-2023
 Baojie_BJ-318,@KC9HI,2-Jan-2023
+Cignus_XTR-5,+Radioddity_GS-5B,17-Mar-2023
 CRT_Micron_UV,+Retevis_RT95,13-Nov-2022
 CRT_Micron_UV_V2,+Retevis_RT95,13-Nov-2022
 Explorer_QRZ-1,+TYT_TH-UV88,5-Dec-2022
@@ -272,7 +273,6 @@ Retevis_RT9000D_400-490,@KC9HI,8-Dec-2022
 Retevis_RT9000D_66-88,@KC9HI,8-Dec-2022
 Ruyage_UV58Plus,@KC9HI,18-Mar-2023
 SenhaiX_8800,+Radioddity_GS-5B,17-Mar-2023
-Signus_XTR-5,+Radioddity_GS-5B,17-Mar-2023
 TDXone_TD-Q8A,@KC9HI,18-Dec-2022
 TIDRADIO_TD-H6,@kk7ds,21-Oct-2022
 TIDRADIO_TD-H8,@Sandmann34,7-Feb-2023


### PR DESCRIPTION
This was added under the wrong vendor name in 18295675. A compat
mapping entry is added to avoid breaking exiting images.

Related to #7997
