### PR TITLE
UV-5R read_block: read requested size from the pipe, not hardcoded 0x40

### DIFF
--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -488,7 +488,7 @@ def _read_block(radio, start, size, first_command=False):
         LOG.debug("CMD: %s  ADDR: %04x  SIZE: %02x" % (cmd, addr, length))
         raise errors.RadioError("Unknown response from radio")
 
-    chunk = radio.pipe.read(0x40)
+    chunk = radio.pipe.read(size)
     if not chunk:
         raise errors.RadioError("Radio did not send block 0x%04x" % start)
     elif len(chunk) != size:


### PR DESCRIPTION
Small clean-up I noticed while working through the UV-5R code. The `_read_block` function is currently only ever called with a size value of 0x40, so functionally this will not make any difference, but it may prevent some future frustration and debugging if it is ever called with a different value. I may also just misunderstand the protocol here if the chunk size must always be 0x40 (or at most 0x40); just let me know if that is the case.