### PR TITLE
Always update cells for font size

### DIFF
--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -1494,8 +1494,8 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
         self._grid.SetDefaultCellFont(font)
         if refresh:
             self.refresh()
-            wx.CallAfter(self._grid.AutoSizeColumns, setAsMin=False)
-            wx.CallAfter(self._grid.AutoSizeRows, setAsMin=False)
+        wx.CallAfter(self._grid.AutoSizeColumns, setAsMin=False)
+        wx.CallAfter(self._grid.AutoSizeRows, setAsMin=False)
 
     def cb_copy(self, cut=False):
         rows = self.get_selected_rows_safe()

--- a/tools/fast-driver.py
+++ b/tools/fast-driver.py
@@ -39,8 +39,12 @@ base_modules = [mod for parent, mod in files_by_module
 if base_modules:
     print('Base modules touched; running all drivers: %s' % base_modules)
     driver_exp = []
-else:
+elif driver_modules:
     driver_exp = ' or '.join(f for f in driver_modules)
+else:
+    print('No driver tests necessary for changes in %s' % ','.join(
+        files))
+    sys.exit(0)
 
 args = ['pytest']
 if driver_exp:


### PR DESCRIPTION
Even if we're not refreshing (i.e. on startup) we need to auto-size
the cells on memedit load if we're changing the font size.

Fixes #10614
