### PR TITLE
Fix/autopep8

### DIFF
--- a/chirp/drivers/alinco.py
+++ b/chirp/drivers/alinco.py
@@ -233,6 +233,7 @@ def _set_name(mem, _mem):
             pass
     return name
 
+
 ALINCO_TONES = list(chirp_common.TONES)
 ALINCO_TONES.remove(159.8)
 ALINCO_TONES.remove(165.5)

--- a/chirp/drivers/anytone.py
+++ b/chirp/drivers/anytone.py
@@ -229,6 +229,7 @@ def _read(radio, length):
         raise errors.RadioError("Short read from radio")
     return data
 
+
 valid_model = [b'QX588UV', b'HR-2040', b'DB-50M\x00', b'DB-750X']
 
 

--- a/chirp/drivers/anytone778uv.py
+++ b/chirp/drivers/anytone778uv.py
@@ -1729,6 +1729,7 @@ class AnyTone778UVBase(chirp_common.CloneModeRadio,
                     LOG.debug(element.get_name())
                     raise
 
+
 # Original non-VOX models
 if has_future:
     @directory.register
@@ -1776,6 +1777,7 @@ class AnyTone778UVvoxBase(AnyTone778UVBase):
     '''AnyTone 778UV VOX, Retivis RT95 VOX and others'''
     NAME_LENGTH = 6
     HAS_VOX = True
+
 
 # New VOX models
 if has_future:

--- a/chirp/drivers/anytone_ht.py
+++ b/chirp/drivers/anytone_ht.py
@@ -250,6 +250,7 @@ def _read(radio, length):
         raise errors.RadioError("Short read from radio")
     return data
 
+
 valid_model = [b'TERMN8R', b'OBLTR8R']
 
 

--- a/chirp/drivers/anytone_iii.py
+++ b/chirp/drivers/anytone_iii.py
@@ -537,6 +537,7 @@ def _read(radio, length):
         raise errors.RadioError("Short read from radio")
     return data
 
+
 valid_model = [b'I588UVP']
 
 

--- a/chirp/drivers/bf_t1.py
+++ b/chirp/drivers/bf_t1.py
@@ -877,7 +877,7 @@ class BFT1(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
 
         rs = RadioSetting("relaym", "Relay Mode",
                           RadioSettingValueList(RELAY_MODE_LIST,
-                              RELAY_MODE_LIST[_settings.relaym]))
+                                                RELAY_MODE_LIST[_settings.relaym]))
         adv.append(rs)
 
         return group

--- a/chirp/drivers/bj9900.py
+++ b/chirp/drivers/bj9900.py
@@ -29,9 +29,10 @@ LOG = logging.getLogger(__name__)
 
 CMD_ACK = 0x06
 
+
 @directory.register
 class BJ9900Radio(chirp_common.CloneModeRadio,
-        chirp_common.ExperimentalRadio):
+                  chirp_common.ExperimentalRadio):
     """Baojie BJ-9900"""
     VENDOR = "Baojie"
     MODEL = "BJ-9900"
@@ -42,10 +43,10 @@ class BJ9900Radio(chirp_common.CloneModeRadio,
     MODES = ["NFM", "FM"]
     TMODES = ["", "Tone", "TSQL", "DTCS", "Cross"]
     CROSS_MODES = ["Tone->Tone", "Tone->DTCS", "DTCS->Tone",
-        "->Tone", "->DTCS", "DTCS->", "DTCS->DTCS"]
+                   "->Tone", "->DTCS", "DTCS->", "DTCS->DTCS"]
     STEPS = [5.0, 6.25, 10.0, 12.5, 25.0]
     VALID_BANDS = [(109000000, 136000000), (136000000, 174000000),
-        (400000000, 470000000)]
+                   (400000000, 470000000)]
 
     CHARSET = list(chirp_common.CHARSET_ALPHANUMERIC)
     CHARSET.remove(" ")
@@ -255,7 +256,7 @@ class BJ9900Radio(chirp_common.CloneModeRadio,
 
         _mem.namelen = len(mem.name)
         for i in range(_mem.namelen):
-                _mem.name[i] = ord(mem.name[i])
+            _mem.name[i] = ord(mem.name[i])
 
         rxmode = ""
         txmode = ""
@@ -393,6 +394,7 @@ class BJ9900Radio(chirp_common.CloneModeRadio,
     def match_model(cls, filedata, filename):
         return len(filedata) == cls._memsize or \
             (len(filedata) == cls._datsize and filedata[-4:] == "\r\n\r\n")
+
 
 class BJ9900RadioLeft(BJ9900Radio):
     """Baojie BJ-9900 Left VFO subdevice"""

--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -1145,9 +1145,9 @@ class BTechMobileCommon(chirp_common.CloneModeRadio,
         basic.append(tot)
 
         if self.MODEL == "KT-8R":
-                rs = RadioSettingValueBoolean(_mem.settings.save)
-                save = RadioSetting("settings.save", "Battery Save", rs)
-                basic.append(save)
+            rs = RadioSettingValueBoolean(_mem.settings.save)
+            save = RadioSetting("settings.save", "Battery Save", rs)
+            basic.append(save)
 
         model_list = ["KT-8R", "KT-WP12", "WP-9900"]
         if self.MODEL not in model_list:

--- a/chirp/drivers/fd268.py
+++ b/chirp/drivers/fd268.py
@@ -584,7 +584,7 @@ class FeidaxinFD2x8yRadio(chirp_common.CloneModeRadio):
         # preparing for callback on vrxfreq (handled also in a special )
         vf_freq = RadioSetting("none.vrx_freq", "VFO frequency",
                                RadioSettingValueString(0, 10, chirp_common.
-                               format_freq(vfo)))
+                                                       format_freq(vfo)))
         vf_freq.set_apply_callback(apply_freq, _mem.vfo.vrx_freq)
         work.append(vf_freq)
 
@@ -611,7 +611,7 @@ class FeidaxinFD2x8yRadio(chirp_common.CloneModeRadio):
 
         offset = RadioSetting("none.vfo_shift", "VFO Offset",
                               RadioSettingValueString(0, 9, chirp_common.
-                              format_freq(vfo_shift)))
+                                                      format_freq(vfo_shift)))
         work.append(offset)
 
         step = RadioSetting("settings", "VFO step",
@@ -632,7 +632,7 @@ class FeidaxinFD2x8yRadio(chirp_common.CloneModeRadio):
                 ani_value = "200"
 
             ani_value = "".join(x for x in ani_value if (int(x) >= 2 and
-                        int(x) <= 9))
+                                                         int(x) <= 9))
 
             ani = RadioSetting("ani", "ANI (200-999)",
                                RadioSettingValueString(0, 3, ani_value))

--- a/chirp/drivers/ft2800.py
+++ b/chirp/drivers/ft2800.py
@@ -32,6 +32,7 @@ def _send(s, data):
         if chunk != echo:
             raise Exception("Failed to read echo chunk")
 
+
 IDBLOCK = "\x0c\x01\x41\x33\x35\x02\x00\xb8"
 TRAILER = "\x0c\x02\x41\x33\x35\x00\x00\xb7"
 ACK = "\x0C\x06\x00"
@@ -125,6 +126,7 @@ def _upload(radio):
         block += 1
 
     _send(radio.pipe, TRAILER)
+
 
 MEM_FORMAT = """
 struct {

--- a/chirp/drivers/ft2900.py
+++ b/chirp/drivers/ft2900.py
@@ -35,6 +35,7 @@ def _send(s, data):
         raise Exception("Failed to read echo")
     LOG.debug("got echo\n%s\n" % util.hexprint(echo))
 
+
 ACK = b"\x06"
 INITIAL_CHECKSUM = 0
 
@@ -163,6 +164,7 @@ def _upload(radio):
         block += 1
 
     _send(radio.pipe, bytes([cs & 0xFF]))
+
 
 MEM_FORMAT = """
 #seekto 0x0080;
@@ -378,7 +380,7 @@ def _decode_name(mem):
 
 
 def _encode_name(mem):
-    if(mem.strip() == ""):
+    if (mem.strip() == ""):
         return [0xff] * 6
 
     name = [None] * 6
@@ -579,7 +581,7 @@ class FT2900Radio(YaesuCloneModeRadio):
         mem.freq = int(_mem.freq) * 1000
 
         # compensate for 12.5 kHz tuning steps, add 500 Hz if needed
-        if(mem.tuning_step == 12.5):
+        if (mem.tuning_step == 12.5):
             lastdigit = int(_mem.freq) % 10
             if (lastdigit == 2 or lastdigit == 7):
                 mem.freq += 500

--- a/chirp/drivers/ft450d.py
+++ b/chirp/drivers/ft450d.py
@@ -1250,7 +1250,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         pnlset.append(rs)
     # End _do_panel_settings
 
-    def _do_panel_buttons(self, pnlcfg):      #- - - Current Panel Config
+    def _do_panel_buttons(self, pnlcfg):      # - - - Current Panel Config
         _settings = self._memobj.settings
 
         rs = RadioSetting("pnl_cs", "C.S. Function",

--- a/chirp/drivers/ft450d.py
+++ b/chirp/drivers/ft450d.py
@@ -37,6 +37,7 @@ T_STEPS.remove(100.0)
 T_STEPS.remove(125.0)
 T_STEPS.remove(200.0)
 
+
 @directory.register
 class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
     """Yaesu FT-450D"""
@@ -49,19 +50,19 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
 
     DUPLEX = ["", "-", "+"]
     MODES = ["LSB", "USB",  "CW",  "AM", "FM", "RTTY-L",
-            "USER-L", "USER-U", "NFM", "CWR"]
+             "USER-L", "USER-U", "NFM", "CWR"]
     TMODES = ["", "Tone", "TSQL"]
     STEPSFM = [5.0, 6.25, 10.0, 12.5, 15.0, 20.0, 25.0, 50.0]
     STEPSAM = [2.5, 5.0, 9.0, 10.0, 12.5, 25.0]
     STEPSSSB = [1.0, 2.5, 5.0]
     VALID_BANDS = [(100000, 33000000), (33000000, 56000000)]
     FUNC_LIST = ['MONI', 'N/A', 'PBAK', 'PLAY1', 'PLAY2', 'PLAY3', 'QSPLIT',
-            'SPOT', 'SQLOFF', 'SWR', 'TXW', 'VCC', 'VOICE2', 'VM1MONI',
-            'VM1REC', 'VM1TX', 'VM2MONI', 'VM2REC', 'VM2TX', 'DOWN', 'FAST',
-            'UP', 'DSP', 'IPO/ATT', 'NB', 'AGC' , 'MODEDN',  'MODEUP',
-            'DSP/SEL', 'KEYER', 'CLAR' , 'BANDDN', 'BANDUP', 'A=B', 'A/B',
-            'LOCK', 'TUNE', 'VOICE', 'MW', 'V/M', 'HOME', 'RCL', 'VOX', 'STO',
-            'STEP', 'SPLIT', 'PMS', 'SCAN', 'MENU', 'DIMMER', 'MTR']
+                 'SPOT', 'SQLOFF', 'SWR', 'TXW', 'VCC', 'VOICE2', 'VM1MONI',
+                 'VM1REC', 'VM1TX', 'VM2MONI', 'VM2REC', 'VM2TX', 'DOWN', 'FAST',
+                 'UP', 'DSP', 'IPO/ATT', 'NB', 'AGC', 'MODEDN',  'MODEUP',
+                 'DSP/SEL', 'KEYER', 'CLAR', 'BANDDN', 'BANDUP', 'A=B', 'A/B',
+                 'LOCK', 'TUNE', 'VOICE', 'MW', 'V/M', 'HOME', 'RCL', 'VOX', 'STO',
+                 'STEP', 'SPLIT', 'PMS', 'SCAN', 'MENU', 'DIMMER', 'MTR']
     CHARSET = list(chirp_common.CHARSET_ASCII)
     CHARSET.remove("\\")
 
