### PR TITLE
Disable HARDWARE_FLOW for Kenwood TH-F6

### DIFF
--- a/chirp/drivers/kenwood_live.py
+++ b/chirp/drivers/kenwood_live.py
@@ -901,6 +901,7 @@ THF6A_DUPLEX[3] = "split"
 class THF6ARadio(KenwoodLiveRadio):
     """Kenwood TH-F6"""
     MODEL = "TH-F6"
+    HARDWARE_FLOW = False
 
     _charset = chirp_common.CHARSET_ASCII
     _upper = 399


### PR DESCRIPTION
The TH-F6 driver appears to have been broken since Commit 9f5d6508, which defaulted this value to True.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
