### PR TITLE
Yaesu FTnD: Issue 6151 and 10629, WiresX and special registers.

### DIFF
--- a/chirp/drivers/ft1d.py
+++ b/chirp/drivers/ft1d.py
@@ -1,6 +1,8 @@
 # Copyright 2010 Dan Smith <dsmith@danplanet.com>
 # Copyright 2014 Angus Ainslie <angus@akkea.ca>
 # Copyright 2023 Declan Rieb <WD5EQY@arrl.net>
+# Sections of digital settings applied from ft70.py, thus
+# Copyright 2017 Nicolas Pike <nick@zbm2.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -44,30 +46,50 @@ struct {
 
 #seekto 0x04ce;
 struct {
-  u8 lcd_dimmer;
-  u8 dtmf_delay;
+  u8 lcd_dimmer;        // 14 DIMMER
+  u8 dtmf_delay;        // 18 DT DLY
   u8 unknown0[3];
   u8 unknown1:4
      lcd_contrast:4;
-  u8 lamp;
-  u8 unknown2[7];
-  u8 scan_restart;
+  u8 lamp;              // 28 LAMP
+  u8 lock;              // 30 LOCK
+  u8 unknown2;
+  u8 mic_gain;          // 31 MCGAIN
+  u8 unknown2_3;
+  u8 dw_interval;       // 21 DW INT
+  u8 ptt_delay;         // 42 PTT.DLY
+  u8 rx_save;           // 48 RX.SAVE
+  u8 scan_restart;      // 53 SCN.STR
   u8 unknown3;
   u8 scan_resume;
   u8 unknown4[5];
   u8 tot;
   u8 unknown5[3];
-  u8 unknown6:2,
-     scan_lamp:1,
-     unknown7:2,
-     dtmf_speed:1,
+  u8 vfo_mode:1,        // 60 VFO.MOD
+     unknown6:1,
+     scan_lamp:1,       // 51 SCN.LMP
+     unknown7:1,
+     ars:1,             // 45 RPT.ARS
+     dtmf_speed:1,      // 20 DT SPD
      unknown8:1,
      dtmf_mode:1;
   u8 busy_led:1,
-     unknown9:7;
-  u8 unknown10[2];
+     unknown9:2,
+     bclo:1,            // 03 BCLO
+     beep_edge:1        // 06 BEP.EDG
+     unknown9_1:3;
+  u8 unknown10:5,
+     password:1,
+     home_rev:1,        // 26 HOME/REV
+     moni:1;            // 32 MON/T-Call
+  u8 gm_interval:4,     // 25 GM INT
+     unknown11:4;
   u8 vol_mode:1,
-     unknown11:7;
+     unknown11_1:7;
+  u8 unknown12:4,
+     home_vfo:1,        // 27 HOME->VFO
+     unknown12_1:2,
+     dw_rt:1;           // 23 DW RVT;
 } scan_settings;
 
 #seekto 0x064a;
@@ -124,7 +146,7 @@ struct {
   } message;
 } opening_message;
 
-#seekto 0x%04X; // FT-1D:0e4a, FT2D:094a
+#seekto 0x%(dtmadd)04X; // FT-1D:0e4a, FT2D:094a
 struct {
   u8 memory[16];
 } dtmf[10];
