### PR TITLE
Fix bug 10608

### DIFF
--- a/chirp/wxui/config.py
+++ b/chirp/wxui/config.py
@@ -31,7 +31,7 @@ class ChirpConfig:
 
         self._default_section = "global"
 
-        self.__config = ConfigParser()
+        self.__config = ConfigParser(interpolation=None)
 
         cfg = os.path.join(basepath, name)
         if os.path.exists(cfg):


### PR DESCRIPTION
The ConfigParser will try to interpolate keywords in strings when
prefixed by %. We don't care about that, and it breaks our setting
of filenames as values when they contain that symbol.

Fixes #10609
Fixes #10608
