### PR TITLE
Retevis H777S/RT24: Support full band TX/RX - fixes #10454

### DIFF
--- a/chirp/drivers/radioddity_r2.py
+++ b/chirp/drivers/radioddity_r2.py
@@ -678,7 +678,7 @@ class RetevisRT24(RadioddityR2):
     VENDOR = "Retevis"
     MODEL = "RT24"
 
-    _pmr = True
+    _pmr = False  # sold as PMR radio but supports full band TX/RX
 
 
 @directory.register
@@ -687,4 +687,4 @@ class RetevisH777S(RadioddityR2):
     VENDOR = "Retevis"
     MODEL = "H777S"
 
-    _frs16 = True
+    _frs16 = False  # sold as FRS radio but supports full band TX/RX


### PR DESCRIPTION
The Retevis H777S (FRS) and RT24 (PMR) are physically identical radios. Only the frequencies preprogrammed at the factory are different.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
