### PR TITLE
dupe() memory in set_memory() for memcache

### DIFF
--- a/chirp/drivers/kenwood_live.py
+++ b/chirp/drivers/kenwood_live.py
@@ -289,7 +289,7 @@ class KenwoodLiveRadio(chirp_common.LiveRadio):
                                                                memory.name))
             if not iserr(r2):
                 memory.name = memory.name.rstrip()
-                self._memcache[memory.number] = memory
+                self._memcache[memory.number] = memory.dupe()
             else:
                 raise errors.InvalidDataError("Radio refused name %i: %s" %
                                               (memory.number,


### PR DESCRIPTION
The memory passed to set_memory() is frozen, so if it's saved in memcache, the next time you try to change the memory, you'll get a lot of "fix this driver!" warnings from memedit and friends.