### PR TITLE
Remove unused system imports

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -1379,11 +1379,11 @@ class CloneModeRadio(FileBackedRadio, ExternalMemoryProperties):
         return cls._memsize and len(filedata) == cls._memsize
 
     def sync_in(self):
-        "Initiate a radio-to-PC clone operation"
+        """Initiate a radio-to-PC clone operation"""
         pass
 
     def sync_out(self):
-        "Initiate a PC-to-radio clone operation"
+        """Initiate a PC-to-radio clone operation"""
         pass
 
     def save(self, filename):

--- a/chirp/drivers/anytone.py
+++ b/chirp/drivers/anytone.py
@@ -13,9 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import struct
-import time
 import logging
 
 from chirp import bitwise

--- a/chirp/drivers/anytone_ht.py
+++ b/chirp/drivers/anytone_ht.py
@@ -13,9 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import struct
-import time
 import logging
 
 from chirp import bitwise

--- a/chirp/drivers/anytone_iii.py
+++ b/chirp/drivers/anytone_iii.py
@@ -13,9 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import struct
-import time
 import logging
 import string
 

--- a/chirp/drivers/baofeng_uv3r.py
+++ b/chirp/drivers/baofeng_uv3r.py
@@ -16,7 +16,6 @@
 """Baofeng UV3r radio management module"""
 
 import time
-import os
 import logging
 
 from chirp.drivers.wouxun_common import do_download, do_upload

--- a/chirp/drivers/baofeng_wp970i.py
+++ b/chirp/drivers/baofeng_wp970i.py
@@ -14,10 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import struct
 import logging
-import re
 
 from chirp.drivers import baofeng_common
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/bf_t1.py
+++ b/chirp/drivers/bf_t1.py
@@ -25,7 +25,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from time import sleep
 from chirp import chirp_common, directory, memmap
 from chirp import bitwise, errors, util
 from chirp.settings import RadioSetting, RadioSettingGroup, \

--- a/chirp/drivers/bf_t8.py
+++ b/chirp/drivers/bf_t8.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import os
 import struct
 import logging
 

--- a/chirp/drivers/bjuv55.py
+++ b/chirp/drivers/bjuv55.py
@@ -15,9 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import struct
-import time
-import os
 import logging
 
 from chirp.drivers import uv5r

--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -18,7 +18,6 @@
 from builtins import bytes
 
 import struct
-import time
 import logging
 
 from time import sleep

--- a/chirp/drivers/fd268.py
+++ b/chirp/drivers/fd268.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import struct
-import os
 import logging
 
 from chirp import chirp_common, directory, memmap, errors, util, bitwise

--- a/chirp/drivers/ft2800.py
+++ b/chirp/drivers/ft2800.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import os
 import logging
 
 from chirp import util, memmap, chirp_common, bitwise, directory, errors

--- a/chirp/drivers/ft2900.py
+++ b/chirp/drivers/ft2900.py
@@ -17,7 +17,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import os
 import logging
 
 from chirp import util, memmap, chirp_common, bitwise, directory, errors

--- a/chirp/drivers/ft60.py
+++ b/chirp/drivers/ft60.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import os
 import logging
 
 from chirp.drivers import yaesu_clone

--- a/chirp/drivers/ft7800.py
+++ b/chirp/drivers/ft7800.py
@@ -15,7 +15,6 @@
 
 import time
 import logging
-import os
 import re
 
 from chirp.drivers import yaesu_clone

--- a/chirp/drivers/ft818.py
+++ b/chirp/drivers/ft818.py
@@ -23,7 +23,6 @@ from chirp.settings import RadioSetting, RadioSettingGroup, \
     RadioSettingValueInteger, RadioSettingValueList, \
     RadioSettingValueBoolean, RadioSettingValueString, \
     RadioSettings
-import os
 import logging
 from chirp.util import safe_charset_string
 

--- a/chirp/drivers/ft857.py
+++ b/chirp/drivers/ft857.py
@@ -22,7 +22,6 @@ from chirp.settings import RadioSetting, RadioSettingGroup, \
     RadioSettingValueInteger, RadioSettingValueList, \
     RadioSettingValueBoolean, RadioSettingValueString, \
     RadioSettings
-import os
 import logging
 from chirp.util import safe_charset_string
 

--- a/chirp/drivers/ft90.py
+++ b/chirp/drivers/ft90.py
@@ -22,7 +22,6 @@ from chirp.settings import RadioSetting, RadioSettingGroup, \
     RadioSettings
 
 import time