@@ -302,7 +303,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
 
     """
     _CALLSIGN_CHARSET = [chr(x) for x in list(range(ord("0"), ord("9") + 1)) +
-                        list(range(ord("A"), ord("Z") + 1)) + [ord(" ")]]
+                         list(range(ord("A"), ord("Z") + 1)) + [ord(" ")]]
     _CALLSIGN_CHARSET_REV = dict(zip(_CALLSIGN_CHARSET,
                                      range(0, len(_CALLSIGN_CHARSET))))
 
@@ -416,7 +417,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
                     checksum.get_calculated(data):
                 raise Exception("Checksum Failed [%02X<>%02X] block %02X" %
                                 (checksum.get_existing(data),
-                                checksum.get_calculated(data), blocknum))
+                                 checksum.get_calculated(data), blocknum))
             # Remove the block number and checksum
             data = data[1:block + 1]
         else:   # Use this info to decode a new Yaesu model
@@ -480,7 +481,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
                 LOG.debug("Sending block %s" % hex(blocks))
                 self.pipe.write(struct.pack('B', blocks))
                 blkdat = self.get_mmap()[pos:pos + block]
-                LOG.debug("Sending %d bytes:\n%s" 
+                LOG.debug("Sending %d bytes:\n%s"
                           % (len(blkdat), util.hexprint(blkdat)))
                 self.pipe.write(blkdat)
                 xs = checksum.get_calculated(self.get_mmap())
@@ -522,7 +523,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
     def get_features(self):
         rf = chirp_common.RadioFeatures()
         rf.has_bank = False
-        rf.has_dtcs= False
+        rf.has_dtcs = False
         rf.valid_modes = [x for x in self.MODES if x in chirp_common.MODES]
         rf.valid_tmodes = list(self.TMODES)
         rf.valid_duplexes = list(self.DUPLEX)
@@ -615,7 +616,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
                          "frequency", "power", "duplex", "offset"]
         else:
             raise Exception("Sorry, you can't edit that special"
-                        " memory channel %i." % mem.number)
+                            " memory channel %i." % mem.number)
 
         mem = self._get_memory(mem, _mem)
         mem.immutable = immutable
@@ -630,7 +631,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         cur_mem = self._get_special(self.SPECIAL_MEMORIES_REV[mem.number])
 
         if mem.number in range(self.FIRST_VFOA_INDEX,
-                            self.LAST_VFOA_INDEX - 1, -1):
+                               self.LAST_VFOA_INDEX - 1, -1):
             _mem = self._memobj.vfoa[-self.LAST_VFOA_INDEX + mem.number]
         elif mem.number in range(self.FIRST_VFOB_INDEX,
                                  self.LAST_VFOB_INDEX - 1, -1):
@@ -654,7 +655,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
                         ~ (1 << bitindex)
                 # pylint get confused by &= operator
                 self._memobj.pmsvisible = self._memobj.pmsvisible & \
-                        ~ (1 << bitindex)
+                    ~ (1 << bitindex)
                 return
             # pylint get confused by |= operator
             self._memobj.pmsvisible = self._memobj.pmsvisible | 1 << bitindex
@@ -668,16 +669,16 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
             if key != "extd_number":
                 if cur_mem.__dict__[key] != mem.__dict__[key]:
                     raise errors.RadioError("Editing field `%s' " % key +
-                                        "is not supported on this channel")
+                                            "is not supported on this channel")
 
         self._set_memory(mem, _mem)
 
     def _get_normal(self, number):
         _mem = self._memobj.memory[number - 1]
         used = (self._memobj.visible[(number - 1) / 8] >> (number - 1) % 8) \
-                & 0x01
+            & 0x01
         valid = (self._memobj.filled[(number - 1) / 8] >> (number - 1) % 8) \
-                & 0x01
+            & 0x01
 
         mem = chirp_common.Memory()
         mem.number = number
@@ -692,7 +693,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
     def _set_normal(self, mem):
         _mem = self._memobj.memory[mem.number - 1]
         wasused = (self._memobj.visible[(mem.number - 1) / 8] >>
-                    (mem.number - 1) % 8) & 0x01
+                   (mem.number - 1) % 8) & 0x01
         wasvalid = (self._memobj.filled[(mem.number - 1) / 8] >>
                     (mem.number - 1) % 8) & 0x01
 
@@ -710,9 +711,9 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
             _mem.set_raw("\x00" * (_mem.size() // 8))    # clean up
 
         self._memobj.visible[(mem.number - 1) // 8] |= 1 << (mem.number - 1) \
-                        % 8
+            % 8
         self._memobj.filled[(mem.number - 1) // 8] |= 1 << (mem.number - 1) \
-                        % 8
+            % 8
         self._set_memory(mem, _mem)
 
     def _get_memory(self, mem, _mem):
@@ -727,7 +728,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
             else:
                 vx = 8          # NFM
         if vx == 10:         # CWR
-                vx = 9
+            vx = 9
         if vx == 5:         # Data/Dual mode
             if _mem.mode2 == 0:          # RTTY-L
                 vx = 5
@@ -780,32 +781,32 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         mem.extra.append(rs)
 
         rs = RadioSetting("cnturon", "Contour Filter",
-                          RadioSettingValueBoolean(_mem.cnturon ))
+                          RadioSettingValueBoolean(_mem.cnturon))
         rs.set_doc("Contour filter on/off")
         mem.extra.append(rs)
 
         options = ["Peak", "Null"]
         rs = RadioSetting("cnturpk", "Contour Filter Mode",
                           RadioSettingValueList(options,
-                                options[_mem.cnturpk]))
+                                                options[_mem.cnturpk]))
         mem.extra.append(rs)
 
         options = ["Low", "High"]
         rs = RadioSetting("cnturgn", "Contour Filter Gain",
                           RadioSettingValueList(options,
-                                options[_mem.cnturgn]))
+                                                options[_mem.cnturgn]))
         rs.set_doc("Filter gain/attenuation")
         mem.extra.append(rs)
 
         options = ["-2", "-1", "Center", "+1", "+2"]
         rs = RadioSetting("cnturmd", "Contour Filter Notch",
                           RadioSettingValueList(options,
-                                options[_mem.cnturmd]))
+                                                options[_mem.cnturmd]))
         rs.set_doc("Filter notch offset")
         mem.extra.append(rs)
 
         rs = RadioSetting("notch", "Notch Filter",
-                          RadioSettingValueBoolean(_mem.notch ))
+                          RadioSettingValueBoolean(_mem.notch))
         rs.set_doc("IF bandpass filter")
         mem.extra.append(rs)
 
@@ -855,7 +856,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
                           "8", "9", "10", "11"]
         rs = RadioSetting("dnr_val", "DSP Noise Reduction Alg",
                           RadioSettingValueList(options,
-                                        options[ _mem.dnr_val]))
+                                                options[_mem.dnr_val]))
         rs.set_doc("Digital noise reduction algorithm number (1-11)")
         mem.extra.append(rs)
 
@@ -905,9 +906,9 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         except ValueError:
             pass
         _mem.freq = mem.freq
-        _mem.uprband  = 0
+        _mem.uprband = 0
         if mem.freq >= 33000000:
-            _mem.uprband  = 1
+            _mem.uprband = 1
         _mem.offset = mem.offset
         _mem.tmode = self.TMODES.index(mem.tmode)
         _mem.tone = chirp_common.TONES.index(mem.rtone)
@@ -937,7 +938,6 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
             else:
                 setattr(_mem, setting.get_name(), setting.value)
 
-
     @classmethod
     def match_model(cls, filedata, filename):
         """Match the opened/downloaded image to the correct version"""
@@ -966,7 +966,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         ary = ""
         for j in range(0, knt, 1):
             chx = ord(str(setting.value)[j])
-            if chx < 32 or  chx >  125:     # strip non-printing
+            if chx < 32 or chx > 125:     # strip non-printing
                 ary += " "
             else:
                 ary += str(setting.value)[j]
@@ -1015,7 +1015,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         options[0] = "Off"
         rs = RadioSetting("tot", "TX 'TOT' time-out (mins)",
                           RadioSettingValueList(options,
-                          options[_settings.tot]))
+                                                options[_settings.tot]))
         tab.append(rs)
 
         bx = not _settings.cat_rts     # Convert from Enable=0
@@ -1027,13 +1027,13 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         options = ["0", "100ms", "1000ms", "3000ms"]
         rs = RadioSetting("cat_tot", "CAT Timeout",
                           RadioSettingValueList(options,
-                          options[_settings.cat_tot]))
+                                                options[_settings.cat_tot]))
         tab.append(rs)
 
         options = ["4800", "9600", "19200", "38400", "Data"]
         rs = RadioSetting("catrate", "CAT rate",
                           RadioSettingValueList(options,
-                          options[_settings.catrate]))
+                                                options[_settings.catrate]))
         tab.append(rs)
 
         rs = RadioSetting("mem_grp", "Mem groups",
@@ -1067,13 +1067,12 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         options = ["ATAS", "EXT ATU", "INT ATU", "INTRATU", "F-TRANS"]
         rs = RadioSetting("tuner", "Antenna Tuner",
                           RadioSettingValueList(options,
-                          options[_settings.tuner]))
+                                                options[_settings.tuner]))
         tab.append(rs)
 
         rs = RadioSetting("rfpower", "RF power (watts)",
                           RadioSettingValueInteger(5, 100, _settings.rfpower))
         tab.append(rs)      # End of _do_general_settings
-
 
     def _do_cw_settings(self, cw):        # - - - CW - - -
         _settings = self._memobj.settings
@@ -1086,7 +1085,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         options = ["%i Hz" % i for i in range(400, 801, 100)]
         rs = RadioSetting("cwpitch", "CW pitch",
                           RadioSettingValueList(options,
-                          options[_settings.cwpitch]))
+                                                options[_settings.cwpitch]))
         cw.append(rs)
 
         rs = RadioSetting("cwspeed", "CW speed (wpm)",
@@ -1097,13 +1096,13 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         options = ["1:%1.1f" % (i / 10) for i in range(25, 46, 1)]
         rs = RadioSetting("cwweigt", "CW weight",
                           RadioSettingValueList(options,
-                          options[_settings.cwweigt]))
+                                                options[_settings.cwweigt]))
         cw.append(rs)
 
         options = ["15ms", "20ms", "25ms", "30ms"]
         rs = RadioSetting("cw_qsk", "CW delay before TX in QSK mode",
                           RadioSettingValueList(options,
-                          options[_settings.cw_qsk]))
+                                                options[_settings.cw_qsk]))
         cw.append(rs)
 
         rs = RadioSetting("cwstone_sgn", "CW sidetone volume Linked",
@@ -1113,18 +1112,18 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
 
         rs = RadioSetting("cwstone_lnk", "CW sidetone linked volume",
                           RadioSettingValueInteger(-50, 50,
-                                        _settings.cwstone_lnk))
+                                                   _settings.cwstone_lnk))
         cw.append(rs)
 
         rs = RadioSetting("cwstone_fix", "CW sidetone fixed volume",
                           RadioSettingValueInteger(0, 100,
-                          _settings.cwstone_fix))
+                                                   _settings.cwstone_fix))
         cw.append(rs)
 
-        options = [ "Numeric", "Alpha", "Mixed"]
+        options = ["Numeric", "Alpha", "Mixed"]
         rs = RadioSetting("cwtrain", "CW Training mode",
                           RadioSettingValueList(options,
-                          options[_settings.cwtrain]))
+                                                options[_settings.cwtrain]))
         cw.append(rs)
 
         rs = RadioSetting("cw_auto", "CW key jack- auto CW mode",
@@ -1135,32 +1134,31 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         options = ["Normal", "Reverse"]
         rs = RadioSetting("cw_key", "CW paddle wiring",
                           RadioSettingValueList(options,
-                          options[_settings.cw_key]))
+                                                options[_settings.cw_key]))
         cw.append(rs)
 
         rs = RadioSetting("beacon_time", "CW beacon Tx interval (secs)",
                           RadioSettingValueInteger(0, 255,
-                          _settings.beacon_time))
+                                                   _settings.beacon_time))
         cw.append(rs)
 
         tmp = self._chars2str(_beacon.t1, 40)
-        rs=RadioSetting("t1", "CW Beacon Line 1",
-                        RadioSettingValueString(0, 40, tmp))
+        rs = RadioSetting("t1", "CW Beacon Line 1",
+                          RadioSettingValueString(0, 40, tmp))
         rs.set_apply_callback(self._my_str2ary, _beacon, "t1", 40)
         cw.append(rs)
 
         tmp = self._chars2str(_beacon.t2, 40)
-        rs=RadioSetting("t2", "CW Beacon Line 2",
-                        RadioSettingValueString(0, 40, tmp))
+        rs = RadioSetting("t2", "CW Beacon Line 2",
+                          RadioSettingValueString(0, 40, tmp))
         rs.set_apply_callback(self._my_str2ary, _beacon, "t2", 40)
         cw.append(rs)
 
         tmp = self._chars2str(_beacon.t3, 40)
-        rs=RadioSetting("t3", "CW Beacon Line 3",
-                        RadioSettingValueString(0, 40, tmp))
+        rs = RadioSetting("t3", "CW Beacon Line 3",
+                          RadioSettingValueString(0, 40, tmp))
         rs.set_apply_callback(self._my_str2ary, _beacon, "t3", 40)
         cw.append(rs)       # END _do_cw_settings
-
 
     def _do_panel_settings(self, pnlset):    # - - - Panel settings
         _settings = self._memobj.settings
@@ -1174,7 +1172,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         options = ["440Hz", "880Hz", "1760Hz"]
         rs = RadioSetting("beepton", "Beep frequency",
                           RadioSettingValueList(options,
-                          options[_settings.beepton]))
+                                                options[_settings.beepton]))
         pnlset.append(rs)
 
         rs = RadioSetting("beepvol_sgn", "Beep volume Linked",
@@ -1184,41 +1182,41 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
 
         rs = RadioSetting("beepvol_lnk", "Linked beep volume",
                           RadioSettingValueInteger(-50, 50,
-                          _settings.beepvol_lnk))
+                                                   _settings.beepvol_lnk))
         rs.set_doc("Relative to AF-Gain setting.")
         pnlset.append(rs)
 
         rs = RadioSetting("beepvol_fix", "Fixed beep volume",
                           RadioSettingValueInteger(0, 100,
-                          _settings.beepvol_fix))
+                                                   _settings.beepvol_fix))
         rs.set_doc("When Linked setting is unchecked.")
         pnlset.append(rs)
 
         rs = RadioSetting("cont", "LCD Contrast",
-                          RadioSettingValueInteger(1, 24, _settings.cont ))
+                          RadioSettingValueInteger(1, 24, _settings.cont))
         rs.set_doc("This setting does not appear to do anything...")
         pnlset.append(rs)
 
         rs = RadioSetting("dimmer", "LCD Dimmer",
-                          RadioSettingValueInteger(1, 8,  _settings.dimmer ))
+                          RadioSettingValueInteger(1, 8,  _settings.dimmer))
         pnlset.append(rs)
 
         options = ["RF-Gain", "Squelch"]
         rs = RadioSetting("sql_rfg", "Squelch/RF-Gain",
                           RadioSettingValueList(options,
-                          options[_settings.sql_rfg]))
+                                                options[_settings.sql_rfg]))
         pnlset.append(rs)
 
         options = ["Frequencies", "Panel", "All"]
         rs = RadioSetting("lockmod", "Lock Mode",
                           RadioSettingValueList(options,
-                          options[_settings.lockmod]))
+                                                options[_settings.lockmod]))
         pnlset.append(rs)
 
         options = ["Dial", "SEL"]
         rs = RadioSetting("clar_btn", "CLAR button control",
                           RadioSettingValueList(options,
-                          options[_settings.clar_btn]))
+                                                options[_settings.clar_btn]))
         pnlset.append(rs)
 
         if _settings.dialstp_mode == 0:             # AM/FM
@@ -1227,13 +1225,13 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
             options = ["AM/FM:100Hz", "AM/FM:200Hz"]
         rs = RadioSetting("dialstp", "Dial tuning step",
                           RadioSettingValueList(options,
-                          options[_settings.dialstp]))
+                                                options[_settings.dialstp]))
         pnlset.append(rs)
 
         options = ["0.5secs", "1.0secs", "1.5secs", "2.0secs"]
         rs = RadioSetting("keyhold", "Buttons hold-to-activate time",
                           RadioSettingValueList(options,
-                          options[_settings.keyhold]))
+                                                options[_settings.keyhold]))
         pnlset.append(rs)
 
         rs = RadioSetting("m_tune", "Memory tune",
@@ -1245,10 +1243,10 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         pnlset.append(rs)
 
         options = ["CW Sidetone", "CW Speed", "100KHz step", "1MHz Step",
-                          "Mic Gain", "RF Power"]
+                   "Mic Gain", "RF Power"]
         rs = RadioSetting("seldial", "SEL dial 2nd function (push)",
                           RadioSettingValueList(options,
-                          options[_settings.seldial]))
+                                                options[_settings.seldial]))
         pnlset.append(rs)
     # End _do_panel_settings
 
@@ -1257,7 +1255,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
 
         rs = RadioSetting("pnl_cs", "C.S. Function",
                           RadioSettingValueList(self.FUNC_LIST,
-                          self.FUNC_LIST[_settings.pnl_cs]))
+                                                self.FUNC_LIST[_settings.pnl_cs]))
         pnlcfg.append(rs)
 
         rs = RadioSetting("nb", "Noise blanker",
@@ -1267,7 +1265,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         options = ["Auto", "Fast",  "Slow", "Auto/Fast", "Auto/Slow", "?5?"]
         rs = RadioSetting("agc", "AGC",
                           RadioSettingValueList(options,
-                          options[_settings.agc]))
+                                                options[_settings.agc]))
         pnlcfg.append(rs)
 
         rs = RadioSetting("keyer", "Keyer",
@@ -1285,7 +1283,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         options = ["PO",  "ALC", "SWR"]
         rs = RadioSetting("mtr_mode", "S-Meter mode",
                           RadioSettingValueList(options,
-                          options[_settings.mtr_mode]))
+                                                options[_settings.mtr_mode]))
         pnlcfg.append(rs)
         # End _do_panel_Buttons
 
@@ -1298,40 +1296,40 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
 
         rs = RadioSetting("vox_gain", "VOX Gain",
                           RadioSettingValueInteger(0, 100,
-                          _settings.vox_gain))
+                                                   _settings.vox_gain))
         voxdat.append(rs)
 
         rs = RadioSetting("dig_vox", "Digital VOX Gain",
                           RadioSettingValueInteger(0, 100,
-                          _settings.dig_vox))
+                                                   _settings.dig_vox))
         voxdat.append(rs)
 
         rs = RadioSetting("d_disp", "User-L/U freq offset (Hz)",
                           RadioSettingValueInteger(-3000, 30000,
-                          _settings.d_disp, 10))
+                                                   _settings.d_disp, 10))
         voxdat.append(rs)
 
         options = ["170Hz", "200Hz", "425Hz", "850Hz"]
         rs = RadioSetting("rty_sft", "RTTY FSK Freq Shift",
                           RadioSettingValueList(options,
-                          options[_settings.rty_sft]))
+                                                options[_settings.rty_sft]))
         voxdat.append(rs)
 
         options = ["1275Hz", "2125Hz"]
         rs = RadioSetting("rty_ton", "RTTY FSK Mark tone",
                           RadioSettingValueList(options,
-                          options[_settings.rty_ton]))
+                                                options[_settings.rty_ton]))
         voxdat.append(rs)
 
         options = ["Normal", "Reverse"]
         rs = RadioSetting("rtyrpol", "RTTY Mark/Space RX polarity",
                           RadioSettingValueList(options,
-                          options[_settings.rtyrpol]))
+                                                options[_settings.rtyrpol]))
         voxdat.append(rs)
 
         rs = RadioSetting("rtytpol", "RTTY Mark/Space TX polarity",
                           RadioSettingValueList(options,
-                          options[_settings.rtytpol]))
+                                                options[_settings.rtytpol]))
         voxdat.append(rs)
         # End _do_vox_settings
 
@@ -1345,7 +1343,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         options = ["Low", "Normal", "High"]
         rs = RadioSetting("micgain", "Mic Gain",
                           RadioSettingValueList(options,
-                          options[_settings.micgain]))
+                                                options[_settings.micgain]))
         mic.append(rs)
 
         rs = RadioSetting("micscan", "Mic scan enabled",
@@ -1355,22 +1353,22 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
 
         rs = RadioSetting("pm_dwn", "Mic Down button function",
                           RadioSettingValueList(self.FUNC_LIST,
-                          self.FUNC_LIST[_settings.pm_dwn]))
+                                                self.FUNC_LIST[_settings.pm_dwn]))
         mic.append(rs)
 
         rs = RadioSetting("pm_fst", "Mic Fast button function",
                           RadioSettingValueList(self.FUNC_LIST,
-                          self.FUNC_LIST[_settings.pm_fst]))
+                                                self.FUNC_LIST[_settings.pm_fst]))
         mic.append(rs)
 
         rs = RadioSetting("pm_up", "Mic Up button function",
                           RadioSettingValueList(self.FUNC_LIST,
-                          self.FUNC_LIST[_settings.pm_up]))
+                                                self.FUNC_LIST[_settings.pm_up]))
         mic.append(rs)
         # End _do_mic_settings
 
     def _do_mymodes_settings(self, mymodes):    # - - MYMODES
-        _settings = self._memobj.settings # Inverted Logic requires callback
+        _settings = self._memobj.settings  # Inverted Logic requires callback
 
         bx = not _settings.mym_lsb
         rs = RadioSetting("mym_lsb", "LSB", RadioSettingValueBoolean(bx))
@@ -1404,7 +1402,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
         # End _do_mymodes_settings
 
     def _do_mybands_settings(self, mybands):    # - - MYBANDS Settings
-        _settings = self._memobj.settings # Inverted Logic requires callback
+        _settings = self._memobj.settings  # Inverted Logic requires callback
 
         bx = not _settings.myb_1_8
         rs = RadioSetting("myb_1_8", "1.8 MHz", RadioSettingValueBoolean(bx))

--- a/chirp/drivers/ft60.py
+++ b/chirp/drivers/ft60.py
@@ -795,7 +795,7 @@ class FT60Radio(yaesu_clone.YaesuCloneModeRadio):
             _nam = self._memobj.names[mem.number - 1]
             _skp = self._memobj.flags[(mem.number - 1) / 4]
 
-        assert(_mem)
+        assert (_mem)
         if mem.empty:
             _mem.used = False
             return

--- a/chirp/drivers/ft70.py
+++ b/chirp/drivers/ft70.py
@@ -40,16 +40,16 @@ MEM_SETTINGS_FORMAT = """
 
 // FT-70DE New Model #5329
 //
