### PR TITLE
UV-50X3: set Duplex=split for crossband memories - fixes #10569

### DIFF
--- a/chirp/drivers/vgc.py
+++ b/chirp/drivers/vgc.py
@@ -556,6 +556,21 @@ def model_match(cls, data):
     return False
 
 
+def _split(rf, f1, f2):
+    """Returns False if the two freqs are in the same band (no split)
+    or True otherwise"""
+
+    # determine if the two freqs are in the same band
+    for low, high in rf.valid_bands:
+        if f1 >= low and f1 <= high and \
+                f2 >= low and f2 <= high:
+            # if the two freqs are on the same Band this is not a split
+            return False
+
+    # if you get here is because the freq pairs are split
+    return True
+
+
 class VGCStyleRadio(chirp_common.CloneModeRadio,
                     chirp_common.ExperimentalRadio):
     """BTECH's UV-50X3"""
@@ -750,12 +765,17 @@ class VGCStyleRadio(chirp_common.CloneModeRadio,
         else:
             # TX feq set
             offset = (int(_mem.txfreq) * 10) - mem.freq
-            if offset < 0:
-                mem.offset = abs(offset)
-                mem.duplex = "-"
-            elif offset > 0:
-                mem.offset = offset
-                mem.duplex = "+"
+            if offset != 0:
+                if _split(self.get_features(), mem.freq, int(
+                          _mem.txfreq) * 10):
+                    mem.duplex = "split"
+                    mem.offset = int(_mem.txfreq) * 10
+                elif offset < 0:
+                    mem.offset = abs(offset)
+                    mem.duplex = "-"
+                elif offset > 0:
+                    mem.offset = offset
+                    mem.duplex = "+"
             else:
                 mem.offset = 0
 


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