-import os
 import traceback
 import string
 import re

--- a/chirp/drivers/ftlx011.py
+++ b/chirp/drivers/ftlx011.py
@@ -13,12 +13,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import struct
-import os
 import logging
 import time
 
-from time import sleep
 from chirp import chirp_common, directory, memmap, errors, util, bitwise
 from chirp.settings import RadioSettingGroup, RadioSetting, \
     RadioSettingValueBoolean, RadioSettingValueList, \

--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -16,7 +16,6 @@
 import os
 import csv
 import logging
-import re
 
 from chirp import chirp_common, errors, directory
 from chirp import import_logic

--- a/chirp/drivers/gmrsuv1.py
+++ b/chirp/drivers/gmrsuv1.py
@@ -14,10 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import struct
 import logging
-import re
 
 from chirp.drivers import baofeng_common
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/gmrsv2.py
+++ b/chirp/drivers/gmrsv2.py
@@ -14,10 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import struct
 import logging
-import re
 
 from chirp.drivers import baofeng_common
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/h777.py
+++ b/chirp/drivers/h777.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import os
 import struct
 import unittest
 import logging

--- a/chirp/drivers/hg_uv98.py
+++ b/chirp/drivers/hg_uv98.py
@@ -20,7 +20,6 @@
 #  KG7KMV and Bartłomiej Zieliński
 # Based on the implementation of Kenwood TK-8102
 
-import os
 import logging
 import struct
 

--- a/chirp/drivers/ic2730.py
+++ b/chirp/drivers/ic2730.py
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import struct
 import logging
 from chirp.drivers import icf
 from chirp import chirp_common, util, directory, bitwise, memmap

--- a/chirp/drivers/icq7.py
+++ b/chirp/drivers/icq7.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import struct
 import logging
 
 from chirp.drivers import icf

--- a/chirp/drivers/icx90.py
+++ b/chirp/drivers/icx90.py
@@ -18,7 +18,6 @@
 import logging
 
 from chirp.drivers import icf
-import struct
 from chirp import chirp_common, bitwise, errors, directory
 from chirp.memmap import MemoryMap
 from chirp.settings import RadioSetting, RadioSettingGroup, \

--- a/chirp/drivers/iradio_uv_5118.py
+++ b/chirp/drivers/iradio_uv_5118.py
@@ -13,10 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import os
 import struct
-import re
 import logging
 
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/kguv8e.py
+++ b/chirp/drivers/kguv8e.py
@@ -21,7 +21,6 @@
 
 import struct
 import time
-import os
 import logging
 from chirp import util, chirp_common, bitwise, memmap, errors, directory
 from chirp.settings import RadioSetting, RadioSettingGroup, \

--- a/chirp/drivers/kguv920pa.py
+++ b/chirp/drivers/kguv920pa.py
@@ -16,7 +16,6 @@
 """Wouxun KG-UV920P-A radio management module based"""
 
 import time
-import os
 import logging
 from chirp import util, chirp_common, bitwise, memmap, errors, directory
 from chirp.settings import RadioSetting, RadioSettingGroup, \

--- a/chirp/drivers/kguv9dplus.py
+++ b/chirp/drivers/kguv9dplus.py
@@ -22,10 +22,8 @@
 """Wouxun KG-UV9D Plus radio management module"""
 
 import time
-import os
 import logging
 import struct
-import string
 from chirp import util, chirp_common, bitwise, memmap, errors, directory
 from chirp.settings import RadioSetting, RadioSettingValue, \
      RadioSettingGroup, \

--- a/chirp/drivers/kyd.py
+++ b/chirp/drivers/kyd.py
@@ -14,8 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import os
 import struct
 import logging
 

--- a/chirp/drivers/kyd_IP620.py
+++ b/chirp/drivers/kyd_IP620.py
@@ -22,7 +22,6 @@
 
 import struct
 import time
-import os
 import logging
 from chirp import util, chirp_common, bitwise, memmap, errors, directory
 from chirp.settings import RadioSetting, RadioSettingGroup, \

--- a/chirp/drivers/leixen.py
+++ b/chirp/drivers/leixen.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import struct
-import os
 import logging
 
 from chirp import chirp_common, directory, memmap, errors, util