-// Communications Mode ? AMS,FM DN,DW   TX vs RX? 
-// Mode not currently correctly stored in memories ? - ALL show as FM in memories 
+// Communications Mode ? AMS,FM DN,DW   TX vs RX?
+// Mode not currently correctly stored in memories ? - ALL show as FM in memories
 // SKIP test/where stored
 // Check storage of steps
 // Pager settings ?
 // Triple check/ understand _memsize and _block_lengths
-// Bank name label name size display 6 store 16? padded with 0xFF same for MYCALL and message 
+// Bank name label name size display 6 store 16? padded with 0xFF same for MYCALL and message
 // CHIRP mode DIG not supported - is there a CHIRP Fusion mode? Auto?
 // Check character set
-// Supported Modes ?  
+// Supported Modes ?
 // Supported Bands ?
 // rf.has_dtcs_polarity = False - think radio supports DTCS polarity
 // rf.memory_bounds = (1, 900) - should this be 0? as zero displays as blank
@@ -59,13 +59,13 @@ MEM_SETTINGS_FORMAT = """
 // Banks and VFO?
 
 // Features Required
-// Default AMS and Memory name (in mem extras) to enabled. 
+// Default AMS and Memory name (in mem extras) to enabled.
 
 // Bugs
 // MYCALL and Opening Message errors if not 10 characters
 // Values greater than one sometimes stored as whole bytes, these need to be refactored into bit fields
-// to prevent accidental overwriting of adjacent values  
-// Bank Name length not checked on gui input - but first 6 characters are saved correctly. 
+// to prevent accidental overwriting of adjacent values
+// Bank Name length not checked on gui input - but first 6 characters are saved correctly.
 // Extended characters entered as bank names on radio are corrupted in Chirp
 
 // Missing
@@ -74,59 +74,59 @@ MEM_SETTINGS_FORMAT = """
 
 // Radio Questions
 // Temp unit C/F not saved by radio, always goes back to C ?
-// 44 RF SQL Adjusts the RF Squelch threshold level. OFF / S1 - S9? Default is OFF - Based on RF strength - for AM? How 
+// 44 RF SQL Adjusts the RF Squelch threshold level. OFF / S1 - S9? Default is OFF - Based on RF strength - for AM? How
 // is this different from F, Monitor, Dial Squelch?
-// Password setting on radio allows letters (DTMF), but letters cannot be entered at the radio's password prompt?  
-// 49 SCM.WTH Set the memory scan frequency range. ALL / BAND Defaults to ALL Not Band as stated in the manual. 
-    
+// Password setting on radio allows letters (DTMF), but letters cannot be entered at the radio's password prompt?
+// 49 SCM.WTH Set the memory scan frequency range. ALL / BAND Defaults to ALL Not Band as stated in the manual.
+
    #seekto 0x049a;
-    struct { 
+    struct {
     u8 unknown0:4,
     squelch:4;              // Squelch F, Monitor, Dial Adjust the Squelch level
-    } squelch_settings; 
-        
+    } squelch_settings;
+
     #seekto 0x04ba;
-    struct { 
+    struct {
     u8 unknown:3,
     scan_resume:5;          // 52 SCN.RSM   Configure the scan stop mode settings. 2.0 S - 5.0 S - 10.0 S / BUSY / HOLD
-    u8 unknown1:3, 
+    u8 unknown1:3,
     dw_resume_interval:5;   // 22 DW RSM    Configure the scan stop mode settings for Dual Receive. 2.0S-10.0S/BUSY/HOLD
-    u8 unknown2;          
+    u8 unknown2;
     u8 unknown3:3,
     apo:5;                  // 02 APO       Set the length of time until the transceiver turns off automatically.
-    u8 unknown4:6, 
-    gm_ring:2;              // 24 GM RNG    Select the beep option while receiving digital GM info. OFF/IN RNG/ALWAYS 
-    u8 temp_cf;             // Placeholder as not found                        
+    u8 unknown4:6,
+    gm_ring:2;              // 24 GM RNG    Select the beep option while receiving digital GM info. OFF/IN RNG/ALWAYS
+    u8 temp_cf;             // Placeholder as not found
     u8 unknown5;
-    } first_settings;   
-   
+    } first_settings;
+
     #seekto 0x04ed;
-    struct {   
+    struct {
     u8 unknown1:1,
-    unknown2:1,           
+    unknown2:1,
     unknown3:1,
-    unknown4:1,            
-    unknown5:1,          
-    unknown6:1, 
-    unknown7:1,          
-    unknown8:1;          
-    } test_bit_field;    
-    
+    unknown4:1,
+    unknown5:1,
+    unknown6:1,
+    unknown7:1,
+    unknown8:1;
+    } test_bit_field;
+
     #seekto 0x04c0;
     struct {
     u8 unknown1:5,
     beep_level:3;           // 05 BEP.LVL   Beep volume setting LEVEL1 - LEVEL4 - LEVEL7
     u8 unknown2:6,
     beep_select:2;          // 04 BEEP      Sets the beep sound function OFF / KEY+SC / KEY
-    } beep_settings;        
-    
-    #seekto 0x04ce;                     
+    } beep_settings;
+
+    #seekto 0x04ce;
     struct {
     u8 lcd_dimmer;                      // 14 DIMMER    LCD Dimmer
-    u8 dtmf_delay;                      // 18 DT DLY    DTMF delay    
-    u8 unknown0[3];             
+    u8 dtmf_delay;                      // 18 DT DLY    DTMF delay
+    u8 unknown0[3];
     u8 unknown1:4,
-    unknown1:4;      
+    unknown1:4;
     u8 lamp;                            // 28 LAMP      Set the duration time of the backlight and keys to be lit
     u8 lock;                            // 30 LOCK      Configure the lock mode setting. KEY/DIAL/K+D/PTT/K+P/D+P/ALL
     u8 unknown2_1;
@@ -134,46 +134,46 @@ MEM_SETTINGS_FORMAT = """
     u8 unknown2_3;
     u8 dw_interval;                     // 21 DW INT Set the priority memory ch mon int during Dual RX 0.1S-5.0S-10.0S
     u8 ptt_delay;                       // 42 PTT.DLY   Set the PTT delay time. OFF / 20 MS / 50 MS / 100 MS / 200 MS
-    u8 rx_save;                         // 48 RX.SAVE   Set the battery save time. OFF / 0.2 S - 60.0 S    
+    u8 rx_save;                         // 48 RX.SAVE   Set the battery save time. OFF / 0.2 S - 60.0 S
     u8 scan_restart;                    // 53 SCN.STR   Set the scanning restart time.  0.1 S - 2.0 S - 10.0 S
-    u8 unknown2_5;                      
-    u8 unknown2_6;          
+    u8 unknown2_5;
+    u8 unknown2_6;
     u8 unknown4[5];
-    u8 tot;                             // 56 TOT       Set the transmission timeout timer 
-    u8 unknown5[3];          // 26                                                
+    u8 tot;                             // 56 TOT       Set the transmission timeout timer
+    u8 unknown5[3];          // 26
     u8 vfo_mode:1,                      // 60 VFO.MOD   Set freq setting range in the VFO mode by DIAL knob. ALL / BAND
     unknown7:1,
     scan_lamp:1,                        // 51 SCN.LMP   Set the scan lamp ON or OFF when scanning stops On/Off
     unknown8:1,
     ars:1,                              // 45 RPT.ARS   Turn the ARS function on/off.
     dtmf_speed:1,                       // 20 DT SPD    Set DTMF speed
-    unknown8:1,                        
+    unknown8:1,
     dtmf_mode:1;                        // DTMF Mode set from front panel
-    u8 busy_led:1,                      // Not Supported ?  
+    u8 busy_led:1,                      // Not Supported ?
     unknown8_2:1,
     unknown8_3:1,
     bclo:1,                             // 03 BCLO      Turns the busy channel lockout function on/off.
-    beep_edge:1,                        // 06 BEP.Edg   Sets the beep sound ON or OFF when a band edge is encountered.    
-    unknown8_6:1, 
+    beep_edge:1,                        // 06 BEP.Edg   Sets the beep sound ON or OFF when a band edge is encountered.
+    unknown8_6:1,
     unknown8_7:1,
     unknown8_8:1;            // 28
-    u8 unknown9_1:1,                   
+    u8 unknown9_1:1,
     unknown9_2:1,
     unknown9_3:1,
-    unknown9_4:1,         
-    unknown9_5:1,             
+    unknown9_4:1,
+    unknown9_5:1,
     password:1,                         // Placeholder location
     home_rev:1,                         // 26 HOME/REV   Select the function of the [HOME/REV] key.
     moni:1;                             // 32 Mon/T-Call Select the function of the [MONI/T-CALL] switch.
-    u8 gm_interval:4,       // 30       // 25 GM INT Set tx interval of digital GM information. OFF / NORMAL / LONG 
+    u8 gm_interval:4,       // 30       // 25 GM INT Set tx interval of digital GM information. OFF / NORMAL / LONG
     unknown10:4;
-    u8 unknown11;          
+    u8 unknown11;
     u8 unknown12:1,
     unknown12_2:1,
     unknown12_3:1,
-    unknown12_4:1,                
+    unknown12_4:1,
     home_vfo:1,                         // 27 HOME->VFO  Turn transfer VFO to the Home channel ON or OFF.
-    unknown12_6:1, 
+    unknown12_6:1,
     unknown12_7:1,
     dw_rt:1;                // 32       // 23 DW RVT Turn "Priority Channel Revert" feature ON or OFF during Dual Rx.
     u8 unknown33;
@@ -181,7 +181,7 @@ MEM_SETTINGS_FORMAT = """
     u8 unknown35;
     u8 unknown36;
     u8 unknown37;
-    u8 unknown38; 
+    u8 unknown38;
     u8 unknown39;
     u8 unknown40;
     u8 unknown41;
@@ -193,39 +193,39 @@ MEM_SETTINGS_FORMAT = """
     u8 prog_key2;           // P2 Set Mode Items to the Programmable Key
     u8 unknown48;
     u8 unknown49;
-    u8 unknown50;                      
-    } scan_settings;    
-    
-    #seekto 0x064b;  
+    u8 unknown50;
+    } scan_settings;
+
+    #seekto 0x064b;
     struct {
     u8 unknown1:1,
     unknown2:1,
     unknown3:1,
     unknown4:1,
-    vfo_scan_width:1,       // Placeholder as not found - 50 SCV.WTH Set the VFO scan frequency range. BAND / ALL 
-    memory_scan_width:1,    // Placeholder as not found - 49 SCM.WTH Set the memory scan frequency range. ALL / BAND 
+    vfo_scan_width:1,       // Placeholder as not found - 50 SCV.WTH Set the VFO scan frequency range. BAND / ALL
+    memory_scan_width:1,    // Placeholder as not found - 49 SCM.WTH Set the memory scan frequency range. ALL / BAND
     unknown7:1,
     unknown8:1;
     } scan_settings_1;
-    
-    #seekto 0x06B6;  
+
+    #seekto 0x06B6;
     struct {
     u8 unknown1:3,
     volume:5;               // # VOL and Dial  Adjust the volume level
-    } scan_settings_2;       
-        
+    } scan_settings_2;
+
     #seekto 0x0690;         // Memory or VFO Settings Map?
     struct {
     u8 unknown[48];         // Array cannot be 64 elements!
-    u8 unknown1[16];        // Exception: Not implemented for chirp.bitwise.structDataElement       
+    u8 unknown1[16];        // Exception: Not implemented for chirp.bitwise.structDataElement
     } vfo_info_1;
-    
+
     #seekto 0x0710;         // Backup Memory or VFO Settings Map?
     struct {
     u8 unknown[48];
     u8 unknown1[16];
-    } vfo_backup_info_1;      
-   
+    } vfo_backup_info_1;
+
     #seekto 0x047e;
     struct {
     u8 unknown1;
@@ -234,30 +234,30 @@ MEM_SETTINGS_FORMAT = """
     struct {
     char padded_string[6];              // 36 OPN.MSG   Select MSG then key vm to edit it
     } message;
-    } opening_message;                  // 36 OPN.MSG   Select the Opening Message when transceiver is ON. OFF/MSG/DC    
- 
+    } opening_message;                  // 36 OPN.MSG   Select the Opening Message when transceiver is ON. OFF/MSG/DC
+
     #seekto 0x094a;                     // DTMF Memories
     struct {
     u8 memory[16];
-    } dtmf[10];    
-    
-    #seekto 0x154a;                     
+    } dtmf[10];
+
+    #seekto 0x154a;
     struct {
     u16 channel[100];
     } bank_members[24];
