### PR TITLE
Fix spelling

### DIFF
--- a/chirp/bitwise.py
+++ b/chirp/bitwise.py
@@ -282,7 +282,7 @@ class arrayDataElement(DataElement):
             # NOTE: All the values should be strings coming out of py3.
             # and on py2 they could be a mix of unicode and str, the latter
             # for non-ASCII values. On py2 we can just coerce all of these
-            # types to a string for compatbility.
+            # types to a string for compatibility.
             return "".join([str(x.get_value()) for x in self.__items])
         else:
             return str(self.__items)

--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -618,7 +618,7 @@ def FrozenMemory(source):
         def __setattr__(self, k, v):
             if self._frozen:
                 # This should really be an error, but we have a number of
-                # drivers that make modificatons during set_memory(). So this
+                # drivers that make modifications during set_memory(). So this
                 # just has to be a warning for now. Later it could turn into
                 # a TypeError.
                 caller = inspect.getframeinfo(inspect.stack()[1][0])
@@ -1266,7 +1266,7 @@ class Radio(Alias):
         rules in order to comply with FCC type acceptance, which requires
         overriding this behavior.
 
-        ** This should almost never be overidden in your driver.
+        ** This should almost never be overridden in your driver.
 
         ** This must not communicate with the radio, if implemented on a live-
            mode driver.

--- a/chirp/drivers/baofeng_common.py
+++ b/chirp/drivers/baofeng_common.py
@@ -65,7 +65,7 @@ def _rawsend(radio, data):
 
 
 def _make_frame(cmd, addr, length, data=""):
-    """Pack the info in the headder format"""
+    """Pack the info in the header format"""
     frame = struct.pack(">BHB", ord(cmd), addr, length)
     # add the data if set
     if len(data) != 0:

--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -394,7 +394,7 @@ def _send(radio, data):
 
 
 def _make_frame(cmd, addr, length, data=""):
-    """Pack the info in the headder format"""
+    """Pack the info in the header format"""
     frame = b"\x06" + struct.pack(">BHB", ord(cmd), addr, length)
     # add the data if set
     if len(data) != 0:
@@ -561,7 +561,7 @@ def _upload(radio):
     """Upload procedure"""
 
     # The UPLOAD mem is restricted to lower than 0x3100,
-    # so we will override that here localy
+    # so we will override that here locally
     MEM_SIZE = radio.UPLOAD_MEM_SIZE
 
     # UI progress

--- a/chirp/drivers/ft857.py
+++ b/chirp/drivers/ft857.py
@@ -692,7 +692,7 @@ class FT857Radio(ft817.FT817Radio):
                                                 options[_settings.cw_speed]))
         cw.append(rs)
         options = ["Numeric", "Alphabet", "AlphaNumeric"]