@@ -156,8 +178,7 @@ struct {
 """
 
 MEM_FORMAT = """
-#seekto 0x2D4A;
-struct {
+struct memslot {
   u8 unknown0:2,
      mode_alt:1,  // mode for FTM-3200D
      clock_shift:1,
@@ -169,30 +190,39 @@ struct {
   u8 power:2,
      digmode:2,   // 0=Analog, 1=AMS, 2=DN, 3=VW
      tone_mode:4;
-  u8 charsetbits[2];
+  u16 charsetbits;
   char label[16];
   bbcd offset[3];
   u8 unknown5:2,
      tone:6;
   u8 unknown6:1,
      dcs:7;
-  u8 unknown7[2];
+  u16 unknown7;
   u8 unknown8:2,
      att:1,
      autostep:1,
      automode:1,
      unknown9:3;
-} memory[%d];
+};
+#seekto 0x2D4A;
+struct memslot memory[%(memnum)d];
+struct memslot Skip[99];
+struct memslot PMS[100];
+#seekto 0x10ca;
+struct memslot Home[11];
 
-#seekto 0x280A;
-struct {
+struct flagslot {
   u8 nosubvfo:1,
      unknown:3,
      pskip:1,
      skip:1,
      used:1,
      valid:1;
-} flag[%d];
+};
+#seekto 0x280A;
+struct flagslot flag[%(memnum)d];
+struct flagslot flagskp[99];
+struct flagslot flagPMS[100];
 """
 
 MEM_APRS_FORMAT = """
@@ -319,7 +349,7 @@ struct {
   char padded_string[60];
 } aprs_beacon_status_txt[5];
 
-#seekto 0x%04X;
+#seekto 0xFECA;
 struct {
   bbcd date[3];
   bbcd time[2];
@@ -339,16 +369,16 @@ struct {
   u16 unknown8;
   u16 unknown9;
   u16 unknown10;
-} aprs_beacon_meta[%d];
+} aprs_beacon_meta[60];
 
-#seekto 0x%04X;
+#seekto 0x1064A;
 struct {
   char dst_callsign[9];
   char path[30];
   u16 flags;
   u8 separator;
-  char body[%d];
-} aprs_beacon_pkt[%d];
+  char body[134];
+} aprs_beacon_pkt[60];
 
 #seekto 0x137c4;
 struct {
@@ -384,6 +414,99 @@ struct {
 } backtrack[3];
 
 """
+
+MEM_GM_FORMAT = """
+#seekto 0x04ba;
+struct {
+    u8 unknown:3,
+        scan_resume:5;          // 52 SCN.RSM
+    u8 unknown1:3,
+       dw_resume_interval:5;       // 22 DW RSM
+    u8 unknown2;
+    u8 unknown3:3,
+        apo:5;                  // 02 APO
+    u8 unknown4:6,
+        gm_ring:2;              // 24 GM RNG
+    u8 temp_cf;               // Placeholder as not found
+    u8 unknown5;
+    } first_settings;
+
+#seekto 0x04ed;
+struct {
+    u8 unknown1:1,
+       unknown2:1,
+       unknown3:1,
+       unknown4:1,
+       unknown5:1,
+       unknown6:1,
+       unknown7:1,
+       unknown8:1;
+     } test_bit_field;
+
+#seekto 0x04c0;
+struct {
+    u8 unknown1:5,
+        beep_level:3;           // 05 BEP.LVL
+    u8 unknown2:6,
+        beep_select:2;          // 04 BEEP
+    } beep_settings;
+
+#seekto 0xCF30;
+struct {
+    u8 unknown0;
+    u8 unknown1;
+    u8 unknown2;
+    u8 unknown3;
+    u8 unknown4;
+    u8 unknown5;
+    u8 unknown6;
+    u8 digital_popup;              // 15 DIG.POP
+    } digital_settings_more;
+
+#seekto 0xCF7C;
+struct {
+    u8 unknown0:6,
+       ams_tx_mode:2;              // AMS TX Mode
+    u8 unknown1;
+    u8 unknown2:7,
+       standby_beep:1;             // 07 BEP.STB
+    u8 unknown3;
+    u8 unknown4:6,
+       gm_ring:2;                  // 24 GM RNG
+    u8 unknown5;
+    u8 rx_dg_id;                   // RX DG-ID
+    u8 tx_dg_id;                   // TX DG-ID
+    u8 unknown6:7,
+       vw_mode:1;                  // 16 DIG VW
+    u8 unknown7;
+    } digital_settings;
+
+#seekto 0x1d6d3;
+struct {
+    char message[32];
+    } GM[10];
+
+#seekto 0x0ced0;
+struct {
+    char callsign[10];              // 63 MYCALL
+    u16 charset;                    // character set ID
+    } my_call;
+
+#seekto 0x1ddca;
+struct {
+    struct {
+        char name[16];
+    } Category[5];
+    struct {
+        struct {
+            char ID[5];             // ASCII numerals
+            char name[16];          // blank-fill
+            u8 unknown[3];
+        } Rooms[20];
+    } RoomsPerCategory[5];
+} WiresX_settings;
+"""
+
 MEM_CHECKSUM_FORMAT = """
 #seekto 0x1FDC9;
 u8 checksum;
@@ -409,6 +532,31 @@ POWER_LEVELS = [chirp_common.PowerLevel("Hi", watts=5.00),
                 chirp_common.PowerLevel("L3", watts=2.50),
                 chirp_common.PowerLevel("L2", watts=1.00),
                 chirp_common.PowerLevel("L1", watts=0.05)]
+SKIPNAMES = ["Skip%i" % i for i in range(901, 1000)]
+PMSNAMES = ["%s%i" % (c, i) for i in range(1, 51) for c in ['L', 'U']]
+HOMENAMES = ["Home%i" % i for i in range(1, 12)]
+ALLNAMES = SKIPNAMES + PMSNAMES + HOMENAMES
+# list of (array name, (list of memories in that array))
+# array names must match names of memories defined for radio
+SPECIALS = [
+    ("Skip", SKIPNAMES),
+    ("PMS", PMSNAMES),
+    ("Home", HOMENAMES)
+]
+# Band edges are integer Hz.
+VALID_BANDS = [
+    (510000, 1790000),
+    (1800000, 50490000),
+    (50500000, 75990000),
+    (76000000, 107990000),
+    (108000000, 136990000),
+    (145000000, 169920000),
+    (174000000, 221950000),
+    (222000000, 419990000),
+    (420000000, 469990000),
+    (470000000, 773990000),
+    (810010000, 999000000)
+]
 
 
 class FT1Bank(chirp_common.NamedBank):
@@ -566,19 +714,17 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
     MODEL = "FT-1D"
     VARIANT = "R"
     FORMATS = [directory.register_format('FT1D ADMS-6', '*.ft1d')]
-
+    class_specials = SPECIALS
     _model = b"AH44M"
     _memsize = 130507
     _block_lengths = [10, 130497]
     _block_size = 32
-    _mem_params = (0xe4a,          # location of DTMF storage
-                   900,            # size of memories array
-                   900,            # size of flags array
-                   0xFECA,         # APRS beacon metadata address.
-                   60,             # Number of beacons stored.
-                   0x1064A,        # APRS beacon content address.
-                   134,            # Length of beacon data stored.
-                   60)             # Number of beacons stored.
+    MAX_MEM_SLOT = 900
+    _mem_params = {
+         "memnum": 900,            # size of memories array
+         "flgnum": 900,            # size of flags array
+         "dtmadd": 0xe4a,          # location of DTMF storage
+    }
     _has_vibrate = False
     _has_af_dual = True
     _adms_ext = '.ft1d'
@@ -652,6 +798,91 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
     _NS_HEMI = ("N", "S")
     _WE_HEMI = ("W", "E")
     _APRS_HIGH_SPEED_MAX = 70
+    _MIC_GAIN = ("Level %d" % i for i in range(1, 10))
+    _AMS_TX_MODE = ("TX Auto", "TX DIGITAL", "TX FM")
+    _VW_MODE = ("On", "Off")
+    _DIG_POP_UP = ("Off", "2sec", "4sec", "6sec", "8sec", "10sec",
+                   "20sec", "30sec", "60sec", "Continuous")
+    _STANDBY_BEEP = ("On", "Off")
+    _ON_OFF = ("On", "Off")
+    _TEMP_CF = ("Centigrade", "Fahrenheit")
+    _APO_SELECT = ("Off", "0.5H", "1.0H", "1.5H", "2.0H", "2.5H",
+                   "3.0H", "3.5H", "4.0H", "4.5H", "5.0H",
+                   "5.5H", "6.0H", "6.5H", "7.0H", "7.5H", "8.0H",
+                   "8.5H", "9.0H", "9.5H", "10.0H", "10.5H",
+                   "11.0H", "11.5H", "12.0H")
+    _MONI_TCALL = ("Monitor", "Tone-CALL")
+    _HOME_REV = ("Home", "Reverse")
+    _LOCK = ("KEY", "DIAL", "Key+Dial", "PTT", "Key+PTT", "Dial+PTT", "ALL")
+    _PTT_DELAY = ("Off", "20 MS", "50 MS", "100 MS", "200 MS")
+    _BEEP_LEVEL = ("Level %i" % i for i in range(1, 7))
+    _SET_MODE = ("Level %i" % i for i in range(1, 8))
+    _RX_SAVE = ("OFF", "0.2s", ".3s", ".4s", ".5s", ".6s",
+                ".7s", ".8s", ".9s", "1.0s", "1.5s",
+                "2.0s", "2.5s", "3.0s", "3.5s", "4.0s", "4.5s",
+                "5.0s", "5.5s", "6.0s", "6.5s", "7.0s",
+                "7.5s", "8.0s", "8.5s", "9.0s", "10.0s", "15s",
+                "20s", "25s", "30s", "35s", "40s", "45s", "50s", "55s",
+                "60s")
+    _VFO_MODE = ("ALL", "BAND")
+    _VFO_SCAN_MODE = ("BAND", "ALL")
+    _MEMORY_SCAN_MODE = ("BAND", "ALL")
+
+    _SG_RE = re.compile(r"(?P<sign>[-+NESW]?)(?P<d>[\d]+)[\s\.,]*"
+                        "(?P<m>[\d]*)[\s\']*(?P<s>[\d]*)")
+
+    _RX_BAUD = ("off", "1200 baud", "9600 baud")
+    _TX_DELAY = ("100ms", "150ms", "200ms", "250ms", "300ms",
+                 "400ms", "500ms", "750ms", "1000ms")
+    _WIND_UNITS = ("m/s", "mph")
+    _RAIN_UNITS = ("mm", "inch")
+    _TEMP_UNITS = ("C", "F")
+    _ALT_UNITS = ("m", "ft")
+    _DIST_UNITS = ("km", "mile")
+    _POS_UNITS = ("dd.mmmm'", "dd mm'ss\"")
+    _SPEED_UNITS = ("km/h", "knot", "mph")
+    _TIME_SOURCE = ("manual", "GPS")
+    _TZ = ("-13:00", "-13:30", "-12:00", "-12:30", "-11:00", "-11:30",
+           "-10:00", "-10:30", "-09:00", "-09:30", "-08:00", "-08:30",
+           "-07:00", "-07:30", "-06:00", "-06:30", "-05:00", "-05:30",
+           "-04:00", "-04:30", "-03:00", "-03:30", "-02:00", "-02:30",
+           "-01:00", "-01:30", "-00:00", "-00:30", "+01:00", "+01:30",
+           "+02:00", "+02:30", "+03:00", "+03:30", "+04:00", "+04:30",
+           "+05:00", "+05:30", "+06:00", "+06:30", "+07:00", "+07:30",
+           "+08:00", "+08:30", "+09:00", "+09:30", "+10:00", "+10:30",
+           "+11:00", "+11:30")
+    _BEACON_TYPE = ("Off", "Interval", "SmartBeaconing")
+    _SMARTBEACON_PROFILE = ("Off", "Type 1", "Type 2", "Type 3")
+    _BEACON_INT = ("30s", "1m", "2m", "3m", "5m", "10m", "15m",
+                   "20m", "30m", "60m")
+    _DIGI_PATHS = ("OFF", "WIDE1-1", "WIDE1-1, WIDE2-1", "Digi Path 4",
+                   "Digi Path 5", "Digi Path 6", "Digi Path 7", "Digi Path 8")
+    _MSG_GROUP_NAMES = ("Message Group 1", "Message Group 2",
+                        "Message Group 3", "Message Group 4",
+                        "Message Group 5", "Message Group 6",
+                        "Message Group 7", "Message Group 8")
+    _POSITIONS = ("GPS", "Manual Latitude/Longitude",
+                  "Manual Latitude/Longitude", "P1", "P2", "P3", "P4",
+                  "P5", "P6", "P7", "P8", "P9")
+    _FLASH = ("OFF", "2 seconds", "4 seconds", "6 seconds", "8 seconds",
+              "10 seconds", "20 seconds", "30 seconds", "60 seconds",
+              "CONTINUOUS", "every 2 seconds", "every 3 seconds",
+              "every 4 seconds", "every 5 seconds", "every 6 seconds",
+              "every 7 seconds", "every 8 seconds", "every 9 seconds",
+              "every 10 seconds", "every 20 seconds", "every 30 seconds",
+              "every 40 seconds", "every 50 seconds", "every minute",
+              "every 2 minutes", "every 3 minutes", "every 4 minutes",
+              "every 5 minutes", "every 6 minutes", "every 7 minutes",
+              "every 8 minutes", "every 9 minutes", "every 10 minutes")
+    _BEEP_SELECT = ("Off", "Key+Scan", "Key")
+    _SQUELCH = ["%d" % x for x in range(0, 16)]
+    _VOLUME = ["%d" % x for x in range(0, 33)]
+    _DG_ID = ["%d" % x for x in range(0, 100)]
+    _GM_RING = ("OFF", "IN RING", "AlWAYS")
+    _GM_INTERVAL = ("LONG", "NORMAL", "OFF")
+
+    _MYCALL_CHR_SET = list(string.ascii_uppercase) + \
+        list(string.digits) + ['-', '/']
 
     @classmethod
     def match_model(cls, filedata, filename):
@@ -680,7 +911,7 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
 
     def process_mmap(self):
         mem_format = MEM_SETTINGS_FORMAT + MEM_FORMAT + MEM_APRS_FORMAT + \
-                MEM_BACKTRACK_FORMAT + MEM_CHECKSUM_FORMAT
+                MEM_BACKTRACK_FORMAT + MEM_GM_FORMAT + MEM_CHECKSUM_FORMAT
         self._memobj = bitwise.parse(mem_format % self._mem_params, self._mmap)
 
     def get_features(self):
@@ -700,6 +931,9 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
         rf.has_ctone = False
         rf.has_bank_names = True
         rf.has_settings = True
+        rf.valid_special_chans = [name for s in SPECIALS for name in s[1]]
+        return rf
+
         return rf
 
     def get_raw_memory(self, number):
@@ -724,34 +958,113 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
             result.append(str(msg_text).rstrip("\xFF"))
         return result
 
+#   Called with a "memref" index to CHIRP memory (int or str)
+#   and optionally with a "extref" extended name.
+#   Find and return the corresponding memobj
+#   Returns:
+#       Corresponding radio memory object
+#       Corresponding radio alag structure (if any)
+#       index into the specific memory object structure (int) ndx
+#       overall index into memory & specials (int) num
+#       an indicator of the specific radio object structure (str)
+    def slotloc(self, memref, extref=None):
+        array = None
+        num = memref
+        ename = ""
+        mstr = isinstance(memref, str)
+        specials = ALLNAMES
+        extr = False
+        if extref is not None:
+            extr = extref in specials
+        if mstr or extr:        # named special?
+            ename = memref
+            num = self.MAX_MEM_SLOT + 1
+            # num = -1
+            sname = memref if mstr else extref
+            # Find name of appropriate memory and index into that memory
+            for x in self.class_specials:
+                try:
+                    ndx = x[1].index(sname)
+                    array = x[0]
+                    break
+                except Exception:
+                    num += len(x[1])
+                    # num -= len(x[1])
+            if array is None:
+                raise IndexError("Unknown special %s", memref)
+            num += ndx
+            # num -= ndx
+        elif memref > self.MAX_MEM_SLOT:         # numbered special
+            ename = extref
+            ndx = memref - (self.MAX_MEM_SLOT + 1)
+            # Find name of appropriate memory and index into that memory
+            # But assumes specials are in reverse-quantity order
+            for x in self.class_specials:
+                if ndx < len(x[1]):
+                    array = x[0]
+                    break
+                ndx -= len(x[1])
+            if array is None:
+                raise IndexError("Unknown memref number %s", memref)
+        else:
+            array = "memory"
+            ndx = memref - 1
+            _flag = self._memobj.flag[ndx]
+        if array == "Skip":
+            _flag = self._memobj.flagskp[ndx]
+        elif array == "PMS":
+            _flag = self._memobj.flagPMS[ndx]
+        elif array == "Home":
+            _flag = None
+        _mem = getattr(self._memobj, array)[ndx]
+        return (_mem, _flag,  ndx, num, array, ename)
+
+    # Build CHIRP version (mem) of radio's memory (_mem)
     def get_memory(self, number):
-        flag = self._memobj.flag[number - 1]
-        _mem = self._memobj.memory[number - 1]
-
+        _mem, _flag, ndx, num, array, ename = self.slotloc(number)
         mem = chirp_common.Memory()
-        mem.number = number
-        if not flag.used:
-            mem.empty = True
-        if not flag.valid:
-            mem.empty = True
-            return mem
-        mem.freq = chirp_common.fix_rounded_step(int(_mem.freq) * 1000)
-        mem.offset = int(_mem.offset) * 1000
-        mem.rtone = mem.ctone = chirp_common.TONES[_mem.tone]
-        self._get_tmode(mem, _mem)
-        mem.duplex = DUPLEX[_mem.duplex]
-        if mem.duplex == "split":
-            mem.offset = chirp_common.fix_rounded_step(mem.offset)
-        mem.mode = self._decode_mode(_mem)
-        mem.dtcs = chirp_common.DTCS_CODES[_mem.dcs]
-        mem.tuning_step = STEPS[_mem.tune_step]
-        mem.power = self._decode_power_level(_mem)
-        mem.skip = flag.pskip and "P" or flag.skip and "S" or ""
+        mem.number = num
+        if array == "Home":
+            mem.empty = False
+            mem.extd_number = ename
+            mem.name = self._decode_label(_mem)
+            mem.immutable += ["empty", "number", "extd_number", "skip"]
+        elif array != "memory":
+            mem.extd_number = ename
+            mem.immutable += ["name", "extd_number"]
+        else:
+            mem.name = self._decode_label(_mem)
 
-        mem.name = self._decode_label(_mem)
-
-        self._get_mem_extra(mem, _mem)
-
+        if _flag is not None:
+            mem.skip = _flag.pskip and "P" or _flag.skip and "S" or ""
+            mem.empty = False
+            if not _flag.used:
+                mem.empty = True
+            if not _flag.valid:
+                mem.empty = True
+        if mem.empty:
+            mem.freq = 0
+            mem.offset = 0
+            mem.duplex = ""
+            mem.power = POWER_LEVELS[0]
+            mem.mode = "FM"
+            mem.tuning_step = 0
+        else:
+            mem.freq = chirp_common.fix_rounded_step(int(_mem.freq) * 1000)
+            mem.offset = int(_mem.offset) * 1000
+            mem.rtone = mem.ctone = chirp_common.TONES[_mem.tone]
+            self._get_tmode(mem, _mem)
+            if mem.duplex is None:
+                mem.duplex = DUPLEX[""]
+            else:
+                mem.duplex = DUPLEX[_mem.duplex]
+            if mem.duplex == "split":
+                mem.offset = chirp_common.fix_rounded_step(mem.offset)
+            mem.mode = self._decode_mode(_mem)
+            mem.dtcs = chirp_common.DTCS_CODES[_mem.dcs]
+            mem.tuning_step = STEPS[_mem.tune_step]
+            mem.power = self._decode_power_level(_mem)
+            self._get_mem_extra(mem, _mem)
         return mem
 
     def _get_mem_extra(self, mem, _mem):
@@ -783,13 +1096,16 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
 
     def _encode_charsetbits(self, mem):
         # We only speak english here in chirpville
-        return [0x00, 0x00]
+        return 0x0000
 
     def _decode_power_level(self, mem):
         return POWER_LEVELS[3 - mem.power]
 
     def _encode_power_level(self, mem):
-        return 3 - POWER_LEVELS.index(mem.power)
+        if mem.power is None:
+            return 3        # Choose lowest power
+        else:
+            return 3 - POWER_LEVELS.index(mem.power)
 
     def _decode_mode(self, mem):
         mode = MODES[mem.mode]
@@ -836,58 +1152,68 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
             LOG.debug('New mode FM, disabling AMS')
             _mem.digmode = 0
         _mem.mode = self._encode_mode(mem)
+        bm = self.get_bank_model()
+        for bank in bm.get_memory_mappings(mem):
+            bm.remove_memory_from_mapping(mem, bank)
 
     def _debank(self, mem):
         bm = self.get_bank_model()
         for bank in bm.get_memory_mappings(mem):
             bm.remove_memory_from_mapping(mem, bank)
 
+    def validate_memory(self, mem):
+        # Only check the home registers for appropriate bands
+        msgs = super().validate_memory(mem)
+        ndx = mem.number - ALLNAMES.index("Home1") - self.MAX_MEM_SLOT - 1
+        if 10 >= ndx >= 0:
+            f = VALID_BANDS[ndx]
+            if not(f[0] < mem.freq < f[1]):
+                msgs.append(chirp_common.ValidationError(
+                            "Frequency outside of band for Home%2d" %
+                            (ndx + 1)))
+        return msgs
+
+    # Modify radio's memory (_mem) corresponding to CHIRP version at 'mem'
     def set_memory(self, mem):
-        _mem = self._memobj.memory[mem.number - 1]
-        flag = self._memobj.flag[mem.number - 1]
-
-        self._debank(mem)
-
-        if not mem.empty and not flag.valid:
-            self._wipe_memory(_mem)
-
-        if mem.empty and flag.valid and not flag.used:
-            flag.valid = False
-            return
-        flag.used = not mem.empty
-        flag.valid = flag.used
-
+        _mem, flag, ndx, num, regtype, ename = self.slotloc(mem.number,
+                                                            mem.extd_number)
         if mem.empty:
+            self._wipe_memory(_mem)
+            if flag is not None:
+                flag.used = False
             return
-
-        if mem.freq < 30000000 or \
-                (mem.freq > 88000000 and mem.freq < 108000000) or \
-                mem.freq > 580000000:
-            flag.nosubvfo = True     # Masked from VFO B
-        else:
-            flag.nosubvfo = False    # Available in both VFOs
-
-        _mem.freq = int(mem.freq / 1000)
-        _mem.offset = int(mem.offset / 1000)
+        _mem.power = self._encode_power_level(mem)
         _mem.tone = chirp_common.TONES.index(mem.rtone)
         self._set_tmode(_mem, mem)
-        _mem.duplex = DUPLEX.index(mem.duplex)
-        self._set_mode(_mem, mem)
         _mem.dcs = chirp_common.DTCS_CODES.index(mem.dtcs)
         _mem.tune_step = STEPS.index(mem.tuning_step)
-        if mem.power:
-            _mem.power = self._encode_power_level(mem)
+        # duplex "off" is equivalent to "" and may show up in tox test.
+        if mem.duplex is None:
+            _mem.duplex = DUPLEX.index("")
         else:
-            _mem.power = 0
-
+            _mem.duplex = DUPLEX.index(mem.duplex)
+        self._set_mode(_mem, mem)
+        if flag is not None:
+            if mem.freq < 30000000 or \
+                    (mem.freq > 88000000 and mem.freq < 108000000) or \
+                    mem.freq > 580000000:
+                flag.nosubvfo = True     # Masked from VFO B
+            else:
+                flag.nosubvfo = False    # Available in both VFOs
+        if regtype != "Home":
+            self._debank(mem)
+            ndx = num - 1
+            flag.used = not mem.empty
+            flag.valid = True
+            flag.skip = mem.skip == "S"
+            flag.pskip = mem.skip == "P"
+        freq = mem.freq
+        _mem.freq = int(freq / 1000)
+        _mem.offset = int(mem.offset / 1000)
         _mem.label = self._encode_label(mem)
-        charsetbits = self._encode_charsetbits(mem)
-        _mem.charsetbits[0], _mem.charsetbits[1] = charsetbits
-
-        flag.skip = mem.skip == "S"
-        flag.pskip = mem.skip == "P"
-
+        _mem.charsetbits = self._encode_charsetbits(mem)
         self._set_mem_extra(mem, _mem)
+        return
 
     @classmethod
     def _wipe_memory(cls, mem):
@@ -972,6 +1298,16 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
 
         return cls._latlong_sanity(sign, result[0], result[1], result[2],
                                    is_lat)
+
+    def _get_aprs_settings(self):
+        menu = RadioSettingGroup("aprs_top", "APRS")
+        menu.append(self._get_aprs_general_settings())
+        menu.append(self._get_aprs_rx_settings())
+        menu.append(self._get_aprs_tx_settings())
+        menu.append(self._get_aprs_smartbeacon())
+        menu.append(self._get_aprs_msgs())
+        menu.append(self._get_aprs_beacons())
+        return menu
 
     def _get_aprs_general_settings(self):
         menu = RadioSettingGroup("aprs_general", "APRS General")
@@ -1477,6 +1813,169 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
 
         return menu
 
+    def _get_digital_settings(self):
+        topmenu = RadioSettingGroup("digital_settings", "Digital")
+        menu = RadioSettingGroup("settings", "Digital Modes")
+        topmenu.append(menu)
+        GMmenu = RadioSettingGroup("first_settings", "Group Monitor(GM)")
+        topmenu.append(GMmenu)
+        WXmenu = RadioSettingGroup("WiresX_settings", "Wires-X")
+        topmenu.append(WXmenu)
+
+        # MYCALL
+        mycall = self._memobj.my_call
+        mycallstr = str(mycall.callsign).rstrip("\xff").rstrip()
+        mycalle = RadioSettingValueString(0, 10, mycallstr, False,
+                                          charset=self._MYCALL_CHR_SET)
+        rs = RadioSetting('mycall.callsign',
+                          'MYCALL (10 uppercase chars)', mycalle)
+        rs.set_apply_callback(self.apply_mycall, mycall)
+        menu.append(rs)
+
+        # Short Press AMS button AMS TX Mode
+        digital_settings = self._memobj.digital_settings
+        val = RadioSettingValueList(
+            self._AMS_TX_MODE,
+            self._AMS_TX_MODE[digital_settings.ams_tx_mode])
+        rs = RadioSetting("digital_settings.ams_tx_mode",
+                          "AMS TX Mode", val)
+        menu.append(rs)
+
+        # 16 DIG VW  Turn the VW mode selection ON or OFF.
+        val = RadioSettingValueList(
+            self._VW_MODE,
+            self._VW_MODE[digital_settings.vw_mode])
+        rs = RadioSetting("digital_settings.vw_mode", "VW Mode", val)
+        menu.append(rs)
+
+        # TX DG-ID Long Press Mode Key, Dial
+        val = RadioSettingValueList(
+            self._DG_ID,
+            self._DG_ID[digital_settings.tx_dg_id])
+        rs = RadioSetting("digital_settings.tx_dg_id",
+                          "TX DG-ID", val)
+        menu.append(rs)
+
+        # RX DG-ID Long Press Mode Key, Mode Key to select, Dial
+        val = RadioSettingValueList(
+            self._DG_ID,
+            self._DG_ID[digital_settings.rx_dg_id])
+        rs = RadioSetting("digital_settings.rx_dg_id",
+                          "RX DG-ID", val)
+        menu.append(rs)
+
+        # 15 DIG.POP    Call sign display pop up time
+        digital_settings_more = self._memobj.digital_settings_more
+
+        val = RadioSettingValueList(
+            self._DIG_POP_UP,
+            self._DIG_POP_UP[
+                0 if digital_settings_more.digital_popup == 0
+                else digital_settings_more.digital_popup - 9])
+
+        rs = RadioSetting("digital_settings_more.digital_popup",
+                          "Digital Popup", val)
+        rs.set_apply_callback(self.apply_digital_popup,
+                              digital_settings_more)
+        menu.append(rs)
+
+        # 07  BEP.STB    Standby Beep in the digital C4FM mode. On/Off
+        val = RadioSettingValueList(
+            self._STANDBY_BEEP,
+            self._STANDBY_BEEP[digital_settings.standby_beep])
+        rs = RadioSetting("digital_settings.standby_beep",
+                          "Standby Beep", val)
+        menu.append(rs)
+
+        # GM settings
+        # 24 GM RNG Select the beep option
+        first_settings = self._memobj.first_settings
+        val = RadioSettingValueList(
+            self._GM_RING,
+            self._GM_RING[first_settings.gm_ring])
+        rs = RadioSetting("first_settings.gm_ring", "GM Ring", val)
+        GMmenu.append(rs)
+
+        # 25 GM INT transmission interval of digital GM info
+        scan_settings = self._memobj.scan_settings
+        val = RadioSettingValueList(
+            self._GM_INTERVAL,
+            self._GM_INTERVAL[scan_settings.gm_interval])
+        rs = RadioSetting("scan_settings.gm_interval",
+                          "GM Interval", val)
+        GMmenu.append(rs)
+
+        m = self._memobj.GM
+        for i in range(0, 10):
+            cname = "GM[%d].message" % i
+            msg = str(m[i].message).rstrip("\xff)")
+            val = RadioSettingValueString(0, 32, msg)
+            rs = RadioSetting(cname, "GM Message%2d" % (i + 1),
+                              val)
+            GMmenu.append(rs)
+
+        # WiresX settings
+        wxc = self._memobj.WiresX_settings
+        for i in range(0, 5):
+            cname = "WiresX_settings.Category[%d].name" % (i + 1)
+            c = ''
+            for j in range(0, 16):
+                s = wxc.Category[i].name[j]
+                if int(s) != 0xff:
+                    c = c + str(s)
+            val = RadioSettingValueString(0, 16, c)
+            rs = RadioSetting(cname, "Category %d" % (i+1), val)
+            rs.set_apply_callback(self.apply_WiresX_category,
+                                  wxc.Category[i].name)
+            WXmenu.append(rs)
+
+            r = wxc.RoomsPerCategory[i]
+            rn = False
+            for j in range(0, 20):
+                idn = "0"
+                if int(r.Rooms[j].ID[1]) != 0xff:
+                    idn = r.Rooms[j].ID
+                    rn = False
+                elif rn:
+                    break
+                elif j > 0:
+                    rn = True
+                val = RadioSettingValueInteger(0, 99999, int(str(idn)))
+                vname = "WiresX_settings.RoomsperCategory%s" \
+                        "Rooms[%d].ID" % (i, j)
+                rs = RadioSetting(vname, "   Room ID%2s (5 numerals)" %
+                                  (j+1), val)
+                rs.set_apply_callback(self.apply_WiresX_roomid,
+                                      r.Rooms[j])
+                WXmenu.append(rs)
+                cn = ''
+                for l in range(0, 16):
+                    s = r.Rooms[j].name[l]
+                    if int(s) != 0xff:
+                        cn = cn + str(s)
+                val = RadioSettingValueString(0, 16, str(cn))
+                cname = "WiresX_settings.RoomsperCategory%s" \
+                        "Rooms[%d].name" % (i, j)
+                rs = RadioSetting(cname, "   Room Name%2s (16 chars)" %
+                                  (j+1), val)
+                rs.set_apply_callback(self.apply_WiresX_roomname,
+                                      r.Rooms[j])
+                WXmenu.append(rs)
+            pass
+        return topmenu
+
+    def apply_WiresX_category(cls, setting, obj):
+        val = setting.value.get_value()
+        setattr(obj, "name", val)
+
+    def apply_WiresX_roomid(cls, setting, obj):
+        val = setting.value.get_value()
+        obj.ID = str(val)
+
+    def apply_WiresX_roomname(cls, setting, obj):
+        val = setting.value.get_value()
+        obj.name = str(val)
+
     def _get_dtmf_settings(self):
         menu = RadioSettingGroup("dtmf_settings", "DTMF")
         dtmf = self._memobj.scan_settings
@@ -1826,12 +2325,8 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
         return menu
 
     def _get_settings(self):
-        top = RadioSettings(self._get_aprs_general_settings(),
-                            self._get_aprs_rx_settings(),
-                            self._get_aprs_tx_settings(),
-                            self._get_aprs_smartbeacon(),
-                            self._get_aprs_msgs(),
-                            self._get_aprs_beacons(),
+        top = RadioSettings(self._get_aprs_settings(),
+                            self._get_digital_settings(),
                             self._get_dtmf_settings(),
                             self._get_misc_settings(),
                             self._get_scan_settings(),
@@ -1883,6 +2378,22 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
         else:
             setattr(obj, "tx_interval_beacon", 0)
             setattr(obj, "tx_smartbeacon", 0)
+
+    # digital settings callback routines
+    def apply_digital_popup(cls, setting, obj):
+        rawval = setting.value.get_value()
+        val = 0 if cls._DIG_POP_UP.index(rawval) == 0 \
+            else cls._DIG_POP_UP.index(rawval) + 9
+        obj.digital_popup = val
+
+    def apply_mycall(cls, setting, obj):
+        cs = setting.value.get_value()
+        if cs[0] in ('-', '/'):
+            raise InvalidValueError("First character of"
+                                    " call sign can't be - or /:  {0:s}"
+                                    .format(cs))
+        else:
+            obj.callsign = cls._add_ff_pad(cs.rstrip(), 10)
 
     @classmethod
     def apply_callsign(cls, setting, obj, default_ssid=None):

--- a/chirp/drivers/ftm3200d.py
+++ b/chirp/drivers/ftm3200d.py
@@ -73,8 +73,9 @@ class FTM3200Radio(ft1d.FT1Radio):
     _has_vibrate = False
     _has_af_dual = False
 
-    _mem_params = (199,            # size of memories array
-                   199)            # size of flags array
+    _mem_params = {
+         "memnum": 199,            # size of memories array
+         "flgnum": 199}            # size of flags array
 
     @classmethod
     def get_prompts(cls):
@@ -125,7 +126,7 @@ class FTM3200Radio(ft1d.FT1Radio):
 
     def _decode_label(self, mem):
         # TODO preserve the unknown \x80-x86 chars?
-        return str(mem.label).rstrip("\xFF")
+        return str(mem.label).rstrip("\xFF").rstrip()
 
     def _encode_label(self, mem):
         label = mem.name.rstrip().encode('ascii', 'ignore')
@@ -136,14 +137,17 @@ class FTM3200Radio(ft1d.FT1Radio):
         # as a name or frequency. Should we expose this setting to the user
         # instead of autoselecting it (and losing their preference)?
         if mem.name.rstrip() == '':
-            return [0x00, 0x00]
-        return [0x00, 0x80]
+            return 0x0000
+        return 0x0080
 
     def _decode_power_level(self, mem):
         return POWER_LEVELS[mem.power - 1]
 
     def _encode_power_level(self, mem):
-        return POWER_LEVELS.index(mem.power) + 1
+        if mem.power is None:
+            return 1
+        else:
+            return POWER_LEVELS.index(mem.power) + 1
 
     def _decode_mode(self, mem):
         return MODES[mem.mode_alt]


### PR DESCRIPTION
FeatureAdd #6151 WiresX settings
FeatureAdd #10629 Handle special registers. This also requires changes to Yaesu FTM3200D_R, which depends upon FT1D_R. Style and driver-test fixes are included rather than in separate commits.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