-    
+
     #seekto 0x54a;
     struct {
     u16 in_use;
     } bank_used[24];
-    
+
     #seekto 0x0EFE;
     struct {
     u8 unknown[2];
     u8 name[6];
     u8 unknown1[10];
     } bank_info[24];
-        
+
     #seekto 0xCF30;
     struct {
     u8 unknown0;
@@ -267,9 +267,9 @@ MEM_SETTINGS_FORMAT = """
     u8 unknown4;
     u8 unknown5;
     u8 unknown6;
-    u8 digital_popup;                   // 15 DIG.POP   Call sign display pop up time                
+    u8 digital_popup;                   // 15 DIG.POP   Call sign display pop up time
     } digital_settings_more;
-   
+
     #seekto 0xCF7C;
     struct {
     u8 unknown0:6,
@@ -277,26 +277,26 @@ MEM_SETTINGS_FORMAT = """
     u8 unknown1;
     u8 unknown2:7,
     standby_beep:1;                     // 07 BEP.STB   Standby Beep in the digital C4FM mode. On/Off
-    u8 unknown3; 
+    u8 unknown3;
     u8 unknown4:6,
     gm_ring:2;                          // 24 GM RNG Select beep option while rx digital GM info. OFF/IN RNG/ALWAYS
     u8 unknown5;
     u8 rx_dg_id;                        // RX DG-ID     Long Press Mode Key, Mode Key to select, Dial
-    u8 tx_dg_id;                        // TX DG-ID     Long Press Mode Key, Dial                  
+    u8 tx_dg_id;                        // TX DG-ID     Long Press Mode Key, Dial
     u8 unknown6:7,
     vw_mode:1;                          // 16 DIG VW    Turn the VW mode selection ON or OFF
     u8 unknown7;
     } digital_settings;
-    
+
     // ^^^ All above referenced U8's have been refactored to minimum number of bits.
-    
+
     """
 
 MEM_FORMAT = """
     #seekto 0x2D4A;
     struct {                            // 32 Bytes per memory entry
     u8 display_tag:1,                   // 0 Display Freq, 1 Display Name
-    unknown0:1,                         // Mode if AMS not selected???????? 
+    unknown0:1,                         // Mode if AMS not selected????????
     deviation:1,                        // 0 Full deviation (Wide), 1 Half deviation (Narrow)
     clock_shift:1,                      // 0 None, 1 CPU clock shifted
     unknown1:4;                                                                         // 1
@@ -305,19 +305,19 @@ MEM_FORMAT = """
     tune_step:4;                        // Works - check all steps? 7 = Auto            // 1
     bbcd freq[3];                       // Works                                        // 3
     u8 power:2,                         // Works
-    unknown2:1,                         // 0 FM, 1 Digital - If AMS off     
-    ams:1,                              // 0 AMS off, 1 AMS on ?        
+    unknown2:1,                         // 0 FM, 1 Digital - If AMS off
+    ams:1,                              // 0 AMS off, 1 AMS on ?
     tone_mode:4;                        // Works                                        // 1
-    u8 charsetbits[2];                                                                  // 2    
+    u8 charsetbits[2];                                                                  // 2
     char label[6];                      // Works - Can only input 6 on screen           // 6
-    char unknown7[10];                  // Rest of label ???                            // 10    
+    char unknown7[10];                  // Rest of label ???                            // 10
     bbcd offset[3];                     // Works                                        // 3
     u8 unknown5:2,
     tone:6;                             // Works                                       // 1
     u8 unknown6:1,
     dcs:7;                              // Works                                        // 1
     u8 unknown9;
-    u8 ams_on_dn_vw_fm:2,               // AMS DN, AMS VW, AMS FM  
+    u8 ams_on_dn_vw_fm:2,               // AMS DN, AMS VW, AMS FM
     unknown8_3:1,
     unknown8_4:1,
     smeter:4;
@@ -327,16 +327,16 @@ MEM_FORMAT = """
        auto_mode:1,
        unknown11:2,
        bell:1;
-    } memory[%d];                        // DN, VW, FM, AM 
-                                        // AMS DN, AMS VW, AMS FM  
-    
+    } memory[%d];                        // DN, VW, FM, AM
+                                        // AMS DN, AMS VW, AMS FM
+
     #seekto 0x280A;
     struct {
     u8 nosubvfo:1,
     unknown:3,
     pskip:1,                            // PSkip (Select?)
     skip:1,                             // Skip memory during scan
-    used:1,                             // Memory used 
+    used:1,                             // Memory used
     valid:1;                            // Always 1?
     } flag[%d];
     """

--- a/chirp/drivers/ft70.py
+++ b/chirp/drivers/ft70.py
@@ -535,7 +535,7 @@ class FT70Radio(yaesu_clone.YaesuCloneModeRadio):
     _GM_RING = ("OFF", "IN RING", "AlWAYS")
     _GM_INTERVAL = ("LONG", "NORMAL", "OFF")
 
-    _MYCALL_CHR_SET = list(string.ascii_uppercase) + list(string.digits) + ['-','/' ]
+    _MYCALL_CHR_SET = list(string.ascii_uppercase) + list(string.digits) + ['-', '/']
 
     @classmethod
     def match_model(cls, filedata, filename):
@@ -969,12 +969,12 @@ class FT70Radio(yaesu_clone.YaesuCloneModeRadio):
         # MYCALL
         mycall = self._memobj.my_call
         mycallstr = str(mycall.callsign).rstrip("\xFF")
-    
+
         mycallentry = RadioSettingValueString(0, 10, mycallstr, False, charset=self._MYCALL_CHR_SET)
         rs = RadioSetting('mycall.callsign', 'MYCALL', mycallentry)
         rs.set_apply_callback(self.apply_mycall, mycall)
         menu.append(rs)
-        
+
         # Short Press AMS button AMS TX Mode
 
         digital_settings = self._memobj.digital_settings

--- a/chirp/drivers/ft7800.py
+++ b/chirp/drivers/ft7800.py
@@ -771,6 +771,7 @@ class FT7800Radio(FTx800Radio):
                 LOG.debug(element.get_name())
                 raise
 
+
 MEM_FORMAT_8800 = """
 #seekto 0x%X;
 struct {
@@ -932,6 +933,7 @@ class FT8800RadioRight(FT8800Radio):
     VARIANT = "Right"
     _memstart = 0x2948
     _bankstart = 0x4BC8
+
 
 MEM_FORMAT_8900 = """
 #seekto 0x0708;

--- a/chirp/drivers/ft857.py
+++ b/chirp/drivers/ft857.py
@@ -484,7 +484,7 @@ class FT857Radio(ft817.FT817Radio):
         elif mem.tmode == "TSQL":
             mem.rtone = mem.ctone = chirp_common.TONES[_mem.tone]
         elif mem.tmode == "DTCS Enc":   # UI does not support it yet but
-                                        # this code has already been tested
+            # this code has already been tested
             mem.dtcs = mem.rx_dtcs = chirp_common.DTCS_CODES[_mem.dcs]
         elif mem.tmode == "DTCS":
             mem.dtcs = mem.rx_dtcs = chirp_common.DTCS_CODES[_mem.dcs]
@@ -511,7 +511,7 @@ class FT857Radio(ft817.FT817Radio):
         elif mem.tmode == "TSQL":
             _mem.tone = _mem.rxtone = chirp_common.TONES.index(mem.ctone)
         elif mem.tmode == "DTCS Enc":   # UI does not support it yet but
-                                        # this code has already been tested
+            # this code has already been tested
             _mem.dcs = _mem.rxdcs = chirp_common.DTCS_CODES.index(mem.dtcs)
         elif mem.tmode == "DTCS":
             _mem.dcs = _mem.rxdcs = chirp_common.DTCS_CODES.index(mem.rx_dtcs)

--- a/chirp/drivers/ftlx011.py
+++ b/chirp/drivers/ftlx011.py
@@ -53,7 +53,7 @@ u8 scan_resume:1,           // Scan sesume: 0 = 0.5 seconds, 1 = Carrier
    talk_back:1,             // Talk Back: 0 = enabled, 1 = disabled
    tx_carrier_delay:1;      // TX carrier delay: 1 = enabled, 0 = disabled
 u8 tot:4,                   // Time out timer: 16 values (0.0-7.5 in 0.5s step)
-   tot_resume:2,            // Time out timer resume: 3, 2, 1, 0 => 0s, 6s, 20s, 60s 
+   tot_resume:2,            // Time out timer resume: 3, 2, 1, 0 => 0s, 6s, 20s, 60s
    unknownB:2;
 u8 a_key:2,                 // A key function: resume: 0-3: Talkaround, High/Low, Call, Accessory
    unknownB:6;

--- a/chirp/drivers/ftlx011.py
+++ b/chirp/drivers/ftlx011.py
@@ -100,9 +100,9 @@ LIST_SCAN_P_SPEED = ["Slow", "Fast"]
 LIST_HOME_CHANNEL = ["Scan Start ch", "Priority 1ch"]
 LIST_TOT = ["Off"] + ["%.1f s" % (x/10.0) for x in range(5, 80, 5)]
 # 3, 2, 1, 0 => 0s, 6s, 20s, 60s
-LIST_TOT_RESUME = ["60s","20s","6s","0s"]
+LIST_TOT_RESUME = ["60s", "20s", "6s", "0s"]
 LIST_A_KEY = ["Talkaround", "High/Low", "Call", "Accessory"]
-LIST_PCH = [] # dynamic, as depends on channel list.
+LIST_PCH = []  # dynamic, as depends on channel list.
 # make a copy of the tones, is not funny to work with this directly
 TONES = list(chirp_common.TONES)
 # this old radios has not the full tone ranges in CST
@@ -139,7 +139,7 @@ def _checksum(data):
     """the radio block checksum algorithm"""
     cs = 0
     for byte in data:
-            cs += ord(byte)
+        cs += ord(byte)
 
     return cs % 256
 
@@ -170,7 +170,7 @@ def _do_download(radio):
     for i in range(0, MEM_SIZE):
         a = radio.pipe.read(1)
         if len(a) == 0:
-            # error, no received data
+        # error, no received data
             if len(data) != 0:
                 # received some data, not the complete stream
                 msg = "Just %02i bytes of the %02i received, try again." % \
@@ -212,11 +212,10 @@ def _do_upload(radio):
     status.msg = " Quick, press MON on the radio to start. "
     radio.status_fn(status)
 
-    for byte in range(0,100):
+    for byte in range(0, 100):
         status.cur = byte
         radio.status_fn(status)
         time.sleep(0.1)
-
 
     # real upload if user don't cancel the timeout
     status.cur = 0
@@ -278,7 +277,7 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
     _memsize = MEM_SIZE
     _upper = 0
     _range = []
-    finger = [] # two elements rid & IF
+    finger = []  # two elements rid & IF
 
     @classmethod
     def get_prompts(cls):
@@ -402,7 +401,7 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
             t = mem.rx_tone
         else:
             t = mem.tx_tone
-        
+
         tMSB = t[0]
         tLSB = t[1]
 
@@ -443,7 +442,7 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
         if mode == "DTCS":
             tone[0] = int(value / 100) + 0x88
             tone[1] = int_to_bcd(value % 100)
-        
+
         if mode == "Tone":
             #CTCS
             tone[1] = TONES.index(value) + 128
@@ -614,7 +613,7 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
                         # activate the tone
                         _mem.rx_tone = [0x00, 0x80]
         else:
-            # reset extra settings 
+            # reset extra settings
             _zero_settings()
 
         _mem.chname = chname
@@ -626,20 +625,20 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
         basic = RadioSettingGroup("basic", "Basic Settings")
         group = RadioSettings(basic)
 
-        # ## Basic Settings 
+        # ## Basic Settings
         scanr = RadioSetting("scan_resume", "Scan resume by",
-                          RadioSettingValueList(
+                             RadioSettingValueList(
                               LIST_SCAN_RESUME, LIST_SCAN_RESUME[_settings.scan_resume]))
         basic.append(scanr)
 
         scant = RadioSetting("scan_time", "Scan time per channel",
-                          RadioSettingValueList(
+                             RadioSettingValueList(
                               LIST_SCAN_TIME, LIST_SCAN_TIME[_settings.scan_time]))
         basic.append(scant)
 
         LIST_PCH = ["%s" % x for x in range(1, _settings.chcount + 1)]
         pch1 = RadioSetting("pch1", "Priority channel 1",
-                             RadioSettingValueList(
+                            RadioSettingValueList(
                                  LIST_PCH, LIST_PCH[_settings.pch1]))
         basic.append(pch1)
 
@@ -657,8 +656,8 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
                                 LIST_SCAN_P_SPEED, LIST_SCAN_P_SPEED[_settings.priority_speed]))
         basic.append(scanps)
 
-        oh = RadioSetting("off_hook", "Off Hook", #inverted
-                        RadioSettingValueBoolean(not _settings.off_hook))
+        oh = RadioSetting("off_hook", "Off Hook",  # inverted
+                          RadioSettingValueBoolean(not _settings.off_hook))
         basic.append(oh)
 
         tb = RadioSetting("talk_back", "Talk Back",  # inverted
@@ -666,17 +665,17 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
         basic.append(tb)
 
         tot = RadioSetting("tot", "Time out timer",
-                             RadioSettingValueList(
+                           RadioSettingValueList(
                                  LIST_TOT, LIST_TOT[_settings.tot]))
         basic.append(tot)
 
         totr = RadioSetting("tot_resume", "Time out timer resume guard",
-                           RadioSettingValueList(
+                            RadioSettingValueList(
                                LIST_TOT_RESUME, LIST_TOT_RESUME[_settings.tot_resume]))
         basic.append(totr)
 
         ak = RadioSetting("a_key", "A Key function",
-                            RadioSettingValueList(
+                          RadioSettingValueList(
                                 LIST_A_KEY, LIST_A_KEY[_settings.a_key]))
         basic.append(ak)
 
@@ -692,7 +691,6 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
         txd = RadioSetting("tx_carrier_delay", "Talk Back",
                            RadioSettingValueBoolean(_settings.tx_carrier_delay))
         basic.append(txd)
-
 
         return group
 

--- a/chirp/drivers/ftlx011.py
+++ b/chirp/drivers/ftlx011.py
@@ -170,7 +170,7 @@ def _do_download(radio):
     for i in range(0, MEM_SIZE):
         a = radio.pipe.read(1)
         if len(a) == 0:
-        # error, no received data
+            # error, no received data
             if len(data) != 0:
                 # received some data, not the complete stream
                 msg = "Just %02i bytes of the %02i received, try again." % \

--- a/chirp/drivers/ftlx011.py
+++ b/chirp/drivers/ftlx011.py
@@ -24,15 +24,15 @@ from chirp.settings import RadioSettingGroup, RadioSetting, \
 
 LOG = logging.getLogger(__name__)
 
-### SAMPLE MEM DUMP as sent from the radios
+# SAMPLE MEM DUMP as sent from the radios
 
 # FTL-1011
-#0x000000  52 f0 16 90 04 08 38 c0  00 00 00 01 00 00 00 ff  |R.....8.........|
-#0x000010  20 f1 00 20 00 00 00 20  04 47 25 04 47 25 00 00  | .. ... .G%.G%..|
+# 0x000000  52 f0 16 90 04 08 38 c0  00 00 00 01 00 00 00 ff  |R.....8.........|
+# 0x000010  20 f1 00 20 00 00 00 20  04 47 25 04 47 25 00 00  | .. ... .G%.G%..|
 
 # FTL-2011
-#0x000000: 50 90 21 40 04 80 fc 40  00 00 00 01 00 00 00 ff  |P.!@...@........|
-#0x000010: 20 f1 00 0b 00 00 00 0b  14 51 70 14 45 70 00 00  |.........Qp.Ep..|
+# 0x000000: 50 90 21 40 04 80 fc 40  00 00 00 01 00 00 00 ff  |P.!@...@........|
+# 0x000010: 20 f1 00 0b 00 00 00 0b  14 51 70 14 45 70 00 00  |.........Qp.Ep..|
 
 
 MEM_FORMAT = """
@@ -338,7 +338,7 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
         rf.valid_skips = SKIP_VALUES
         rf.valid_modes = ["FM"]
         rf.valid_power_levels = POWER_LEVELS
-        #rf.valid_tuning_steps = [5.0]
+        # rf.valid_tuning_steps = [5.0]
         rf.valid_bands = [self._range]
         rf.memory_bounds = (1, self._upper)
         return rf
@@ -444,7 +444,7 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
             tone[1] = int_to_bcd(value % 100)
 
         if mode == "Tone":
-            #CTCS
+            # CTCS
             tone[1] = TONES.index(value) + 128
 
         # set it

--- a/chirp/drivers/hobbypcb.py
+++ b/chirp/drivers/hobbypcb.py
@@ -183,7 +183,7 @@ class HobbyPCBRSUV3Radio(chirp_common.LiveRadio):
 
         tg = RadioSetting('TG%7s', 'CW Timeout Message',
                           RadioSettingValueString(0, 7,
-                                                   _get('TG')))
+                                                  _get('TG')))
         cw.append(tg)
 
         io = RadioSettingGroup('io', 'IO')