-        rs = RadioSetting("cw_training", "CW trainig",
+        rs = RadioSetting("cw_training", "CW training",
                           RadioSettingValueList(options,
                                                 options[_settings.cw_training])
                           )

--- a/chirp/drivers/hf90.py
+++ b/chirp/drivers/hf90.py
@@ -536,7 +536,7 @@ class HF90StyleRadio(chirp_common.CloneModeRadio,
 # LateHF90Radio imitates version 3. It seems both are needed because
 # version 3 warns that it is incompatible with firmware revisions below V301.
 # Unfortunately, the author does not have access to the technical information
-# required to better accomodate the quirks of the various firmware revisions.
+# required to better accommodate the quirks of the various firmware revisions.
 
 @directory.register
 class EarlyHF90Radio(HF90StyleRadio):

--- a/chirp/drivers/iradio_uv_5118.py
+++ b/chirp/drivers/iradio_uv_5118.py
@@ -165,7 +165,7 @@ def _checksum(data):
 def _enter_programming_mode(radio):
     serial = radio.pipe
 
-    # lengthen the timeout here as these radios are reseting due to timeout
+    # lengthen the timeout here as these radios are resetting due to timeout
     radio.pipe.timeout = 0.75
 
     exito = False
@@ -506,7 +506,7 @@ class IradioUV5118(chirp_common.CloneModeRadio):
         LOG.debug("Setting %i(%s)" % (mem.number, mem.extd_number))
         _mem = self._memobj.channels[mem.number - 1]
 
-        # if empty memmory
+        # if empty memory
         if mem.empty:
             _mem.set_raw("\xFF" * 16)
             return

--- a/chirp/drivers/iradio_uv_5118plus.py
+++ b/chirp/drivers/iradio_uv_5118plus.py
@@ -563,7 +563,7 @@ class IradioUV5118plus(chirp_common.CloneModeRadio):
         LOG.debug("Setting %i(%s)" % (mem.number, mem.extd_number))
         _mem = self._memobj.channels[mem.number - 1]
 
-        # if empty memmory
+        # if empty memory
         if mem.empty:
             _mem.set_raw("\xFF" * 22 + "\20" * 10)
             return

--- a/chirp/drivers/kguv980p.py
+++ b/chirp/drivers/kguv980p.py
@@ -611,7 +611,7 @@ def _oem_str_encode(in_str):
             pass
     while len(out_str) < 8:
         out_str += chr(0x50)
-    LOG.debug("OEM Ouput String = %s", out_str)
+    LOG.debug("OEM Output String = %s", out_str)
     return out_str
 
 
@@ -627,7 +627,7 @@ def _oem_str_decode_1000GPLUS(in_str):
             out_str += chr(c+48)
         else:
             out_str += ''
-    LOG.debug("decode OEM Ouput String = %s", out_str)
+    LOG.debug("decode OEM Output String = %s", out_str)
     return out_str
 
 
@@ -642,7 +642,7 @@ def _oem_str_encode_1000GPLUS(in_str):
             out_str += chr(int(ord(c)) - 48)
     while len(out_str) < 8:
         out_str += chr(0x50)
-    LOG.debug("encode OEM Ouput String = %s", out_str)
+    LOG.debug("encode OEM Output String = %s", out_str)
     return out_str
 
 

--- a/chirp/drivers/lt725uv.py
+++ b/chirp/drivers/lt725uv.py
@@ -296,7 +296,7 @@ def _rawsend(radio, data):
 
 
 def _make_frame(cmd, addr, length, data=""):
-    """Pack the info in the headder format"""
+    """Pack the info in the header format"""
     frame = struct.pack(">4sHH", cmd, addr, length)
     # Add the data if set
     if len(data) != 0:

--- a/chirp/drivers/tdxone_tdq8a.py
+++ b/chirp/drivers/tdxone_tdq8a.py
@@ -207,7 +207,7 @@ def _rawsend(radio, data):
 
 
 def _make_frame(cmd, addr, length, data=""):
-    """Pack the info in the headder format"""
+    """Pack the info in the header format"""
     frame = struct.pack(">BHB", ord(cmd), addr, length)
     # add the data if set
     if len(data) != 0:

--- a/chirp/drivers/th_uv8000.py
+++ b/chirp/drivers/th_uv8000.py
@@ -299,7 +299,7 @@ def _rawsend(radio, data):
 
 
 def _make_frame(cmd, addr, length, data=""):
-    """Pack the info in the headder format"""
+    """Pack the info in the header format"""
     frame = struct.pack(">shB", cmd, addr, length)
     # Add the data if set
     if len(data) != 0:

--- a/chirp/drivers/vgc.py
+++ b/chirp/drivers/vgc.py
@@ -390,7 +390,7 @@ def _rawsend(radio, data):
 
 
 def _make_frame(cmd, addr, length, data=""):
-    """Pack the info in the headder format"""
+    """Pack the info in the header format"""
     frame = struct.pack(">BHB", ord(cmd), addr, length)
     # add the data if set
     if len(data) != 0:

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -419,7 +419,7 @@ class ChirpDuplexColumn(ChirpChoiceColumn):
 
 
 class ChirpFlagColumn(ChirpChoiceColumn):
-    """Support boolean values as a sepecial case of Choice
+    """Support boolean values as a special case of Choice
 
     This allows us to have translated strings for the boolean flags,
     while retaining choice-like behavior instead of rendering checkboxes,
@@ -772,7 +772,7 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
     def synchronous_get_memory(self, number):
         """SYNCHRONOUSLY Get memory with extra properties
 
-        This shoud ideally not be used except in situations (like copy)
+        This should ideally not be used except in situations (like copy)
         where we really have to do the operation synchronously.
         """
         mem = self._radio.get_memory(number)

--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -444,7 +444,7 @@ If you have a model listed in this matrix with either "implied" or
 "probably works" status, an actual confirmation with real hardware is
 welcome and can replace the weaker reference.
 
-## Minimal test prodecure
+## Minimal test procedure
 For the purposes of the Python 3 effort, a "tested" radio means
 at least the following procedure was followed:
 1. Download from the radio

--- a/tests/unit/test_icf.py
+++ b/tests/unit/test_icf.py
@@ -105,7 +105,7 @@ class TestFileICF(unittest.TestCase):
 
             icfdata, mmap = icf.read_file(fn)
             # If we sourced from an image, we use our defaults in
-            # generating the ICF metdata
+            # generating the ICF metadata
             self.assertEqual({'MapRev': 1,
                               'EtcData': 5,
                               'Comment': '',

--- a/tools/py3_driver_progress.py
+++ b/tools/py3_driver_progress.py
@@ -182,7 +182,7 @@ def main():
     "probably works" status, an actual confirmation with real hardware is
     welcome and can replace the weaker reference.
 
-    ## Minimal test prodecure
+    ## Minimal test procedure
     For the purposes of the Python 3 effort, a "tested" radio means
     at least the following procedure was followed:
     1. Download from the radio


### PR DESCRIPTION
The change is in `chirp/drivers/ft857.py` is visible in the user interface and  I checked it by loading `./tests/images/Yaesu_FT-857_897.img` and `./tests/images/Yaesu_FT-857_897_US.img`)
```
-        rs = RadioSetting("cw_training", "CW trainig",
+        rs = RadioSetting("cw_training", "CW training",
```

Another change is visible in `tests/Python3_Driver_Testing.md` and `tools/py3_driver_progress.py`.

The other changes are in log messages and  in comments.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