--- a/chirp/drivers/lt725uv.py
+++ b/chirp/drivers/lt725uv.py
@@ -25,10 +25,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import struct
 import logging
-import re
 
 from chirp import chirp_common, directory, memmap
 from chirp import bitwise, errors, util

--- a/chirp/drivers/mursv1.py
+++ b/chirp/drivers/mursv1.py
@@ -14,10 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import struct
 import logging
-import re
 
 from chirp.drivers import baofeng_common
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/radioddity_r2.py
+++ b/chirp/drivers/radioddity_r2.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import os
 import struct
 import logging
 

--- a/chirp/drivers/radtel_t18.py
+++ b/chirp/drivers/radtel_t18.py
@@ -13,10 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import os
 import struct
-import unittest
 import logging
 
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/retevis_rb15.py
+++ b/chirp/drivers/retevis_rb15.py
@@ -13,10 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import os
 import struct
-import re
 import logging
 
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/retevis_rb17p.py
+++ b/chirp/drivers/retevis_rb17p.py
@@ -14,9 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import os
 import struct
-import unittest
 import logging
 
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/retevis_rb28.py
+++ b/chirp/drivers/retevis_rb28.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import os
 import struct
 import logging
 

--- a/chirp/drivers/retevis_rt1.py
+++ b/chirp/drivers/retevis_rt1.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import os
 import struct
 import logging
 

--- a/chirp/drivers/retevis_rt21.py
+++ b/chirp/drivers/retevis_rt21.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import os
 import struct
 import logging
 

--- a/chirp/drivers/retevis_rt22.py
+++ b/chirp/drivers/retevis_rt22.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import os
 import struct
 import logging
 

--- a/chirp/drivers/retevis_rt23.py
+++ b/chirp/drivers/retevis_rt23.py
@@ -14,9 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import os
 import struct
-import re
 import logging
 
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/retevis_rt26.py
+++ b/chirp/drivers/retevis_rt26.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import struct
 import logging
 import re

--- a/chirp/drivers/retevis_rt76p.py
+++ b/chirp/drivers/retevis_rt76p.py
@@ -14,9 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
-import os
 import struct