--- a/chirp/drivers/icv80.py
+++ b/chirp/drivers/icv80.py
@@ -473,7 +473,7 @@ class ICV80Radio(icf.IcomCloneModeRadio, chirp_common.ExperimentalRadio):
         _mem = self._memobj.memory[mem.number]
         _unused = self._memobj.unused[byte]
         _skip = (mem.extd_number == "") and self._memobj.skip[byte] or None
-        assert(_mem)
+        assert (_mem)
 
         if mem.empty:
             self._fill_memory(mem)

--- a/chirp/drivers/icv86.py
+++ b/chirp/drivers/icv86.py
@@ -151,7 +151,6 @@ class ICV86Radio(icf.IcomCloneModeRadio):
     def process_mmap(self):
         self._memobj = bitwise.parse(ICV86_MEM_FORMAT, self._mmap)
 
-
     def get_settings(self):
         _settings = self._memobj.settings
 
@@ -168,7 +167,8 @@ class ICV86Radio(icf.IcomCloneModeRadio):
 
         # Mic Gain
         rs = RadioSetting("mic", "Mic Gain",
-                RadioSettingValueInteger(1, 4, _settings.mic + 1))
+                          RadioSettingValueInteger(1, 4, _settings.mic + 1))
+
         def apply_mic(s, obj):
             setattr(obj, s.get_name(), int(s.value) - 1)
         rs.set_apply_callback(apply_mic, self._memobj.settings)
@@ -250,12 +250,12 @@ class ICV86Radio(icf.IcomCloneModeRadio):
         # Extras
         mem.extra = RadioSettingGroup("extra", "Extra")
         rev = RadioSetting("rev", "Reverse duplex",
-                    RadioSettingValueBoolean(bool(_mem.rev)))
+                           RadioSettingValueBoolean(bool(_mem.rev)))
         rev.set_doc("Reverse duplex")
         mem.extra.append(rev)
-        
+
         tx = RadioSetting("tx", "Tx permission",
-                    RadioSettingValueBoolean(bool(_mem.tx)))
+                          RadioSettingValueBoolean(bool(_mem.tx)))
         tx.set_doc("Tx permission")
         mem.extra.append(tx)
 
@@ -268,7 +268,7 @@ class ICV86Radio(icf.IcomCloneModeRadio):
         if not self._mmap:
             self.sync_in()
 
-        assert(self._mmap)
+        assert (self._mmap)
 
         if isinstance(number, str):
             try:
@@ -281,12 +281,12 @@ class ICV86Radio(icf.IcomCloneModeRadio):
     def _fill_memory(self, number):
         _mem = self._memobj.memory[number]
 
-        assert(_mem)
+        assert (_mem)
 
         # zero-fill
         _mem.freq = 146010000
         _mem.offset = 146010000
-        _mem.name =  str("").ljust(5)
+        _mem.name = str("").ljust(5)
         _mem.reserved1 = 0x0
         _mem.rtone = 0x8
         _mem.reserved2 = 0x0
@@ -306,7 +306,7 @@ class ICV86Radio(icf.IcomCloneModeRadio):
         _mem.tx = 0x1
         _mem.reserved8 = 0x0
         _mem.power = 0x0
-        _mem.reserved9 = 0x0 
+        _mem.reserved9 = 0x0
         _mem.reserved10 = 0x0
         _mem.reserved11 = 0x0
         _mem.reserved12 = 0x0
@@ -319,7 +319,7 @@ class ICV86Radio(icf.IcomCloneModeRadio):
         _usd = self._memobj.used[byte] if mem.number <= 206 else None
         _skp = self._memobj.skips[byte] if mem.number < 200 else None
 
-        assert(_mem)
+        assert (_mem)
 
         if mem.empty:
             self._fill_memory(mem.number)
@@ -359,11 +359,10 @@ class ICV86Radio(icf.IcomCloneModeRadio):
         if not self._mmap:
             self.sync_in()
 
-        assert(self._mmap)
+        assert (self._mmap)
 
         return self._set_memory(mem)
 
     def get_raw_memory(self, number):
         return repr(self._memobj.memory[number]) + \
             repr(self._memobj.flags[(number)])
-

--- a/chirp/drivers/icx90.py
+++ b/chirp/drivers/icx90.py
@@ -163,8 +163,8 @@ DTMF_AUTODIAL_NUM = 10
 DTMF_DIGITS_NUM = 16
 OPENING_MESSAGE_LEN = 6
 COMMENT_LEN = 16
-BANDS=10
-TV_CHANNELS=68
+BANDS = 10
+TV_CHANNELS = 68
 
 CHARSET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789()*+-,/|= "
 NAME_LENGTH = 6
@@ -217,6 +217,7 @@ VFO_SCAN = ["All", "Band", "P0", "P1", "P2", "P3", "P4", "P5", "P6", "P7", "P8",
 MEMORY_SCAN = ["All", "Bank", "Sel BC", "Sel 5 MHz", "Sel 50 MHz", "Sel WFM", "Sel Air",
                "Sel 144 MHz", "Sel 220 MHz", "Sel 300 MHz", "Sel 440 MHz", "Sel 800 MHz"]
 
+
 class ICx90BankModel(icf.IcomIndexedBankModel):
     bank_index = BANK_INDEX
 
@@ -225,7 +226,7 @@ class ICx90BankModel(icf.IcomIndexedBankModel):
 
         if (self._radio._num_banks != len(type(self).bank_index)):
             raise Exception("Invalid number of banks %d, supported only %d banks" %
-                (self._radio._num_banks, len(type(self).bank_index)))
+                            (self._radio._num_banks, len(type(self).bank_index)))
 
         for i in range(0, self._radio._num_banks):
             index = type(self).bank_index[i]
@@ -235,9 +236,11 @@ class ICx90BankModel(icf.IcomIndexedBankModel):
 
         return banks
 
+
 class ICT90_Alias(chirp_common.Alias):
     VENDOR = "Icom"
     MODEL = "IC-T90"
+
 
 @directory.register
 class ICx90Radio(icf.IcomCloneModeRadio):
@@ -260,32 +263,32 @@ class ICx90Radio(icf.IcomCloneModeRadio):
         icf.IcomCloneModeRadio.__init__(self, pipe)
 
     def special_add(self, key, item_type, num, unique_idx):
-          item = {}
-          item["item_type"] = item_type
-          item["num"] = num
-          item["uidx"] = unique_idx
-          self.special[key] = item
+        item = {}
+        item["item_type"] = item_type
+        item["num"] = num
+        item["uidx"] = unique_idx
+        self.special[key] = item
 
     def init_special(self):
-      self.special = {}
-      i = 0
-      # program scan edges
-      for x in range(25):
-          self.special_add("Scan edge: %02dA" % x, "scan_edge", x * 2, i)
-          self.special_add("Scan edge: %02dB" % x, "scan_edge", x * 2 + 1, i + 1)
-          i += 2
-      # call channels
-      for x in range(5):
-          self.special_add("Call ch: %d" % x, "call_chan", x, i)
-          i += 1
-      # VFO A
-      for x in range(10):
-          self.special_add("VFO A: %d" % x, "vfo_a", x, i)
-          i += 1
-      # VFO B
-      for x in range(10):
-          self.special_add("VFO B: %d" % x, "vfo_b", x, i)
-          i += 1
+        self.special = {}
+        i = 0
+        # program scan edges
+        for x in range(25):
+            self.special_add("Scan edge: %02dA" % x, "scan_edge", x * 2, i)
+            self.special_add("Scan edge: %02dB" % x, "scan_edge", x * 2 + 1, i + 1)
+            i += 2
+        # call channels
+        for x in range(5):
+            self.special_add("Call ch: %d" % x, "call_chan", x, i)
+            i += 1
+        # VFO A
+        for x in range(10):
+            self.special_add("VFO A: %d" % x, "vfo_a", x, i)
+            i += 1
+        # VFO B
+        for x in range(10):
+            self.special_add("VFO B: %d" % x, "vfo_b", x, i)
+            i += 1
 
     def get_sub_devices(self):
         return [ICx90Radio_ham(self._mmap), ICx90Radio_tv(self._mmap)]
@@ -402,68 +405,68 @@ class ICx90Radio(icf.IcomCloneModeRadio):
                          RadioSettingValueInteger(0, MEM_NUM - 1, self.memobj.mem_channel)))
             basic.append(RadioSetting("squelch_level", "Squelch level",
                          RadioSettingValueList(SQUELCH_LEVEL,
-                         SQUELCH_LEVEL[self.memobj.squelch_level])))
+                                               SQUELCH_LEVEL[self.memobj.squelch_level])))
             basic.append(RadioSetting("scan_resume", "Scan resume",
                          RadioSettingValueList(SCAN_RESUME,
-                         SCAN_RESUME[self.memobj.scan_resume])))
+                                               SCAN_RESUME[self.memobj.scan_resume])))
             basic.append(RadioSetting("scan_pause", "Scan pause",
                          RadioSettingValueList(SCAN_PAUSE,
-                         SCAN_PAUSE[self.memobj.scan_pause])))
+                                               SCAN_PAUSE[self.memobj.scan_pause])))
             basic.append(RadioSetting("beep_volume", "Beep audio",
                          RadioSettingValueList(BEEP_VOLUME,
-                         BEEP_VOLUME[self.memobj.beep_volume])))
+                                               BEEP_VOLUME[self.memobj.beep_volume])))
             basic.append(RadioSetting("beep", "Operation beep",
                          RadioSettingValueBoolean(self.memobj.beep)))
             basic.append(RadioSetting("backlight", "LCD backlight",
                          RadioSettingValueList(BACKLIGHT,
-                         BACKLIGHT[self.memobj.backlight])))
+                                               BACKLIGHT[self.memobj.backlight])))
             basic.append(RadioSetting("busy_led", "Busy LED",
                          RadioSettingValueBoolean(self.memobj.busy_led)))
             basic.append(RadioSetting("auto_power_off", "Auto power off",
                          RadioSettingValueList(AUTO_POWER_OFF,
-                         AUTO_POWER_OFF[self.memobj.auto_power_off])))
+                                               AUTO_POWER_OFF[self.memobj.auto_power_off])))
             basic.append(RadioSetting("power_save", "Power save",
                          RadioSettingValueList(POWER_SAVE,
-                         POWER_SAVE[self.memobj.power_save])))
+                                               POWER_SAVE[self.memobj.power_save])))
             basic.append(RadioSetting("monitor", "Monitor",
                          RadioSettingValueList(MONITOR,
-                         MONITOR[self.memobj.monitor])))
+                                               MONITOR[self.memobj.monitor])))
             basic.append(RadioSetting("dial_speedup", "Dial speedup",
                          RadioSettingValueBoolean(self.memobj.dial_speedup)))
             basic.append(RadioSetting("auto_repeater", "Auto repeater",
                          RadioSettingValueList(AUTO_REPEATER,
-                         AUTO_REPEATER[self.memobj.auto_repeater])))
+                                               AUTO_REPEATER[self.memobj.auto_repeater])))
             basic.append(RadioSetting("hm_75a_function", "HM-75A function",
                          RadioSettingValueList(HM_75A_FUNCTION,
-                         HM_75A_FUNCTION[self.memobj.hm_75a_function])))
+                                               HM_75A_FUNCTION[self.memobj.hm_75a_function])))
             basic.append(RadioSetting("wx_alert", "WX alert",
                          RadioSettingValueBoolean(self.memobj.wx_alert)))
             basic.append(RadioSetting("wx_channel", "Current WX channel",
                          RadioSettingValueList(WX_CHANNEL,
-                         WX_CHANNEL[self.memobj.wx_channel])))
+                                               WX_CHANNEL[self.memobj.wx_channel])))
             basic.append(RadioSetting("comment", "Comment",
                          RadioSettingValueString(0, COMMENT_LEN,
-                         str(self.memobj.comment),
-                         autopad = True)))
+                                                 str(self.memobj.comment),
+                                                 autopad=True)))
             basic.append(RadioSetting("tune_step", "Current tune step",
                          RadioSettingValueList(TUNE_STEP_STR,
-                         TUNE_STEP_STR[self.memobj.tune_step])))
+                                               TUNE_STEP_STR[self.memobj.tune_step])))
             basic.append(RadioSetting("band_selected", "Selected band",
                          RadioSettingValueInteger(0, BANDS - 1, self.memobj.band_selected)))
             basic.append(RadioSetting("memory_display", "Memory display",
                          RadioSettingValueList(MEMORY_DISPLAY,
-                         MEMORY_DISPLAY[self.memobj.memory_display])))
+                                               MEMORY_DISPLAY[self.memobj.memory_display])))
             basic.append(RadioSetting("memory_name", "Memory name",
                          RadioSettingValueBoolean(self.memobj.memory_name)))
             basic.append(RadioSetting("dial_select", "Dial select",
                          RadioSettingValueList(DIAL_SELECT,
-                         DIAL_SELECT[self.memobj.dial_select])))
+                                               DIAL_SELECT[self.memobj.dial_select])))
             basic.append(RadioSetting("power", "RF power",
                          RadioSettingValueList(POWER,
-                         POWER[self.memobj.power])))
+                                               POWER[self.memobj.power])))
             basic.append(RadioSetting("vfo", "Current VFO",
                          RadioSettingValueList(VFO,
-                         VFO[self.memobj.vfo])))
+                                               VFO[self.memobj.vfo])))
             basic.append(RadioSetting("attenuator", "RF attenuator",
                          RadioSettingValueBoolean(self.memobj.attenuator)))
             basic.append(RadioSetting("skip_scan", "Skip scan",
@@ -475,25 +478,25 @@ class ICx90Radio(icf.IcomCloneModeRadio):
 #                         OPERATION_MODE[self.memobj.mode])))
             basic.append(RadioSetting("vfo_scan", "VFO scan",
                          RadioSettingValueList(VFO_SCAN,
-                         VFO_SCAN[self.memobj.vfo_scan])))
+                                               VFO_SCAN[self.memobj.vfo_scan])))
             basic.append(RadioSetting("memory_scan", "Memory scan",
                          RadioSettingValueList(MEMORY_SCAN,
-                         MEMORY_SCAN[self.memobj.memory_scan])))
+                                               MEMORY_SCAN[self.memobj.memory_scan])))
             basic.append(RadioSetting("tv_channel", "Current TV channel",
                          RadioSettingValueInteger(0, TV_CHANNELS - 1, self.memobj.tv_channel)))
 
             # DTMF auto dial
             dtmf_autodial.append(RadioSetting("autodial", "Autodial",
                                  RadioSettingValueList(AUTODIAL,
-                                 AUTODIAL[self.memobj.autodial])))
+                                                       AUTODIAL[self.memobj.autodial])))
             dtmf_autodial.append(RadioSetting("dtmf_speed", "Speed",
                                  RadioSettingValueList(DTMF_SPEED,
-                                 DTMF_SPEED[self.memobj.dtmf_speed])))
+                                                       DTMF_SPEED[self.memobj.dtmf_speed])))
             for x in range(DTMF_AUTODIAL_NUM):
                 rs = RadioSetting("dtmf_codes[%d].dtmf_digits" % x, "DTMF autodial: %d" % x,
                                   RadioSettingValueString(0, DTMF_DIGITS_NUM,
-                                  self.dtmf_icom2chirp(self.memobj.dtmf_codes[x].dtmf_digits),
-                                  autopad = True, charset = "0123456789ABCD*#abcd "))
+                                                          self.dtmf_icom2chirp(self.memobj.dtmf_codes[x].dtmf_digits),
+                                                          autopad=True, charset="0123456789ABCD*#abcd "))
                 rs.set_apply_callback(self.apply_dtmf_autodial, self.memobj.dtmf_codes[x].dtmf_digits)
                 dtmf_autodial.append(rs)
 
