### PR TITLE
Split WANTS_RTS and HARDWARE_FLOW

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -1119,10 +1119,12 @@ class Alias(object):
 class Radio(Alias):
     """Base class for all Radio drivers"""
     BAUD_RATE = 9600
-    # Whether or not we should assert RTS (and use RTS/CTS flow control)
-    HARDWARE_FLOW = True
+    # Whether or not we should use RTS/CTS flow control
+    HARDWARE_FLOW = False
     # Whether or not we should assert DTR when opening the serial port
     WANTS_DTR = True
+    # Whether or not we should assert RTS when opening the serial port
+    WANTS_RTS = True
     ALIASES = []
     NEEDS_COMPAT_SERIAL = True
     FORMATS = []

--- a/chirp/drivers/icomciv.py
+++ b/chirp/drivers/icomciv.py
@@ -339,7 +339,7 @@ class IcomCIVRadio(icf.IcomLiveRadio):
     NEEDS_COMPAT_SERIAL = False
     MODEL = "CIV Radio"
     # RTS is interpreted as "transmit now" on some interface boxes for these
-    HARDWARE_FLOW = False
+    WANTS_RTS = False
     _model = "\x00"
     _template = 0
 

--- a/chirp/wxui/clone.py
+++ b/chirp/wxui/clone.py
@@ -123,14 +123,15 @@ def open_serial(port, rclass):
     if '://' in port:
         pipe = serial.serial_for_url(port, do_not_open=True)
         pipe.timeout = 0.25
-        pipe.rts = rclass.HARDWARE_FLOW
+        pipe.rtscts = rclass.HARDWARE_FLOW
+        pipe.rts = rclass.WANTS_RTS
         pipe.dtr = rclass.WANTS_DTR
         pipe.open()
         pipe.baudrate = rclass.BAUD_RATE
     else:
         pipe = serial.Serial(baudrate=rclass.BAUD_RATE,
                              rtscts=rclass.HARDWARE_FLOW, timeout=0.25)
-        pipe.rts = rclass.HARDWARE_FLOW
+        pipe.rts = rclass.WANTS_RTS
         pipe.dtr = rclass.WANTS_DTR
         pipe.port = port
         pipe.open()

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1100,6 +1100,9 @@ class ChirpMain(wx.Frame):
         if not editorset.modified:
             return True
 
+        if isinstance(editorset, ChirpLiveEditorSet):
+            return True
+
         answer = wx.MessageBox(
             _('%s has not been saved. Save before closing?') % (
                 editorset.filename),


### PR DESCRIPTION
- Split WANTS_RTS from HARDWARE_FLOW
- Avoid "save before closing" on live radios
