### PR TITLE
Fix ICF drivers with bytes endframes

### DIFF
--- a/chirp/drivers/icf.py
+++ b/chirp/drivers/icf.py
@@ -844,7 +844,7 @@ class IcomCloneModeRadio(chirp_common.CloneModeRadio):
 
     def get_endframe(self):
         """Returns the magic clone end frame for this radio"""
-        return bytes([ord(x) for x in self._endframe])
+        return bytes([util.byte_to_int(x) for x in self._endframe])
 
     def get_ranges(self):
         """Returns the ranges this radio likes to have in a clone"""


### PR DESCRIPTION
THese really should all be converted to bytes, but apparently only
the ID51plus2 was that way and get_endframe() didn't handle it.

Fixes #10495
