### PR TITLE
Add separate flag for WANTS_DTR

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -1119,7 +1119,10 @@ class Alias(object):
 class Radio(Alias):
     """Base class for all Radio drivers"""
     BAUD_RATE = 9600
+    # Whether or not we should assert RTS (and use RTS/CTS flow control)
     HARDWARE_FLOW = False
+    # Whether or not we should assert DTR when opening the serial port
+    WANTS_DTR = True
     ALIASES = []
     NEEDS_COMPAT_SERIAL = True
     FORMATS = []

--- a/chirp/wxui/clone.py
+++ b/chirp/wxui/clone.py
@@ -124,14 +124,14 @@ def open_serial(port, rclass):
         pipe = serial.serial_for_url(port, do_not_open=True)
         pipe.timeout = 0.25
         pipe.rts = rclass.HARDWARE_FLOW
-        pipe.dtr = False
+        pipe.dtr = rclass.WANTS_DTR
         pipe.open()
         pipe.baudrate = rclass.BAUD_RATE
     else:
         pipe = serial.Serial(baudrate=rclass.BAUD_RATE,
                              rtscts=rclass.HARDWARE_FLOW, timeout=0.25)
         pipe.rts = rclass.HARDWARE_FLOW
-        pipe.dtr = False
+        pipe.dtr = rclass.WANTS_DTR
         pipe.port = port
         pipe.open()
 


### PR DESCRIPTION
In #10510 I fixed a problem stemming from a bug in python-serial where
we ask for no RTS/CTS but get it anyway. That also forced DTR to be
de-asserted, which _is_ the default in the python-serial API as well,
but isn't what we've been running with since probably forever. Since
there are some cables that require DTR for level-converter power,
this defaults DTR back to asserted by default, but with a radio class
flag to allow it to be disabled if need-be.

Fixes #10515
