### PR TITLE
Fix unused-format-string-argument errors

### DIFF
--- a/chirp/drivers/ft7800.py
+++ b/chirp/drivers/ft7800.py
@@ -494,9 +494,8 @@ class FT7800BankModel(chirp_common.BankModel):
         _bitmap = self._radio._memobj.bank_channels[bank.index]
         ishft = 31 - (index % 32)
         if not (_bitmap.bitmap[index // 32] & (1 << ishft)):
-            raise Exception("Memory {num} is " +
-                            "not in bank {bank}".format(num=memory.number,
-                                                        bank=bank))
+            raise Exception("Memory {num} is not in bank {bank}".format(
+                            num=memory.number, bank=bank))
         _bitmap.bitmap[index // 32] &= ~(1 << ishft)
         self.__b2m_cache[bank.index].remove(memory.number)
         self.__m2b_cache[memory.number].remove(bank.index)

--- a/chirp/drivers/vx7.py
+++ b/chirp/drivers/vx7.py
@@ -138,9 +138,8 @@ class VX7BankModel(chirp_common.BankModel):
                 remaining_members += 1
 
         if not found:
-            raise Exception("Memory {num} not in " +
-                            "bank {bank}".format(num=memory.number,
-                                                 bank=bank))
+            raise Exception("Memory {num} is not in bank {bank}".format(
+                            num=memory.number, bank=bank))
         if not remaining_members:
             _bank_used.in_use = 0xFFFF
 


### PR DESCRIPTION
This PR joins a format string that was divided in two parts joined with the `+` operator, but the `.format()` method applies only to the second part (just as `"a" + "b".upper()` gives "aB"). The two files contain similar code.

I'm adding the word "is" in vx7.py for consistency with other drivers (12 drivers contain "is", 5 don't).

Fixes:
************* Module chirp.drivers.ft7800
chirp/drivers/ft7800.py:498:28: W1304: Unused format argument 'num' (unused-format-string-argument) ************* Module chirp.drivers.vx7
chirp/drivers/vx7.py:142:28: W1304: Unused format argument 'num' (unused-format-string-argument)

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
