### PR TITLE
Fixes for bug 10533

### DIFF
--- a/chirp/import_logic.py
+++ b/chirp/import_logic.py
@@ -203,8 +203,9 @@ def _make_offset_with_split(rxfreq, txfreq):
 def _import_duplex(dst_radio, srcrf, mem):
     dstrf = dst_radio.get_features()
 
-    # If a radio does not support odd split, we can use an equivalent offset
     if mem.duplex == "split" and mem.duplex not in dstrf.valid_duplexes:
+        # If a radio does not support odd split, we can use an equivalent
+        # offset
         mem.duplex, mem.offset = _make_offset_with_split(mem.freq, mem.offset)
 
         # Enforce maximum offset
@@ -215,6 +216,10 @@ def _import_duplex(dst_radio, srcrf, mem):
             if lo < mem.freq <= hi:
                 if abs(mem.offset) > limit:
                     raise DestNotCompatible("offset is abnormally large.")
+    elif mem.duplex == 'off' and mem.duplex not in dstrf.valid_duplexes:
+        # If a radio does not support duplex=off, we should just convert to
+        # simplex
+        mem.duplex = ''
 
 
 def import_mem(dst_radio, src_features, src_mem, overrides={}):

--- a/chirp/sources/repeaterbook.py
+++ b/chirp/sources/repeaterbook.py
@@ -170,7 +170,10 @@ class RepeaterBook(base.NetworkResultRadio):
         except errors.InvalidDataError as e:
             LOG.debug(e)
         txf = chirp_common.parse_freq(item['Input Freq'])
-        chirp_common.split_to_offset(m, m.freq, txf)
+        if txf == 0:
+            m.duplex = 'off'
+        else:
+            chirp_common.split_to_offset(m, m.freq, txf)
         txm, tx = parse_tone(item['PL'])
         rxm, rx = parse_tone(item['TSQ'])
         chirp_common.split_tone_decode(m, (txm, tx, 'N'), (rxm, rx, 'N'))

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -875,6 +875,7 @@ class ChirpMain(wx.Frame):
         can_save = False
         can_saveas = False
         can_upload = False
+        can_edit = False
         is_memedit = False
         is_bank = False
         CSVRadio = directory.get_radio('Generic_CSV')
@@ -890,6 +891,7 @@ class ChirpMain(wx.Frame):
                           not is_live and not is_network)
             is_memedit = isinstance(eset.current_editor, memedit.ChirpMemEdit)
             is_bank = isinstance(eset.current_editor, bankedit.ChirpBankEdit)
+            can_edit = not is_network
 
         items = [
             (wx.ID_CLOSE, can_close),
@@ -900,12 +902,12 @@ class ChirpMain(wx.Frame):
             (self._find_next_item, is_memedit),
             (wx.ID_FIND, is_memedit),
             (wx.ID_PRINT, is_memedit),
-            (wx.ID_DELETE, is_memedit),
-            (wx.ID_CUT, is_memedit),
+            (wx.ID_DELETE, is_memedit and can_edit),
+            (wx.ID_CUT, is_memedit and can_edit),
             (wx.ID_COPY, is_memedit),
-            (wx.ID_PASTE, is_memedit),
-            (self._movedn_item, is_memedit),
-            (self._moveup_item, is_memedit),
+            (wx.ID_PASTE, is_memedit and can_edit),
+            (self._movedn_item, is_memedit and can_edit),
+            (self._moveup_item, is_memedit and can_edit),
             (wx.ID_SELECTALL, is_memedit),
             (self._print_preview_item, is_memedit),
             (self._export_menu_item, can_close),

--- a/tests/unit/test_import_logic.py
+++ b/tests/unit/test_import_logic.py
@@ -329,6 +329,14 @@ class ImportFieldTests(base.BaseTest):
         self.assertRaises(import_logic.DestNotCompatible,
                           import_logic._import_duplex, radio, None, mem)
 
+    def test_import_duplex_off_not_supported(self):
+        radio = FakeRadio(None)
+        mem = chirp_common.Memory()
+        mem.freq = 146000000
+        mem.duplex = 'off'
+        import_logic._import_duplex(radio, None, mem)
+        self.assertEqual('', mem.duplex)
+
     @mock.patch('chirp.import_logic._import_name')
     @mock.patch('chirp.import_logic._import_power')
     @mock.patch('chirp.import_logic._import_tone')


### PR DESCRIPTION
- Handle bad repeaterbook TX freq entries
- Import duplex=off to simplex if unsupported
- Disable edit operations on network sources
