### PR TITLE
Properly indent sub-groups in RadioSettingGroup.__str__

### DIFF
--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -355,7 +355,8 @@ class RadioSettingGroup(object):
     def __str__(self):
         string = "group '%s': {\n" % self._name
         for element in sorted(self._elements.values()):
-            string += "\t" + str(element) + "\n"
+            for line in str(element).split("\n"):
+                string += "\t" + line + "\n"
         string += "}"
         return string
 


### PR DESCRIPTION
Previously, sub-groups would all have headers/footers left aligned and all options would start with a single tab, making it hard to understand a settings list with nested groups.

This adds a tab for each level of nesting.