@@ -506,29 +509,29 @@ class ICx90Radio(icf.IcomCloneModeRadio):
                             RadioSettingValueBoolean(self.memobj.scan_stop_light)))
             expand_1.append(RadioSetting("light_postion", "Light position",
                             RadioSettingValueList(LIGHT_POSITION,
-                            LIGHT_POSITION[self.memobj.light_position])))
+                                                  LIGHT_POSITION[self.memobj.light_position])))
             expand_1.append(RadioSetting("light_color", "Light color",
                             RadioSettingValueList(LIGHT_COLOR,
-                            LIGHT_COLOR[self.memobj.light_color])))
+                                                  LIGHT_COLOR[self.memobj.light_color])))
             expand_1.append(RadioSetting("band_edge_beep", "Band edge beep",
                             RadioSettingValueBoolean(self.memobj.band_edge_beep)))
             expand_1.append(RadioSetting("auto_power_on", "Auto power on",
                             RadioSettingValueList(AUTO_POWER_ON,
-                            AUTO_POWER_ON[self.memobj.auto_power_on])))
+                                                  AUTO_POWER_ON[self.memobj.auto_power_on])))
             expand_1.append(RadioSetting("key_lock", "Key lock",
                             RadioSettingValueList(KEY_LOCK,
-                            KEY_LOCK[self.memobj.key_lock])))
+                                                  KEY_LOCK[self.memobj.key_lock])))
             expand_1.append(RadioSetting("ptt_lock", "PTT lock",
                             RadioSettingValueBoolean(self.memobj.ptt_lock)))
             expand_1.append(RadioSetting("lcd_contrast", "LCD contrast",
                             RadioSettingValueList(LCD_CONTRAST,
-                            LCD_CONTRAST[self.memobj.lcd_contrast])))
+                                                  LCD_CONTRAST[self.memobj.lcd_contrast])))
             expand_1.append(RadioSetting("opening_message", "Opening message",
                             RadioSettingValueBoolean(self.memobj.opening_message)))
             expand_1.append(RadioSetting("opening_message_text", "Opening message",
                             RadioSettingValueString(0, OPENING_MESSAGE_LEN,
-                            str(self.memobj.opening_message_text),
-                            autopad = True, charset = CHARSET)))
+                                                    str(self.memobj.opening_message_text),
+                                                    autopad=True, charset=CHARSET)))
 
             # expand 2
             expand_2.append(RadioSetting("expand_2", "Expand 2",
@@ -537,10 +540,10 @@ class ICx90Radio(icf.IcomCloneModeRadio):
                             RadioSettingValueBoolean(self.memobj.busy_lockout)))
             expand_2.append(RadioSetting("timeout_timer", "Timeout timer",
                             RadioSettingValueList(TIMEOUT_TIMER,
-                            TIMEOUT_TIMER[self.memobj.timeout_timer])))
+                                                  TIMEOUT_TIMER[self.memobj.timeout_timer])))
             expand_2.append(RadioSetting("active_band", "Active band",
                             RadioSettingValueList(ACTIVE_BAND,
-                            ACTIVE_BAND[self.memobj.active_band])))
+                                                  ACTIVE_BAND[self.memobj.active_band])))
             expand_2.append(RadioSetting("fm_narrow", "FM narrow",
                             RadioSettingValueBoolean(self.memobj.fm_narrow)))
             expand_2.append(RadioSetting("split", "Split",
@@ -549,7 +552,7 @@ class ICx90Radio(icf.IcomCloneModeRadio):
                             RadioSettingValueBoolean(self.memobj.morse_code_enable)))
             expand_2.append(RadioSetting("morse_code_speed", "Morse code speed",
                             RadioSettingValueList(MORSE_CODE_SPEED,
-                            MORSE_CODE_SPEED[self.memobj.morse_code_speed])))
+                                                  MORSE_CODE_SPEED[self.memobj.morse_code_speed])))
 
             return group
         except:
@@ -696,10 +699,10 @@ class ICx90Radio(icf.IcomCloneModeRadio):
             if not special:
                 mem.skip = self.get_skip(number)
         if special:
-           mem.extd_number = number
-           mem.number = -len(self.special) + unique_idx
+            mem.extd_number = number
+            mem.number = -len(self.special) + unique_idx
         else:
-           mem.number = number
+            mem.number = number
 
         return mem
 
@@ -738,6 +741,7 @@ class ICx90Radio(icf.IcomCloneModeRadio):
     def get_bank_model(self):
         return ICx90BankModel(self)
 
+
 class ICx90Radio_ham(ICx90Radio):
     VARIANT = 'Radio'
 
@@ -746,6 +750,7 @@ class ICx90Radio_ham(ICx90Radio):
         rf.has_sub_devices = False
 
         return rf
+
 
 class ICx90Radio_tv(ICx90Radio):
     VARIANT = "TV"
@@ -836,6 +841,7 @@ class ICx90Radio_tv(ICx90Radio):
             mem_item.mode = TV_MODE.index(memory.mode)
             self.set_skip(memory.number, memory.skip)
 
+
 def dump_banks(icx90, template_file):
     mb = icx90.get_features().memory_bounds
     with open(template_file, "w") as f:
@@ -848,6 +854,7 @@ def dump_banks(icx90, template_file):
             if not mem.empty and bank is not None and bank_pos is not None:
                 f.write("%s;%s;%d\n" % (mem.name, bank, bank_pos))
 
+
 def read_template_file(template_file):
     banks_templ = {}
     with open(template_file, "r") as f:
@@ -856,6 +863,7 @@ def read_template_file(template_file):
             l[1] = BANK_INDEX.index(l[1])
             banks_templ[l[0]] = l[1:]
     return banks_templ
+
 
 def reorder_banks(icx90, preserve_position, preserve_unknown, banks_templ):
     banks_cnt = []
@@ -886,6 +894,7 @@ def reorder_banks(icx90, preserve_position, preserve_unknown, banks_templ):
             bank_pos = 0
         icx90._set_bank(mi, bank)
         icx90._set_bank_index(mi, bank_pos)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Icom IC-E90 banks handling helper.")

--- a/chirp/drivers/kguv8dplus.py
+++ b/chirp/drivers/kguv8dplus.py
@@ -292,9 +292,10 @@ _MEM_FORMAT = """
 # the maximum payload size (from the Wouxun software) seems to be 66 bytes
 #  (2 bytes location + 64 bytes data).
 
+
 @directory.register
 class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
-                  chirp_common.ExperimentalRadio):
+                      chirp_common.ExperimentalRadio):
 
     """Wouxun KG-UV8D Plus"""
     VENDOR = "Wouxun"
@@ -740,7 +741,7 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
                           RadioSettingValueInteger(0, 10, _settings.toalarm))
         cfg_grp.append(rs)
         rs = RadioSetting("roger_beep", "Roger Beep",
-                          RadioSettingValueList(ROGER_LIST, 
+                          RadioSettingValueList(ROGER_LIST,
                                                 ROGER_LIST[_settings.roger_beep]))
         cfg_grp.append(rs)
         rs = RadioSetting("power_save", "Power save",
@@ -844,8 +845,8 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
                                                 SMUTESET_LIST[_settings.
                                                               smuteset]))
         cfg_grp.append(rs)
-        
-		#
+
+        #
         # VFO A Settings
         #
         rs = RadioSetting("workmode_a", "VFO A Workmode",
@@ -888,8 +889,8 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
         rs = RadioSetting("bcl_a", "Busy Channel Lock-out A",
                           RadioSettingValueBoolean(_settings.bcl_a))
         vfoa_grp.append(rs)
-        
-		#
+
+        #
         # VFO B Settings
         #
         rs = RadioSetting("workmode_b", "VFO B Workmode",
@@ -932,8 +933,8 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
         rs = RadioSetting("bcl_b", "Busy Channel Lock-out B",
                           RadioSettingValueBoolean(_settings.bcl_b))
         vfob_grp.append(rs)
-        
-		#
+
+        #
         # Key Settings
         #
         _msg = str(_settings.dispstr).split("\0")[0]
@@ -948,6 +949,7 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
         val = RadioSettingValueString(3, 6, _code, False)
         val.set_charset(dtmfchars)
         rs = RadioSetting("ani_code", "ANI Code", val)
+
         def apply_ani_id(setting, obj):
             value = []
             for j in range(0, 6):
@@ -1103,4 +1105,3 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
                 or "rx_stop" in element.get_name() \
                 or "tx_start" in element.get_name() \
                 or "tx_stop" in element.get_name()
-

--- a/chirp/drivers/kguv8dplus.py
+++ b/chirp/drivers/kguv8dplus.py
@@ -266,7 +266,7 @@ _MEM_FORMAT = """
     #seekto 0x4780;
     struct {
         u8    name[8];
-		u8    unknown[4];
+        u8    unknown[4];
     } names[1000];
 
     #seekto 0x7670;

--- a/chirp/drivers/kguv8dplus.py
+++ b/chirp/drivers/kguv8dplus.py
@@ -710,8 +710,8 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
         vhf_lmt_grp = RadioSettingGroup("vhf_lmt_grp", "VHF")
         oem_grp = RadioSettingGroup("oem_grp", "OEM Info")
 
-        lmt_grp.append(uhf_lmt_grp);
-        lmt_grp.append(vhf_lmt_grp);
+        lmt_grp.append(uhf_lmt_grp)
+        lmt_grp.append(vhf_lmt_grp)
         group = RadioSettings(cfg_grp, vfoa_grp, vfob_grp,
                               key_grp, lmt_grp, oem_grp)
 

--- a/chirp/drivers/kguv8e.py
+++ b/chirp/drivers/kguv8e.py
@@ -719,9 +719,9 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
         vhf1_lmt_grp = RadioSettingGroup("vhf1_lmt_grp", "VHF1")
         oem_grp = RadioSettingGroup("oem_grp", "OEM Info")
 
-        lmt_grp.append(vhf_lmt_grp);
-        lmt_grp.append(vhf1_lmt_grp);
-        lmt_grp.append(uhf_lmt_grp);
+        lmt_grp.append(vhf_lmt_grp)
+        lmt_grp.append(vhf1_lmt_grp)
+        lmt_grp.append(uhf_lmt_grp)
         group = RadioSettings(cfg_grp, vfoa_grp, vfob_grp,
                               key_grp, lmt_grp, oem_grp)
 

--- a/chirp/drivers/kguv8e.py
+++ b/chirp/drivers/kguv8e.py
@@ -57,7 +57,7 @@ PONMSG_LIST = ["Bitmap", "Battery Volts"]
 SPMUTE_LIST = ["QT", "QT+DTMF", "QT*DTMF"]
 DTMFST_LIST = ["DT-ST", "ANI-ST", "DT-ANI", "Off"]
 DTMF_TIMES = ["%s" % x for x in range(50, 501, 10)]
-RPTSET_LIST = ["", "X-DIRRPT", "X-TWRPT"] # TODO < what is index 0?
+RPTSET_LIST = ["", "X-DIRRPT", "X-TWRPT"]  # TODO < what is index 0?
 ALERTS = [1750, 2100, 1000, 1450]
 ALERTS_LIST = [str(x) for x in ALERTS]
 PTTID_LIST = ["Begin", "End", "Both"]
@@ -275,24 +275,25 @@ _MEM_FORMAT = """
     u8          valid[1000];
     """
 
-    # Support for the Wouxun KG-UV8E radio
-    # Serial coms are at 19200 baud
-    # The data is passed in variable length records
-    # Record structure:
-    #  Offset   Usage
-    #    0      start of record (\x7a)
-    #    1      Command (\x80 Identify \x81 End/Reboot \x82 Read \x83 Write)
-    #    2      direction (\xff PC-> Radio, \x00 Radio -> PC)
-    #    3      length of payload (excluding header/checksum) (n)
-    #    4      payload (n bytes)
-    #    4+n+1  checksum - byte sum (% 256) of bytes 1 -> 4+n
-    #
-    # Memory Read Records:
-    # the payload is 3 bytes, first 2 are offset (big endian),
-    # 3rd is number of bytes to read
-    # Memory Write Records:
-    # the maximum payload size (from the Wouxun software) seems to be 66 bytes
-    #  (2 bytes location + 64 bytes data).
+# Support for the Wouxun KG-UV8E radio
+# Serial coms are at 19200 baud
+# The data is passed in variable length records
+# Record structure:
+#  Offset   Usage
+#    0      start of record (\x7a)
+#    1      Command (\x80 Identify \x81 End/Reboot \x82 Read \x83 Write)
+#    2      direction (\xff PC-> Radio, \x00 Radio -> PC)
+#    3      length of payload (excluding header/checksum) (n)
+#    4      payload (n bytes)
+#    4+n+1  checksum - byte sum (% 256) of bytes 1 -> 4+n
+#
+# Memory Read Records:
+# the payload is 3 bytes, first 2 are offset (big endian),
+# 3rd is number of bytes to read
+# Memory Write Records:
+# the maximum payload size (from the Wouxun software) seems to be 66 bytes
+#  (2 bytes location + 64 bytes data).
+
 
 @directory.register
 class KGUV8ERadio(chirp_common.CloneModeRadio,
@@ -302,7 +303,7 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
     VENDOR = "Wouxun"
     MODEL = "KG-UV8E"
     _model = b"KG-UV8D-A"
-    _file_ident = b"kguv8e" # lowercase
+    _file_ident = b"kguv8e"  # lowercase
     BAUD_RATE = 19200
     POWER_LEVELS = [chirp_common.PowerLevel("L", watts=1),
                     chirp_common.PowerLevel("H", watts=5)]
@@ -377,7 +378,7 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
 
     @classmethod
     def match_model(cls, filedata, filename):
-        id = cls._file_ident 
+        id = cls._file_ident
         return cls._file_ident in b'kg' + filedata[0x426:0x430].replace(b'(', b'').replace(b')', b'').lower()
 
     def _identify(self):
@@ -855,7 +856,7 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
                                                               smuteset]))
         cfg_grp.append(rs)
 
