### PR TITLE
Revert to RTS signaling by default

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -1120,7 +1120,7 @@ class Radio(Alias):
     """Base class for all Radio drivers"""
     BAUD_RATE = 9600
     # Whether or not we should assert RTS (and use RTS/CTS flow control)
-    HARDWARE_FLOW = False
+    HARDWARE_FLOW = True
     # Whether or not we should assert DTR when opening the serial port
     WANTS_DTR = True
     ALIASES = []

--- a/chirp/drivers/icomciv.py
+++ b/chirp/drivers/icomciv.py
@@ -338,6 +338,8 @@ class IcomCIVRadio(icf.IcomLiveRadio):
     BAUD_RATE = 19200
     NEEDS_COMPAT_SERIAL = False
     MODEL = "CIV Radio"
+    # RTS is interpreted as "transmit now" on some interface boxes for these
+    HARDWARE_FLOW = False
     _model = "\x00"
     _template = 0
 

--- a/chirp/drivers/kenwood_live.py
+++ b/chirp/drivers/kenwood_live.py
@@ -174,6 +174,9 @@ class KenwoodLiveRadio(chirp_common.LiveRadio):
     VENDOR = "Kenwood"
     MODEL = ""
     NEEDS_COMPAT_SERIAL = False
+    # Lots of Kenwood radios actually require RTS, even some of the ones with
+    # USB integrated
+    HARDWARE_FLOW = True
 
     _vfo = 0
     _upper = 200


### PR DESCRIPTION
Since the pyserial bug mentioned in 0b4dc922, we have had RTS enabled
for all radios, even though it wasn't intentional. Turns out quite a
lot of radios require that, and we didn't have them marked as
HARDWARE_FLOW=True because it was already enabled. This reverts
changing the default to False, explicitly enables it for all radios
except for those that don't want it. Also mark the icomciv driver as
disabled explicitly. Mark parent KenwoodLive as wanting hardware flow
explicitly (even though it's the default) since so many of those
require it, in case the default were to change later.

Related to #10515
