### PR TITLE
Fix updating repeaterbook cache on windows

### DIFF
--- a/chirp/sources/repeaterbook.py
+++ b/chirp/sources/repeaterbook.py
@@ -147,7 +147,12 @@ class RepeaterBook(base.NetworkResultRadio):
             return
 
         if results['count']:
-            os.rename(tmp, data_file)
+            try:
+                os.rename(tmp, data_file)
+            except FileExistsError:
+                # Windows can't do atomic rename
+                os.remove(data_file)
+                os.rename(tmp, data_file)
         else:
             os.remove(tmp)
             status.send_fail('No results!')


### PR DESCRIPTION
Apparently windows can't do atomic rename, which means we have to
remove and rename (and hope we don't fail in between).

Fixes #10479