-                #
+        #
         # VFO A Settings
         #
         rs = RadioSetting("workmode_a", "VFO A Workmode",
@@ -899,7 +900,7 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
                           RadioSettingValueBoolean(_settings.bcl_a))
         vfoa_grp.append(rs)
 
-                #
+        #
         # VFO B Settings
         #
         rs = RadioSetting("workmode_b", "VFO B Workmode",
@@ -943,7 +944,7 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
                           RadioSettingValueBoolean(_settings.bcl_b))
         vfob_grp.append(rs)
 
-                #
+        #
         # Key Settings
         #
         _msg = str(_settings.dispstr).split("\0")[0]
@@ -958,6 +959,7 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
         val = RadioSettingValueString(3, 6, _code, False)
         val.set_charset(dtmfchars)
         rs = RadioSetting("ani_code", "ANI Code", val)
+
         def apply_ani_id(setting, obj):
             value = []
             for j in range(0, 6):

--- a/chirp/drivers/kguv9dplus.py
+++ b/chirp/drivers/kguv9dplus.py
@@ -711,7 +711,7 @@ def _pkt_encode(op, payload):
         xord = xorbits ^ byte
         data[i + 4] = xord
         xorbits = xord
-    return(data)
+    return (data)
 
 
 def _pkt_decode(data):
@@ -1758,12 +1758,12 @@ class KGUV9DPlusRadio(chirp_common.CloneModeRadio,
                                RadioSettingValueBoolean(s.bledsw)))
 
         if (self.MODEL == "KG-UV9PX" or self.MODEL == "KG-UV9GX"):
-                cf.append(RadioSetting("screen.screen_mode",
-                                       "Screen Mode (Menu 62)",
-                                       RadioSettingValueList(
-                                             SCREEN_MODE_LIST,
-                                             SCREEN_MODE_LIST[
-                                                 sm.screen_mode])))
+            cf.append(RadioSetting("screen.screen_mode",
+                                   "Screen Mode (Menu 62)",
+                                   RadioSettingValueList(
+                                         SCREEN_MODE_LIST,
+                                         SCREEN_MODE_LIST[
+                                             sm.screen_mode])))
         if (self.MODEL == "KG-UV9PX" or self.MODEL == "KG-UV9GX"):
             langlst = LANGUAGE_LIST2
         else:

--- a/chirp/drivers/kyd_IP620.py
+++ b/chirp/drivers/kyd_IP620.py
@@ -413,19 +413,19 @@ class IP620Radio(chirp_common.CloneModeRadio,
                           RadioSettingValueList(NO_YES_LIST,
                                                 NO_YES_LIST[_mem.scan_add]))
         mem.extra.append(rs)
-        #TODO: Show name channel
-##        count = 0
-##        for i in _nam.chan_name:
-##            if i == 0xFF:
-##                break
-##            try:
-##                mem.name += IP620_CHARSET[i]
-##            except Exception:
-##                LOG.error("Unknown name char %i: 0x%02x (mem %i)" %
-##                          (count, i, number - 1))
-##                mem.name += " "
-##            count += 1
-##        mem.name = mem.name.rstrip()
+        # TODO: Show name channel
+#        count = 0
+#        for i in _nam.chan_name:
+#            if i == 0xFF:
+#                break
+#            try:
+#                mem.name += IP620_CHARSET[i]
+#            except Exception:
+#                LOG.error("Unknown name char %i: 0x%02x (mem %i)" %
+#                          (count, i, number - 1))
+#                mem.name += " "
+#            count += 1
+#        mem.name = mem.name.rstrip()
 
         return mem
 

--- a/chirp/drivers/kyd_IP620.py
+++ b/chirp/drivers/kyd_IP620.py
@@ -127,7 +127,7 @@ OFF_ON_LIST = ["OFF", "ON"]
 ON_OFF_LIST = ["ON", "OFF"]
 NO_YES_LIST = ["NO", "YES"]
 STEP_LIST = ["5.0", "6.25", "10.0", "12.5", "25.0"]
-BAT_SAVE_LIST = ["OFF", "0.2 Sec", "0.4 Sec", "0.6 Sec", "0.8 Sec","1.0 Sec"]
+BAT_SAVE_LIST = ["OFF", "0.2 Sec", "0.4 Sec", "0.6 Sec", "0.8 Sec", "1.0 Sec"]
 SHIFT_LIST = ["", "-", "+"]
 SCANM_LIST = ["Time", "Carrier wave", "Search"]
 ENDBEEP_LIST = ["OFF", "Begin", "End", "Begin/End"]
@@ -143,7 +143,7 @@ BACKLIGHT_LIST = ["Always Off", "Auto", "Always On"]
 BUSYLOCK_LIST = ["NO", "Carrier", "SM"]
 KEYBLOCK_LIST = ["Manual", "Auto"]
 CALLTONE_LIST = ["OFF", "1", "2", "3", "4", "5", "6", "7", "8", "1750"]
-RFSQL_LIST = ["OFF", "S-1", "S-2", "S-3", "S-4", "S-5", "S-6","S-7", "S-8", "S-FULL"]
+RFSQL_LIST = ["OFF", "S-1", "S-2", "S-3", "S-4", "S-5", "S-6", "S-7", "S-8", "S-FULL"]
 
 IP620_CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ?+-* "
 
@@ -157,9 +157,10 @@ IP620_BANDS = [
     (450000000, 520000000),
 ]
 
+
 @directory.register
 class IP620Radio(chirp_common.CloneModeRadio,
-                chirp_common.ExperimentalRadio):
+                 chirp_common.ExperimentalRadio):
     """KYD IP-620"""
     VENDOR = "KYD"
     MODEL = "IP-620"
@@ -365,7 +366,7 @@ class IP620Radio(chirp_common.CloneModeRadio,
             mem.dtcs_polarity = "%s%s" % (tpol, rpol)
 
         LOG.debug("Got TX %s (%i) RX %s (%i)" % (txmode, _mem.tx_tone,
-                                              rxmode, _mem.rx_tone))
+                                                 rxmode, _mem.rx_tone))
 
     def get_memory(self, number):
         _mem = self._memobj.memory[number - 1]
@@ -400,17 +401,17 @@ class IP620Radio(chirp_common.CloneModeRadio,
         mem.extra = RadioSettingGroup("Extra", "extra")
         rs = RadioSetting("lout", "Lock out",
                           RadioSettingValueList(OFF_ON_LIST,
-                          OFF_ON_LIST[_mem.lout]))
+                                                OFF_ON_LIST[_mem.lout]))
         mem.extra.append(rs)
 
         rs = RadioSetting("busy_loc", "Busy lock",
                           RadioSettingValueList(BUSYLOCK_LIST,
-                          BUSYLOCK_LIST[_mem.busy_loc]))
+                                                BUSYLOCK_LIST[_mem.busy_loc]))
         mem.extra.append(rs)
 
         rs = RadioSetting("scan_add", "Scan add",
                           RadioSettingValueList(NO_YES_LIST,
-                          NO_YES_LIST[_mem.scan_add]))
+                                                NO_YES_LIST[_mem.scan_add]))
         mem.extra.append(rs)
         #TODO: Show name channel
 ##        count = 0
@@ -500,92 +501,92 @@ class IP620Radio(chirp_common.CloneModeRadio,
 
         rs = RadioSetting("rf_sql", "Squelch level (SQL)",
                           RadioSettingValueList(RFSQL_LIST,
-                          RFSQL_LIST[_settings.rf_sql]))
+                                                RFSQL_LIST[_settings.rf_sql]))
         basic.append(rs)
 
         rs = RadioSetting("step_freq", "Step frequency KHz (STP)",
                           RadioSettingValueList(STEP_LIST,
-                          STEP_LIST[_settings.step_freq]))
+                                                STEP_LIST[_settings.step_freq]))
         basic.append(rs)
 
         rs = RadioSetting("fm_radio", "FM radio (DW)",
                           RadioSettingValueList(OFF_ON_LIST,
-                          OFF_ON_LIST[_settings_misc.fm_radio]))
+                                                OFF_ON_LIST[_settings_misc.fm_radio]))
         basic.append(rs)
 
         rs = RadioSetting("call_tone", "Call tone (CK)",
                           RadioSettingValueList(CALLTONE_LIST,
-                          CALLTONE_LIST[_settings.call_tone]))
+                                                CALLTONE_LIST[_settings.call_tone]))
         basic.append(rs)
 
         rs = RadioSetting("tot", "Time-out timer (TOT)",
                           RadioSettingValueList(TIMEOUT_LIST,
-                          TIMEOUT_LIST[_settings.tot]))
+                                                TIMEOUT_LIST[_settings.tot]))
         basic.append(rs)
 
         rs = RadioSetting("chan_disp_way", "Channel display way",
                           RadioSettingValueList(CH_FLAG_LIST,
-                          CH_FLAG_LIST[_settings.chan_disp_way]))
+                                                CH_FLAG_LIST[_settings.chan_disp_way]))
         basic.append(rs)
 
         rs = RadioSetting("vox", "VOX Gain (VOX)",
                           RadioSettingValueList(VOX_LIST,
-                          VOX_LIST[_settings.vox]))
+                                                VOX_LIST[_settings.vox]))
         basic.append(rs)
 
         rs = RadioSetting("vox_dly", "VOX Delay",
                           RadioSettingValueList(VOXDELAY_LIST,
-                          VOXDELAY_LIST[_settings.vox_dly]))
+                                                VOXDELAY_LIST[_settings.vox_dly]))
         basic.append(rs)
 
         rs = RadioSetting("beep", "Beep (BP)",
                           RadioSettingValueList(OFF_ON_LIST,
-                          OFF_ON_LIST[_settings.beep]))
+                                                OFF_ON_LIST[_settings.beep]))
         basic.append(rs)
 
         rs = RadioSetting("auto_lock", "Auto lock (KY)",
                           RadioSettingValueList(NO_YES_LIST,
-                          NO_YES_LIST[_settings_misc.auto_lock]))
+                                                NO_YES_LIST[_settings_misc.auto_lock]))
         basic.append(rs)
 
         rs = RadioSetting("bat_save", "Battery Saver (SAV)",
                           RadioSettingValueList(BAT_SAVE_LIST,
-                          BAT_SAVE_LIST[_settings.bat_save]))
+                                                BAT_SAVE_LIST[_settings.bat_save]))
         basic.append(rs)
 
         rs = RadioSetting("chan_pri", "Channel PRI (PRI)",
                           RadioSettingValueList(OFF_ON_LIST,
-                          OFF_ON_LIST[_settings.chan_pri]))
+                                                OFF_ON_LIST[_settings.chan_pri]))
         basic.append(rs)
 
         rs = RadioSetting("chan_pri_num", "Channel PRI time Sec (PRI)",
                           RadioSettingValueList(PRI_NUM_LIST,
-                          PRI_NUM_LIST[_settings.chan_pri_num]))
+                                                PRI_NUM_LIST[_settings.chan_pri_num]))
         basic.append(rs)
 
         rs = RadioSetting("end_beep", "End beep (ET)",
                           RadioSettingValueList(ENDBEEP_LIST,
-                          ENDBEEP_LIST[_settings.end_beep]))
+                                                ENDBEEP_LIST[_settings.end_beep]))
         basic.append(rs)
 
         rs = RadioSetting("ch_mode", "CH mode",
                           RadioSettingValueList(ON_OFF_LIST,
-                          ON_OFF_LIST[_settings.ch_mode]))
+                                                ON_OFF_LIST[_settings.ch_mode]))
         basic.append(rs)
 
         rs = RadioSetting("scan_rev", "Scan rev (SCAN)",
                           RadioSettingValueList(SCANM_LIST,
-                          SCANM_LIST[_settings.scan_rev]))
+                                                SCANM_LIST[_settings.scan_rev]))
         basic.append(rs)
 
         rs = RadioSetting("enc", "Frequency lock (ENC)",
                           RadioSettingValueList(OFF_ON_LIST,
-                          OFF_ON_LIST[_settings.enc]))
+                                                OFF_ON_LIST[_settings.enc]))
         basic.append(rs)
 
         rs = RadioSetting("wait_back_light", "Wait back light (LED)",
                           RadioSettingValueList(BACKLIGHT_LIST,
-                          BACKLIGHT_LIST[_settings.wait_back_light]))
+                                                BACKLIGHT_LIST[_settings.wait_back_light]))
         basic.append(rs)
 
         return top