-import time
 
 from chirp import (
     bitwise,

--- a/chirp/drivers/retevis_rt98.py
+++ b/chirp/drivers/retevis_rt98.py
@@ -13,9 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import struct
-import time
 import logging
 
 from chirp import bitwise

--- a/chirp/drivers/tdxone_tdq8a.py
+++ b/chirp/drivers/tdxone_tdq8a.py
@@ -17,7 +17,6 @@
 import time
 import struct
 import logging
-import re
 
 from chirp import chirp_common, directory, memmap
 from chirp import bitwise, errors, util

--- a/chirp/drivers/th7800.py
+++ b/chirp/drivers/th7800.py
@@ -24,8 +24,6 @@ from chirp.settings import RadioSetting, RadioSettingGroup, \
     RadioSettingValueFloat, InvalidValueError, RadioSettings, \
     RadioSettingValueMap, zero_indexed_seq_map
 from chirp.chirp_common import format_freq
-import os
-import time
 import logging
 from datetime import date
 

--- a/chirp/drivers/th9000.py
+++ b/chirp/drivers/th9000.py
@@ -13,9 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import struct
-import time
 import logging
 
 from chirp import bitwise

--- a/chirp/drivers/th9800.py
+++ b/chirp/drivers/th9800.py
@@ -22,8 +22,6 @@ from chirp.settings import RadioSetting, RadioSettingGroup, \
     RadioSettingValueBoolean, RadioSettingValueString, \
     RadioSettingValueFloat, InvalidValueError, RadioSettings
 from chirp.chirp_common import format_freq
-import os
-import time
 import logging
 from datetime import date
 

--- a/chirp/drivers/th_uv3r.py
+++ b/chirp/drivers/th_uv3r.py
@@ -15,7 +15,6 @@
 
 """TYT uv3r radio management module"""
 
-import os
 import logging
 from chirp import chirp_common, bitwise, errors, directory
 from chirp.drivers.wouxun import do_download, do_upload

--- a/chirp/drivers/th_uv8000.py
+++ b/chirp/drivers/th_uv8000.py
@@ -18,10 +18,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import struct
 import logging
-import re
 import math
 from chirp import chirp_common, directory, memmap
 from chirp import bitwise, errors, util

--- a/chirp/drivers/th_uv88.py
+++ b/chirp/drivers/th_uv88.py
@@ -16,10 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.
 
-import time
 import struct
 import logging
-import re
 import math
 from chirp import chirp_common, directory, memmap
 from chirp import bitwise, errors, util

--- a/chirp/drivers/tk760g.py
+++ b/chirp/drivers/tk760g.py
@@ -16,7 +16,6 @@
 import logging
 import struct
 import time
-import sys
 
 from chirp import chirp_common, directory, memmap, errors, util, bitwise
 from chirp.settings import RadioSettingGroup, RadioSetting, \

--- a/chirp/drivers/tk8180.py
+++ b/chirp/drivers/tk8180.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import struct
-import os
 import time
 import logging
 from collections import OrderedDict

--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -18,8 +18,6 @@
 import time
 import struct
 import logging
-import re
-import math
 from chirp import chirp_common, directory, memmap
 from chirp import bitwise, errors, util
 from chirp.settings import RadioSettingGroup, RadioSetting, \

--- a/chirp/drivers/ts480.py
+++ b/chirp/drivers/ts480.py
@@ -16,10 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import struct
 import logging
-import re
-import math
 from chirp import chirp_common, directory, memmap
 from chirp import bitwise, errors, util
 from chirp.settings import RadioSettingGroup, RadioSetting, \

--- a/chirp/drivers/ts590.py
+++ b/chirp/drivers/ts590.py
@@ -17,10 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
-import struct
 import logging
-import re
-import math
 import threading
 from chirp import chirp_common, directory, memmap
 from chirp import bitwise, errors, util

--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -17,7 +17,6 @@ from builtins import bytes
 
 import struct
 import time
-import os
 import logging
 
 from chirp import chirp_common, errors, util, directory, memmap

--- a/chirp/drivers/uv5x3.py
+++ b/chirp/drivers/uv5x3.py
@@ -14,10 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import struct
 import logging
-import re
 
 from chirp.drivers import baofeng_common
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/uv6r.py
+++ b/chirp/drivers/uv6r.py
@@ -14,10 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
-import struct
 import logging
-import re
 
 from chirp.drivers import baofeng_common
 from chirp import chirp_common, directory, memmap

--- a/chirp/drivers/vgc.py
+++ b/chirp/drivers/vgc.py
@@ -15,7 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import struct
 import logging
 import re

--- a/chirp/drivers/vx170.py
+++ b/chirp/drivers/vx170.py
@@ -15,8 +15,6 @@
 
 from chirp.drivers import yaesu_clone, ft7800
 from chirp import chirp_common, directory, memmap, bitwise, errors
-import time
-import os
 
 MEM_FORMAT = """
 #seekto 0x018A;

--- a/chirp/drivers/vx2.py
+++ b/chirp/drivers/vx2.py
@@ -20,8 +20,6 @@ from chirp.settings import RadioSetting, RadioSettingGroup, \
     RadioSettingValueInteger, RadioSettingValueList, \
     RadioSettingValueBoolean, RadioSettingValueString, \
     RadioSettings
-import os
-import traceback
 import re
 import logging
 

--- a/chirp/drivers/vx3.py
+++ b/chirp/drivers/vx3.py
@@ -20,7 +20,6 @@ from chirp.settings import RadioSetting, RadioSettingGroup, \
     RadioSettingValueInteger, RadioSettingValueList, \
     RadioSettingValueBoolean, RadioSettingValueString, \
     RadioSettings
-import os
 import re
 import logging
 

--- a/chirp/drivers/vx8.py
+++ b/chirp/drivers/vx8.py
@@ -13,7 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import re
 import logging
 

--- a/chirp/drivers/wouxun.py
+++ b/chirp/drivers/wouxun.py
@@ -16,7 +16,6 @@
 """Wouxun radios management module"""
 
 import time
-import os
 import logging
 from chirp import util, chirp_common, bitwise, memmap, errors, directory
 from chirp.settings import RadioSetting, RadioSettingGroup, \


### PR DESCRIPTION
I used `autoflake` to remove unused imports of modules from the standard library of Python, but I kept all `pass` statements by adding triple quotes around two docstrings and not applying the deletion of other `pass` statements.

Running `pytest` I get the same number of pass/fail and 7 warnings less:

after the changes in this PR I get:
> 33 failed, 7348 passed, 1891 skipped, 11567 warnings

on master I get:
> 33 failed, 7348 passed, 1891 skipped, 11574 warnings

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
