### PR TITLE
Update KG-UV9PX manual channel entry

### DIFF
--- a/chirp/drivers/kguv9dplus.py
+++ b/chirp/drivers/kguv9dplus.py
@@ -127,6 +127,7 @@ config_map2 = (          # map address, write size, write count
 
 MEM_VALID = 0xfc
 MEM_INVALID = 0xff
+VALID_MEM_VALUES = [MEM_VALID, 0x00, 0x02, 0x40, 0x3D]
 
 # Radio memory map. This matches the reads/writes above.
 # structure elements whose name starts with x are currently unidentified
@@ -1420,8 +1421,7 @@ class KGUV9DPlusRadio(chirp_common.CloneModeRadio,
         if _valid == MEM_INVALID and _mem.rxfreq != 0xFFFFFFFF and _nam != '':
             _valid = MEM_VALID
 
-        if (_valid != MEM_VALID and _valid != 0 and _valid != 2 and
-           _valid != 0x40 and _valid != 0x3D):
+        if _valid not in VALID_MEM_VALUES:
             # In Issue #6995 we can find _valid values of 0 and 2 in the IMG
             # so these values should be treated like MEM_VALID.
             # state value of 0x40 found in deleted memory - still shows in CPS

--- a/chirp/drivers/kguv9dplus.py
+++ b/chirp/drivers/kguv9dplus.py
@@ -1421,7 +1421,7 @@ class KGUV9DPlusRadio(chirp_common.CloneModeRadio,
             _valid = MEM_VALID
 
         if (_valid != MEM_VALID and _valid != 0 and _valid != 2 and
-           _valid != 0x40):
+           _valid != 0x40 and _valid != 0x3D):
             # In Issue #6995 we can find _valid values of 0 and 2 in the IMG
             # so these values should be treated like MEM_VALID.
             # state value of 0x40 found in deleted memory - still shows in CPS


### PR DESCRIPTION
Fixes: #10461

Update driver to accept a newly found value as for a valid memory location.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