@@ -611,7 +612,7 @@ class IP620Radio(chirp_common.CloneModeRadio,
                 continue
             try:
                 setting = element.get_name()
-                if setting in ["auto_lock","fm_radio"]:
+                if setting in ["auto_lock", "fm_radio"]:
                     oldval = getattr(_settings_misc, setting)
                 else:
                     oldval = getattr(_settings, setting)
@@ -619,7 +620,7 @@ class IP620Radio(chirp_common.CloneModeRadio,
                 newval = element.value
 
                 LOG.debug("Setting %s(%s) <= %s" % (setting, oldval, newval))
-                if setting in ["auto_lock","fm_radio"]:
+                if setting in ["auto_lock", "fm_radio"]:
                     setattr(_settings_misc, setting, newval)
                 else:
                     setattr(_settings, setting, newval)

--- a/chirp/drivers/retevis_rb28.py
+++ b/chirp/drivers/retevis_rb28.py
@@ -155,13 +155,14 @@ SETTING_LISTS = {
     }
 
 PMR_TONES = list(chirp_common.TONES)
-[PMR_TONES.remove(x) for x in [ 69.3, 159.8, 165.5, 171.3, 177.3, 183.5,
+[PMR_TONES.remove(x) for x in [69.3, 159.8, 165.5, 171.3, 177.3, 183.5,
                                189.9, 196.6, 199.5, 206.5, 229.1, 254.1]]
 
 PMR_DTCS_CODES = list(chirp_common.DTCS_CODES)
-[PMR_DTCS_CODES.remove(x) for x in [ 36,  53, 122, 145, 212, 225, 246,
+[PMR_DTCS_CODES.remove(x) for x in [36,  53, 122, 145, 212, 225, 246,
                                     252, 255, 266, 274, 325, 332, 356,
                                     446, 452, 454, 455, 462, 523, 526]]
+
 
 def _enter_programming_mode(radio):
     serial = radio.pipe

--- a/chirp/drivers/rh5r_v2.py
+++ b/chirp/drivers/rh5r_v2.py
@@ -272,7 +272,7 @@ class TYTTHUVF8_V2(chirp_common.CloneModeRadio):
         _mem.tx_freq = (mem.freq + (mem.offset * mult)) / 10
 
         (txmode, txval, txpol), (rxmode, rxval, rxpol) = \
-                chirp_common.split_tone_encode(mem)
+            chirp_common.split_tone_encode(mem)
 
         self._encode_tone(_mem.tx_tone, txmode, txval, txpol)
         self._encode_tone(_mem.rx_tone, rxmode, rxval, rxpol)

--- a/chirp/drivers/tg_uv2p.py
+++ b/chirp/drivers/tg_uv2p.py
@@ -187,6 +187,7 @@ def do_upload(radio):
         LOG.debug("Radio ACK'd block at address 0x%04x" % i)
         do_status(radio, "to", i)
 
+
 DUPLEX = ["", "+", "-"]
 TGUV2P_STEPS = [5, 6.25, 10, 12.5, 15, 20, 25, 30, 50, 100]
 CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_|* +-"

--- a/chirp/drivers/th9800.py
+++ b/chirp/drivers/th9800.py
@@ -184,13 +184,13 @@ def isValidDate(month, day, year):
             max1 = 29
         else:
             max1 = 28
-    if(month < 1 or month > 12):
+    if (month < 1 or month > 12):
         LOG.debug("Invalid 'Last Program Date: Month'")
         return False
-    elif(day < 1 or day > max1):
+    elif (day < 1 or day > max1):
         LOG.debug("Invalid 'Last Program Date: Day'")
         return False
-    elif(year < 2014 or year > today.year):
+    elif (year < 2014 or year > today.year):
         LOG.debug("Invalid 'Last Program Date: Year'")
         return False
     return True

--- a/chirp/drivers/th_uv3r.py
+++ b/chirp/drivers/th_uv3r.py
@@ -41,6 +41,7 @@ def tyt_uv3r_upload(radio):
     tyt_uv3r_prep(radio)
     return do_upload(radio, 0x0000, 0x0910, 0x0010)
 
+
 mem_format = """
 struct memory {
   ul24 duplex:2,

--- a/chirp/drivers/th_uv3r25.py
+++ b/chirp/drivers/th_uv3r25.py
@@ -34,6 +34,7 @@ def tyt_uv3r_upload(radio):
     tyt_uv3r_prep(radio)
     return do_upload(radio, 0x0000, 0x0B30, 0x0010)
 
+
 mem_format = """
 // 20 bytes per memory
 struct memory {

--- a/chirp/drivers/tk270.py
+++ b/chirp/drivers/tk270.py
@@ -103,7 +103,7 @@ POWER_LEVELS = [chirp_common.PowerLevel("Low", watts=1),
                 chirp_common.PowerLevel("High", watts=5)]
 SKIP_VALUES = ["", "S"]
 TONES = chirp_common.TONES
-#TONES.remove(254.1)
+# TONES.remove(254.1)
 DTCS_CODES = chirp_common.DTCS_CODES
 
 # some vars for the UI
@@ -126,7 +126,7 @@ def rawrecv(radio, amount):
     data = ""
     try:
         data = radio.pipe.read(amount)
-        #print("<= %02i: %s" % (len(data), util.hexprint(data)))
+        # print("<= %02i: %s" % (len(data), util.hexprint(data)))
     except:
         raise errors.RadioError("Error reading data from radio")
 
@@ -137,7 +137,7 @@ def rawsend(radio, data):
     """Raw send to the radio device"""
     try:
         radio.pipe.write(data)
-        #print("=> %02i: %s" % (len(data), util.hexprint(data)))
+        # print("=> %02i: %s" % (len(data), util.hexprint(data)))
     except:
         raise errors.RadioError("Error sending data from radio")
 
@@ -168,7 +168,7 @@ def handshake(radio, msg="", full=False):
     ack = rawrecv(radio, 1)
     # check ACK
     if ack != ACK_CMD:
-        #close_radio(radio)
+        # close_radio(radio)
         mesg = "Handshake failed: " + msg
         raise Exception(mesg)
 
@@ -252,7 +252,7 @@ def do_download(radio):
         data += recv(radio)
         handshake(radio, "Rx error in block %03i" % addr, True)
         # DEBUG
-        #print("Block: %04x, Pos: %06x" % (addr, addr * BLOCK_SIZE))
+        # print("Block: %04x, Pos: %06x" % (addr, addr * BLOCK_SIZE))
 
         # UI Update
         status.cur = addr
@@ -304,7 +304,7 @@ def model_match(cls, data):
     rid = get_radio_id(data)
 
     # DEBUG
-    #print("Full ident string is %s" % util.hexprint(rid))
+    # print("Full ident string is %s" % util.hexprint(rid))
 
     if (rid in cls.VARIANTS):
         # correct model
@@ -424,7 +424,7 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
             self._VARIANT += self._kind + ", %d - %d MHz" % (low, high)
 
             # DEBUG
-            #print self._VARIANT
+            # print self._VARIANT
 
         except KeyError:
             LOG.debug("Wrong Kenwood radio, ID or unknown variant")
@@ -444,8 +444,8 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         # The x0280 area has the settings for the DTMF/2-Tone per channel,
         # as we don't support this feature yet,
         # we disabled by cleaning the data
-        #fldata = "\x00\xf0\xff\xff\xff" * achs + \
-            #"\xff" * (5 * (self._upper - achs))
+        # fldata = "\x00\xf0\xff\xff\xff" * achs + \
+            # "\xff" * (5 * (self._upper - achs))
 
         fldata = "\xFF" * 5 * self._upper
         self._fill(0x0280, fldata)
@@ -479,13 +479,13 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         bit = chan % 8
 
         # DEBUG
-        #print("SET Chan %s, Byte %s, Bit % s" % (chan, byte, bit))
+        # print("SET Chan %s, Byte %s, Bit % s" % (chan, byte, bit))
 
         # get the actual value to see if I need to change anything
         actual = self.get_active(chan)
         if actual != bool(value):
             # DEBUG
-            #print "VALUE %s fliping" % int(not value)
+            # print "VALUE %s fliping" % int(not value)
 
             # I have to flip the value
             rbyte = self._memobj.active[byte]
@@ -827,8 +827,8 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
                 value = element.value
 
                 # integers case + special case
-                if setting in ["tot", "tot_alert", "tot_rekey", \
-                               "tot_reset", "sql", "kMoni", "kScan", \
+                if setting in ["tot", "tot_alert", "tot_rekey",
+                               "tot_reset", "sql", "kMoni", "kScan",
                                "kDial", "kTa", "kLo"]:
                     # catching the "off" values as zero
                     try:
@@ -842,7 +842,7 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
 
             # Apply al configs done
             # DEBUG
-            #print("%s: %s" % (setting, value))
+            # print("%s: %s" % (setting, value))
             setattr(obj, setting, value)
 
 

--- a/chirp/drivers/tk270.py
+++ b/chirp/drivers/tk270.py
@@ -120,6 +120,7 @@ SCAN = off + ["Carrier operated (COS)", "Time operated (TOS)"]
 YESNO = ["Enabled", "Disabled"]
 TA = off + ["Turn around", "Reverse"]
 
+
 def rawrecv(radio, amount):
     """Raw read from the radio device"""
     data = ""
@@ -238,7 +239,7 @@ def do_download(radio):
     """This is your download function"""
     open_radio(radio)
 
-     # UI progress
+    # UI progress
     status = chirp_common.Status()
     status.cur = 0
     status.max = MEM_SIZE / BLOCK_SIZE
@@ -265,7 +266,7 @@ def do_upload(radio):
     """Upload info to radio"""
     open_radio(radio)
 
-     # UI progress
+    # UI progress
     status = chirp_common.Status()
     status.cur = 0
     status.max = MEM_SIZE / BLOCK_SIZE
@@ -326,7 +327,7 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         rp = chirp_common.RadioPrompts()
         rp.experimental = \
             ('This driver is experimental; not all features have been '
-            'implemented, but it has those features most used by hams.\n'
+             'implemented, but it has those features most used by hams.\n'
              '\n'
              'This radios are able to work slightly outside the OEM '
              'frequency limits. After testing, the limit in Chirp has '
@@ -707,7 +708,7 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         basic.append(mod)
 
         beep = RadioSetting("settings.beep", "Beep tone",
-                             RadioSettingValueBoolean(
+                            RadioSettingValueBoolean(
                                  bool(sett.beep)))
         basic.append(beep)
 
@@ -717,12 +718,12 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         basic.append(bsave)
 
         deal = RadioSetting("settings.dealer", "Dealer & Test",
-                             RadioSettingValueBoolean(
+                            RadioSettingValueBoolean(
                                  bool(sett.dealer)))
         basic.append(deal)
 
         add = RadioSetting("settings.add", "Del / Add feature",
-                             RadioSettingValueBoolean(
+                           RadioSettingValueBoolean(
                                  bool(sett.add)))
         basic.append(add)
 
@@ -749,15 +750,15 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         basic.append(tot)
 
         tota = RadioSetting("settings.tot_alert", "TOT pre-plert",
-                           RadioSettingValueList(TOT_A, TOT_A[int(sett.tot_alert)]))
+                            RadioSettingValueList(TOT_A, TOT_A[int(sett.tot_alert)]))
         basic.append(tota)
 
         totrk = RadioSetting("settings.tot_rekey", "TOT rekey time",
-                           RadioSettingValueList(TOT_RK, TOT_RK[int(sett.tot_rekey)]))
+                             RadioSettingValueList(TOT_RK, TOT_RK[int(sett.tot_rekey)]))
         basic.append(totrk)
 
         totrs = RadioSetting("settings.tot_reset", "TOT reset time",
-                           RadioSettingValueList(TOT_RS, TOT_RS[int(sett.tot_reset)]))
+                             RadioSettingValueList(TOT_RS, TOT_RS[int(sett.tot_reset)]))
         basic.append(totrs)
 
         sql = RadioSetting("settings.sql", "Squelch level",
@@ -783,14 +784,14 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         if d > 1:
             d = 0
         dial = RadioSetting("settings.kDial", "Dial",
-                           RadioSettingValueList(YESNO, YESNO[d]))
+                            RadioSettingValueList(YESNO, YESNO[d]))
         fkeys.append(dial)
 
         t = int(sett.kTa)
         if t > 2:
             t = 2
         ta = RadioSetting("settings.kTa", "Ta",
-                           RadioSettingValueList(TA, TA[t]))
+                          RadioSettingValueList(TA, TA[t]))
         fkeys.append(ta)
 
         l = int(sett.kLo)

--- a/chirp/drivers/tk760g.py
+++ b/chirp/drivers/tk760g.py
@@ -364,7 +364,7 @@ def _checksum(data):
     """the radio block checksum algorithm"""
     cs = 0
     for byte in data:
-            cs += byte
+        cs += byte
     return cs % 256
 
 

--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -372,6 +372,7 @@ def _do_status(radio, block):
     status.max = radio.get_memsize()
     radio.status_fn(status)
 
+
 UV5R_MODEL_ORIG = b"\x50\xBB\xFF\x01\x25\x98\x4D"
 UV5R_MODEL_291 = b"\x50\xBB\xFF\x20\x12\x07\x25"
 UV5R_MODEL_F11 = b"\x50\xBB\xFF\x13\xA1\x11\xDD"
@@ -701,6 +702,7 @@ def _do_upload(radio):
             "This is NOT an error.\n"
             "The upload has finished successfully.\n"
             "Please restart CHIRP.")
+
 
 UV5R_POWER_LEVELS = [chirp_common.PowerLevel("High", watts=4.00),
                      chirp_common.PowerLevel("Low",  watts=1.00)]

--- a/chirp/drivers/uvb5.py
+++ b/chirp/drivers/uvb5.py
@@ -251,6 +251,7 @@ def do_upload(radio):
         LOG.debug("Radio ACK'd block at address 0x%04x" % i)
         do_status(radio, "to", i)
 
+
 DUPLEX = ["", "-", "+"]
 UVB5_STEPS = [5.00, 6.25, 10.0, 12.5, 20.0, 25.0]
 CHARSET = "0123456789- ABCDEFGHIJKLMNOPQRSTUVWXYZ/_+*"

--- a/chirp/drivers/wouxun.py
+++ b/chirp/drivers/wouxun.py
@@ -897,7 +897,7 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
                 filedata[0x0d70:0x0d80] == \
                 b"\xff\xff\xff\xff\xff\xff\xff\xff" \
                 b"\xff\xff\xff\xff\xff\xff\xff\xff":
-                # those areas are (seems to be) unused
+            # those areas are (seems to be) unused
             return True
         # Old-style image (CHIRP 0.1.11)
         if len(filedata) == 8200 and \

--- a/chirp/wxui/developer.py
+++ b/chirp/wxui/developer.py
@@ -287,7 +287,7 @@ class ChirpBCDEditor(ChirpEditor):
             digits = self._obj.size() // 4
             assert val >= 0, _('Value must be zero or greater')
             assert len(entry.GetValue()) == digits, \
-                   _('Value must be exactly %i decimal digits') % digits
+                _('Value must be exactly %i decimal digits') % digits
         except (ValueError, AssertionError) as e:
             self._mark_error(entry, str(e))
         else:

--- a/tools/cpep8.manifest
+++ b/tools/cpep8.manifest
@@ -7,7 +7,6 @@
 #
 #
 ./chirp/drivers/alinco.py
-./chirp/drivers/anytone.py
 ./chirp/drivers/anytone778uv.py
 ./chirp/drivers/anytone_ht.py
 ./chirp/drivers/anytone_iii.py
@@ -19,7 +18,6 @@
 ./chirp/drivers/bjuv55.py
 ./chirp/drivers/btech.py
 ./chirp/drivers/ft1d.py
-./chirp/drivers/ft2800.py
 ./chirp/drivers/ft2900.py
 ./chirp/drivers/ft2d.py
 ./chirp/drivers/ft60.py

--- a/tools/py3_driver_progress.py
+++ b/tools/py3_driver_progress.py
@@ -22,8 +22,8 @@ def tester_link(text):
         assert os.path.exists(os.path.join('chirp', 'drivers',
                                            text[1:] + '.py'))
         return ('[Probably works]('
-            'https://github.com/kk7ds/chirp/blob/py3/chirp/drivers/%s.py)' % (
-                text[1:]))
+                'https://github.com/kk7ds/chirp/blob/py3/chirp/drivers/%s.py)' % (
+                    text[1:]))
     elif text.startswith('#') and text[1:].isdigit():
         return '[Reported working](https://chirp.danplanet.com/issues/%i)' % int(text[1:])
     else:
@@ -111,7 +111,6 @@ def main():
         output = sys.stdout
     else:
         output = open(args.output, 'w')
-
 
     print('## Status', file=output)
 
@@ -205,7 +204,7 @@ def main():
     that are fixed for py3 should do so with this flag set to False and with
     the byte-native memory map.
     """),
-    file=output)
+          file=output)
 
     for driver, (tester, tested) in testers.items():
         print('Error in testers file; driver %s by %s on %s unknown' % (


### PR DESCRIPTION
This PR fixes some style issues relate to pep8.

There are still many lines longer than 79 characters:
269   E501 line too long

This is the output of `flake8 --statistics`:
```
3     E402 module level import not at top of file
269   E501 line too long (83 > 79 characters)
185   E722 do not use bare 'except'
3     E731 do not assign a lambda expression, use a def
18    E741 ambiguous variable name 'l'
150   F401 'chirp.settings.RadioSettings' imported but unused
1     F509 '...' % ... has unsupported format character 'k'
17    F601 dictionary key 'tot' repeated with different values
8     F811 redefinition of unused 'apply_WEhemi' from line 2011
417   F821 undefined name '_'
202   F841 local variable '_usd' is assigned to but never used
21    W605 invalid escape sequence '\#'
```
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
