### PR TITLE
Fix spelling

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -913,7 +913,7 @@ class RadioFeatures:
                   "Indicates that the radio supports general settings")
         self.init("has_variable_power", False,
                   "Indicates the radio supports any power level between the "
-                  "min and max in valid_powe_levels")
+                  "min and max in valid_power_levels")
 
         self.init("valid_modes", list(MODES),
                   "Supported emission (or receive) modes")
@@ -971,7 +971,7 @@ class RadioFeatures:
         return self.__dict__[name]
 
     def validate_memory(self, mem):
-        """Return a list of warnings and errors that will be encoundered
+        """Return a list of warnings and errors that will be encountered
         if trying to set @mem on the current radio"""
         msgs = []
 
@@ -1166,7 +1166,7 @@ class Radio(Alias):
         in the radio's memory. The memory should accurately represent what is
         actually stored in the radio as closely as possible. If the radio
         does not support changing some attributes of the location in question,
-        the Memory.immutable list should be set approproately.
+        the Memory.immutable list should be set appropriately.
 
         NB: No changes to the radio's memory should occur as a result of
         calling get_memory().
@@ -1225,7 +1225,7 @@ class Radio(Alias):
         return []
 
     def validate_memory(self, mem):
-        """Return a list of warnings and errors that will be encoundered
+        """Return a list of warnings and errors that will be encountered
         if trying to set @mem on the current radio"""
         rf = self.get_features()
         return rf.validate_memory(mem)

--- a/chirp/drivers/alinco.py
+++ b/chirp/drivers/alinco.py
@@ -818,7 +818,7 @@ class AlincoDJG7(AlincoStyleRadio):
             elif mem.tmode == "TSQL":
                 _mem.squelch_type = self.TMODES.index("TSQL")
                 # Note how the same TSQL tone is copied to both memory
-                # locaations
+                # locations
                 try:
                     _mem.tx_tone = ALINCO_TONES.index(mem.ctone)+1
                     _mem.rx_tone = ALINCO_TONES.index(mem.ctone)+1

--- a/chirp/drivers/anytone778uv.py
+++ b/chirp/drivers/anytone778uv.py
@@ -569,7 +569,7 @@ def do_upload(radio):
             bptr += MEMORY_RW_BLOCK_SIZE
 
             if write_response == '\x0a':
-                # NACK from radio, e.g. checksum wrongn
+                # NACK from radio, e.g. checksum wrong
                 LOG.debug('Radio returned 0x0a - NACK:')
                 LOG.debug(' * write cmd:\n%s' % util.hexprint(write_command))
                 LOG.debug(' * write response:\n%s' %
@@ -642,7 +642,7 @@ def dtcs_code_val_to_bits(code):
 
 class AnyTone778UVBase(chirp_common.CloneModeRadio,
                        chirp_common.ExperimentalRadio):
-    '''AnyTone 778UV and probably Retivis RT95 and others'''
+    '''AnyTone 778UV and probably Retevis RT95 and others'''
     BAUD_RATE = 9600
     NEEDS_COMPAT_SERIAL = False
     NAME_LENGTH = 5
@@ -888,7 +888,7 @@ class AnyTone778UVBase(chirp_common.CloneModeRadio,
                     mem.rx_dtcs = rxcode
                     # #8327 Not sure this is the correct interpretation of
                     # DevelopersToneModes, but it seems to make it work round
-                    # tripping with the anytone software.  DTM implies that we
+                    # tripping with the Anytone software.  DTM implies that we
                     # might not need to set mem.dtcs, but if we do it only DTCS
                     # rx works (as if we were Cross:None->DTCS).
                     mem.dtcs = rxcode
@@ -1320,7 +1320,7 @@ class AnyTone778UVBase(chirp_common.CloneModeRadio,
         rset = RadioSetting("settings.tbstFrequency", "TBST frequency", rs)
         function.append(rset)
 
-        # Save Channel Perameter
+        # Save Channel Parameter
         rs = RadioSettingValueBoolean(_settings.saveChParameter)
         rset = RadioSetting("settings.saveChParameter",
                             "Save channel parameter", rs)
@@ -1774,7 +1774,7 @@ if has_future:
 
 
 class AnyTone778UVvoxBase(AnyTone778UVBase):
-    '''AnyTone 778UV VOX, Retivis RT95 VOX and others'''
+    '''AnyTone 778UV VOX, Retevis RT95 VOX and others'''
     NAME_LENGTH = 6
     HAS_VOX = True
 

--- a/chirp/drivers/anytone_iii.py
+++ b/chirp/drivers/anytone_iii.py
@@ -30,7 +30,7 @@ from chirp.settings import RadioSetting, RadioSettingGroup, \
 
 
 class ATBankModel(chirp_common.BankModel):
-    """Anytone Banks A-J, Each chan in zero or one bank"""
+    """AnyTone Banks A-J, Each chan in zero or one bank"""
 
     def __init__(self, radio, name='Banks'):
         super(ATBankModel, self).__init__(radio, name)

--- a/chirp/drivers/ap510.py
+++ b/chirp/drivers/ap510.py
@@ -140,7 +140,7 @@ def boolstr(b):
 class AP510Memory(object):
     """Parses and generates AP510 key/value format
 
-    The AP510 sends it's configuration as a set of keys and values. There
+    The AP510 sends its configuration as a set of keys and values. There
     is one key/value pair per line. Line separators are \r\n. Keys are
     deliminated from values with the = symbol.
 

--- a/chirp/drivers/bf_t1.py
+++ b/chirp/drivers/bf_t1.py
@@ -380,7 +380,7 @@ def _model_match(cls, data):
 
 def _decode_ranges(low, high):
     """Unpack the data in the ranges zones in the memmap and return
-    a tuple with the integer corresponding to the Mhz it means"""
+    a tuple with the integer corresponding to the MHz it means"""
     return (int(low) * 100000, int(high) * 100000)
 
 
@@ -435,7 +435,7 @@ struct {
   u8 fmrange;       // fm range 1 = low[65-76](ASIA), 0 = high[76-108](AMERICA)
   u8 alarm;         // alarm (count down timer)
                     //    d0 - d16 in half hour increments => off, 0.5 - 8.0 h
-  u8 voice;         // voice prompt 0 = off, 1 = english, 2 = chinese
+  u8 voice;         // voice prompt 0 = off, 1 = English, 2 = Chinese
   u8 volume;        // volume 1-7 as per the radio steps
                     //    set to #FF by original software on upload
                     //    chirp uploads actual value and works.

--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -623,7 +623,7 @@ def model_match(cls, data):
 
 def _decode_ranges(low, high):
     """Unpack the data in the ranges zones in the memmap and return
-    a tuple with the integer corresponding to the Mhz it means"""
+    a tuple with the integer corresponding to the MHz it means"""
     ilow = int(low[0]) * 100 + int(low[1]) * 10 + int(low[2])
     ihigh = int(high[0]) * 100 + int(high[1]) * 10 + int(high[2])
     ilow *= 1000000
@@ -1092,7 +1092,7 @@ class BTechMobileCommon(chirp_common.CloneModeRadio,
                 LOG.debug("New mem is empty.")
             else:
                 LOG.debug("New mem is NOT empty")
-                # set extra-settings to default ONLY when apreviously empty or
+                # set extra-settings to default ONLY when a previously empty or
                 # deleted memory was edited to prevent errors such as #4121
                 if mem_was_empty:
                     LOG.debug("old mem was empty. Setting default for extras.")
@@ -3463,7 +3463,7 @@ class BTech(BTechMobileCommon):
         LOG.info("Radio ranges: VHF %d to %d" % vhf)
         LOG.info("Radio ranges: UHF %d to %d" % uhf)
 
-        # 220Mhz radios case
+        # 220MHz radios case
         if self.MODEL in ["UV-2501+220", "KT8900R"]:
             vhf2 = _decode_ranges(ranges.vhf2_low, ranges.vhf2_high)
             LOG.info("Radio ranges: VHF(220) %d to %d" % vhf2)
@@ -3970,12 +3970,12 @@ class BTechColor(BTechMobileCommon):
 
         # the additional bands
         if self.MODEL in ["UV-25X4", "KT7900D"]:
-            # 200Mhz band
+            # 200MHz band
             vhf2 = _decode_ranges(ranges.vhf2_low, ranges.vhf2_high)
             LOG.info("Radio ranges: VHF(220) %d to %d" % vhf2)
             self._220_range = vhf2
 
-            # 350Mhz band
+            # 350MHz band
             uhf2 = _decode_ranges(ranges.uhf2_low, ranges.uhf2_high)
             LOG.info("Radio ranges: UHF(350) %d to %d" % uhf2)
             self._350_range = uhf2
@@ -4933,12 +4933,12 @@ class QYTColorHT(BTechMobileCommon):
 
         # the additional bands
         if self.MODEL in ["KT-8R"]:
-            # 200Mhz band
+            # 200MHz band
             vhf2 = _decode_ranges(ranges.vhf2_low, ranges.vhf2_high)
             LOG.info("Radio ranges: VHF(220) %d to %d" % vhf2)
             self._220_range = vhf2
 
-            # 350Mhz band
+            # 350MHz band
             uhf2 = _decode_ranges(ranges.uhf2_low, ranges.uhf2_high)
             LOG.info("Radio ranges: UHF(350) %d to %d" % uhf2)
             self._350_range = uhf2

--- a/chirp/drivers/fd268.py
+++ b/chirp/drivers/fd268.py
@@ -177,7 +177,7 @@ def do_magic(radio):
     status.msg = "Linking to radio, please wait."
     radio.status_fn(status)
 
-    # every byte of this magic chain must be send separatedly
+    # every byte of this magic chain must be send separately
     magic = "\x02PROGRA"
 
     # start the fun, finger crossed please...

--- a/chirp/drivers/ft1d.py
+++ b/chirp/drivers/ft1d.py
@@ -1095,7 +1095,7 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
         return self._add_ff_pad(label, 16)
 
     def _encode_charsetbits(self, mem):
-        # We only speak english here in chirpville
+        # We only speak English here in chirpville
         return 0x0000
 
     def _decode_power_level(self, mem):

--- a/chirp/drivers/ft4.py
+++ b/chirp/drivers/ft4.py
@@ -520,7 +520,7 @@ US_LEGAL_STEPS.remove(6.25)       # euro radios just use STEP_CODE
 # is 6 (PAGER). Each row is a tuple. Its first member is a list of
 # [tmode,cross] or [tmode, cross, suppress]. "Suppress" is used only when
 # encoding UI-->radio. When decoding radio-->UI, two of the sql_types each
-# result in 5 possibible UI decodings depending on the tx and rx codes, and the
+# result in 5 possible UI decodings depending on the tx and rx codes, and the
 # list in each of these rows has five members. These two row tuples each have
 # two additional members to specify which of the radio fields to examine.
 # The map from CHIRP UI to radio image types is also built from this table.
@@ -837,7 +837,7 @@ class YaesuSC35GenericRadio(chirp_common.CloneModeRadio,
     # A param is a tuple:
     #  for a simple param: (paramname, paramtitle,[valuename list])
     #  for a handler param: (paramname, paramtitle,( handler,[handler params]))
-    # This is a class variable. subclasses msut create a variable named
+    # This is a class variable. subclasses must create a variable named
     # class_group_descs. The FT-4 classes simply equate this, but the
     # FT-65 classes must copy and modify this.
     group_descriptions = [

--- a/chirp/drivers/ft450d.py
+++ b/chirp/drivers/ft450d.py
@@ -236,7 +236,7 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
                 mym_cw:1,
                 mym_usb:1,
                 mym_lsb:1;
-            u8  myb_24:1,          // My Band: 24Mhz set = OFF
+            u8  myb_24:1,          // My Band: 24MHz set = OFF
                 myb_21:1,
                 myb_18:1,
                 myb_14:1,

--- a/chirp/drivers/ft70.py
+++ b/chirp/drivers/ft70.py
@@ -644,7 +644,7 @@ class FT70Radio(yaesu_clone.YaesuCloneModeRadio):
         return self._add_ff_pad(mem.name.rstrip(), 6)
 
     def _encode_charsetbits(self, mem):
-        # We only speak english here in chirpville
+        # We only speak English here in chirpville
         return [0x00, 0x00]
 
     def _decode_power_level(self, mem):  # 3 High 2 Mid 1 Low

--- a/chirp/drivers/ft817.py
+++ b/chirp/drivers/ft817.py
@@ -59,7 +59,7 @@ class FT817Radio(yaesu_clone.YaesuCloneModeRadio):
     CHARSET.remove("\\")
 
     _memsize = 6509
-    # block 9 (130 Bytes long) is to be repeted 40 times
+    # block 9 (130 Bytes long) is to be repeated 40 times
     _block_lengths = [2, 40, 208, 182, 208, 182, 198, 53, 130, 118, 118]
 
     MEM_FORMAT = """
@@ -623,7 +623,7 @@ class FT817Radio(yaesu_clone.YaesuCloneModeRadio):
         if mem.empty:
             if mem.number == 1:
                 # as Dan says "yaesus are not good about that :("
-                # if you ulpoad an empty image you can brick your radio
+                # if you upload an empty image you can brick your radio
                 raise Exception("Sorry, can't delete first memory")
             if wasvalid and not wasused:
                 self._memobj.filled[(mem.number - 1) // 8] &= \
@@ -1121,7 +1121,7 @@ class FT817NDRadio(FT817Radio):
 
     _model = ""
     _memsize = 6521
-    # block 9 (130 Bytes long) is to be repeted 40 times
+    # block 9 (130 Bytes long) is to be repeated 40 times
     _block_lengths = [2, 40, 208, 182, 208, 182, 198, 53, 130, 118, 130]
 
 
@@ -1136,7 +1136,7 @@ class FT817NDUSRadio(FT817Radio):
     _model = ""
     _US_model = True
     _memsize = 6651
-    # block 9 (130 Bytes long) is to be repeted 40 times
+    # block 9 (130 Bytes long) is to be repeated 40 times
     _block_lengths = [2, 40, 208, 182, 208, 182, 198, 53, 130, 118, 130, 130]
 
     SPECIAL_60M = {

--- a/chirp/drivers/ft857.py
+++ b/chirp/drivers/ft857.py
@@ -58,7 +58,7 @@ class FT857Radio(ft817.FT817Radio):
                                     list(CROSS_MODES.keys()))))
 
     _memsize = 7341
-    # block 9 (140 Bytes long) is to be repeted 40 times
+    # block 9 (140 Bytes long) is to be repeated 40 times
     # should be 42 times but this way I can use original 817 functions
     _block_lengths = [2, 82, 252, 196, 252, 196, 212, 55, 140, 140, 140,
                       38, 176]
@@ -1116,7 +1116,7 @@ class FT857USRadio(FT857Radio):
     _model = ""
     _US_model = True
     _memsize = 7481
-    # block 9 (140 Bytes long) is to be repeted 40 times
+    # block 9 (140 Bytes long) is to be repeated 40 times
     # should be 42 times but this way I can use original 817 functions
     _block_lengths = [2, 82, 252, 196, 252, 196, 212, 55, 140, 140, 140, 38,
                       176, 140]

--- a/chirp/drivers/ft90.py
+++ b/chirp/drivers/ft90.py
@@ -417,7 +417,7 @@ struct  {
         mem.skip = _mem.skip and "S" or ""
         if not all(char in chirp_common.CHARSET_ASCII
                    for char in str(_mem.name)):
-            # dont display blank/junk name
+            # don't display blank/junk name
             mem.name = ""
         else:
             mem.name = str(_mem.name).rstrip()

--- a/chirp/drivers/ftlx011.py
+++ b/chirp/drivers/ftlx011.py
@@ -388,7 +388,7 @@ class ftlx011(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
         return repr(self._memobj.memory[number])
 
     def _decode_tone(self, mem, rx=True):
-        """Parse the tone data to decode from mem tones are encodded like this
+        """Parse the tone data to decode from mem tones are encoded like this
         CTCS: mapped [0x80...0xa5] = [67.0...250.3]
         DTCS: mixed  [0x88, 0x23] last is BCD and first is the 100 power - 88
 

--- a/chirp/drivers/ftm350.py
+++ b/chirp/drivers/ftm350.py
@@ -85,7 +85,7 @@ _TMODES = ["", "Tone", "TSQL", "-RVT", "DTCS", "-PR", "-PAG"]
 TMODES = ["", "Tone", "TSQL", "", "DTCS", "", ""]
 MODES = ["FM", "AM", "NFM", "", "WFM"]
 DUPLEXES = ["", "", "-", "+", "split"]
-# TODO: add japanese characters (viewable in special menu, scroll backwards)
+# TODO: add Japanese characters (viewable in special menu, scroll backwards)
 CHARSET = \
     ('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz!"' +
      '#$%&`()*+,-./:;<=>?@[\\]^_`{|}~?????? ' + '?' * 91)

--- a/chirp/drivers/ic2300.py
+++ b/chirp/drivers/ic2300.py
@@ -40,7 +40,7 @@ from chirp.settings import RadioSetting, RadioSettingGroup, \
 #        +------------| GND              |
 #                     `------------------'
 #
-# D1: 1N4148 shottky diode
+# D1: 1N4148 Schottky diode
 # R1: 10K ohm resistor
 
 MEM_FORMAT = """

--- a/chirp/drivers/ic2730.py
+++ b/chirp/drivers/ic2730.py
@@ -866,7 +866,7 @@ class IC2730Radio(icf.IcomCloneModeRadio):
         other.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_sets.toneburst))
-        rset = RadioSetting("settings.toneburst", "1750 Htz Tone Burst", rx)
+        rset = RadioSetting("settings.toneburst", "1750 Hz Tone Burst", rx)
         other.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_sets.ifxchg))

--- a/chirp/drivers/iradio_uv_5118plus.py
+++ b/chirp/drivers/iradio_uv_5118plus.py
@@ -323,7 +323,7 @@ def do_upload(radio):
     status.cur = 0
     status.max = radio._memsize
 
-    # The OEM software reads the 1st block from the radio before comencing
+    # The OEM software reads the 1st block from the radio before commencing
     # with the upload. That behavior will be mirrored here.
     _read_block(radio, radio.START_ADDR, radio.BLOCK_SIZE)
 

--- a/chirp/drivers/kenwood_live.py
+++ b/chirp/drivers/kenwood_live.py
@@ -126,10 +126,10 @@ def get_id(ser):
                 resp = command(ser, "ID")
             except UnicodeDecodeError:
                 # If we got binary here, we are using the wrong rate
-                # or not talking to a kenwood live radio.
+                # or not talking to a Kenwood live radio.
                 continue
 
-            # most kenwood radios
+            # most Kenwood radios
             if " " in resp:
                 LAST_BAUD = i
                 return resp.split(" ")[1]
@@ -169,7 +169,7 @@ def iserr(result):
 
 
 class KenwoodLiveRadio(chirp_common.LiveRadio):
-    """Base class for all live-mode kenwood radios"""
+    """Base class for all live-mode Kenwood radios"""
     BAUD_RATE = 9600
     VENDOR = "Kenwood"
     MODEL = ""

--- a/chirp/drivers/kg935g.py
+++ b/chirp/drivers/kg935g.py
@@ -1136,7 +1136,7 @@ class KG935GRadio(chirp_common.CloneModeRadio,
     # It would be smarter to only load the active areas and none of
     # the padding/unused areas. Padding still need to be investigated.
     def _download(self):
-        """Talk to a wouxun KG-935G and do a download"""
+        """Talk to a Wouxun KG-935G and do a download"""
         try:
             self._identify()
             return self._do_download(0, 32768, 64)
@@ -1168,7 +1168,7 @@ class KG935GRadio(chirp_common.CloneModeRadio,
         return memmap.MemoryMapBytes(image)
 
     def _upload(self):
-        """Talk to a wouxun KG-935G and do a upload"""
+        """Talk to a Wouxun KG-935G and do a upload"""
         try:
             self._identify()
             self._do_upload()
@@ -2006,7 +2006,7 @@ class KG935GRadio(chirp_common.CloneModeRadio,
         # FM RADIO PRESETS
 
         # memory stores raw integer value like 760
-        # radio will divide 760 by 10 and interpret correctly at 76.0Mhz
+        # radio will divide 760 by 10 and interpret correctly at 76.0MHz
         for i in range(1, 21):
             chan = str(i)
             rs = RadioSetting("FM_radio" + chan, "FM Preset" + chan,

--- a/chirp/drivers/kguv8d.py
+++ b/chirp/drivers/kguv8d.py
@@ -382,11 +382,11 @@ class KGUV8DRadio(chirp_common.CloneModeRadio,
     def sync_out(self):
         self._upload()
 
-    # TODO: This is a dumb, brute force method of downlolading the memory.
+    # TODO: This is a dumb, brute force method of downloading the memory.
     # it would be smarter to only load the active areas and none of
     # the padding/unused areas.
     def _download(self):
-        """Talk to a wouxun KG-UV8D and do a download"""
+        """Talk to a Wouxun KG-UV8D and do a download"""
         try:
             self._identify()
             return self._do_download(0, 32768, 64)
@@ -419,7 +419,7 @@ class KGUV8DRadio(chirp_common.CloneModeRadio,
         return memmap.MemoryMapBytes(image)
 
     def _upload(self):
-        """Talk to a wouxun KG-UV8D and do a upload"""
+        """Talk to a Wouxun KG-UV8D and do a upload"""
         try:
             self._identify()
             self._do_upload(0, 32768, 64)

--- a/chirp/drivers/kguv8dplus.py
+++ b/chirp/drivers/kguv8dplus.py
@@ -421,7 +421,7 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
     # It would be smarter to only load the active areas and none of
     # the padding/unused areas. Padding still need to be investigated.
     def _download(self):
-        """Talk to a wouxun KG-UV8D Plus and do a download"""
+        """Talk to a Wouxun KG-UV8D Plus and do a download"""
         try:
             self._identify()
             return self._do_download(0, 32768, 64)
@@ -453,7 +453,7 @@ class KGUV8DPlusRadio(chirp_common.CloneModeRadio,
         return memmap.MemoryMapBytes(image)
 
     def _upload(self):
-        """Talk to a wouxun KG-UV8D Plus and do a upload"""
+        """Talk to a Wouxun KG-UV8D Plus and do a upload"""
         try:
             self._identify()
             self._do_upload(0, 32768, 64)

--- a/chirp/drivers/kguv8e.py
+++ b/chirp/drivers/kguv8e.py
@@ -421,7 +421,7 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
     # It would be smarter to only load the active areas and none of
     # the padding/unused areas. Padding still need to be investigated.
     def _download(self):
-        """Talk to a wouxun KG-UV8E and do a download"""
+        """Talk to a Wouxun KG-UV8E and do a download"""
         try:
             self._identify()
             return self._do_download(0, 32768, 64)
@@ -453,7 +453,7 @@ class KGUV8ERadio(chirp_common.CloneModeRadio,
         return memmap.MemoryMapBytes(image)
 
     def _upload(self):
-        """Talk to a wouxun KG-UV8E and do a upload"""
+        """Talk to a Wouxun KG-UV8E and do a upload"""
         try:
             self._identify()
             self._do_upload(0, 32768, 64)

--- a/chirp/drivers/kguv920pa.py
+++ b/chirp/drivers/kguv920pa.py
@@ -601,11 +601,11 @@ class KGUV920PARadio(chirp_common.CloneModeRadio,
     def sync_out(self):
         self._upload()
 
-    # TODO: This is a dumb, brute force method of downlolading the memory.
+    # TODO: This is a dumb, brute force method of downloading the memory.
     # it would be smarter to only load the active areas and none of
     # the padding/unused areas.
     def _download(self):
-        """Talk to a wouxun KG-UV920P-A and do a download"""
+        """Talk to a Wouxun KG-UV920P-A and do a download"""
         try:
             self._identify()
             return self._do_download(0, 0x6640, 0x40)
@@ -637,7 +637,7 @@ class KGUV920PARadio(chirp_common.CloneModeRadio,
         return memmap.MemoryMapBytes(image)
 
     def _upload(self):
-        """Talk to a wouxun KG-UV920P-A and do a upload"""
+        """Talk to a Wouxun KG-UV920P-A and do a upload"""
         try:
             self._identify()
             self._do_upload(0x0000, 0x6640, 0x40)

--- a/chirp/drivers/kguv980p.py
+++ b/chirp/drivers/kguv980p.py
@@ -826,7 +826,7 @@ class KG980PRadio(chirp_common.CloneModeRadio,
     # It would be smarter to only load the active areas and none of
     # the padding/unused areas. Padding still need to be investigated.
     def _download(self):
-        """Talk to a wouxun KG-UV980P and do a download"""
+        """Talk to a Wouxun KG-UV980P and do a download"""
         try:
             self._identify()
             return self._do_download(0, 32768, 64)
@@ -859,7 +859,7 @@ class KG980PRadio(chirp_common.CloneModeRadio,
         return memmap.MemoryMapBytes(image)
 
     def _upload(self):
-        """Talk to a wouxun KG-UV980P and do a upload"""
+        """Talk to a Wouxun KG-UV980P and do a upload"""
         try:
             self._identify()
             LOG.debug("Done with Upload Identify")
@@ -2472,17 +2472,17 @@ class KG980PRadio(chirp_common.CloneModeRadio,
         # FM RADIO PRESETS
 
         # memory stores raw integer value like 7600
-        # radio will divide 7600 by 100 and interpret correctly at 76.0Mhz
+        # radio will divide 7600 by 100 and interpret correctly at 76.0MHz
 
         for i in range(1, 21):
             # chan = str(i)
             fmname = "FM_radio%i" % i
             fmlabel = "FM Preset %i" % i
             fmvalue = getattr(_settings, fmname)
-            # some CPS versions store values with .01 Mhz in error
-            # eg 99.5 Mhz is stored as 0x26df = 9951 dec = 99.51 Mhz
+            # some CPS versions store values with .01 MHz in error
+            # eg 99.5 MHz is stored as 0x26df = 9951 dec = 99.51 MHz
             # even though the radio properly displays 99.5
-            # this will drop the 0.01 Mhz for Chirp Displayed values
+            # this will drop the 0.01 MHz for Chirp Displayed values
             fmvalue = fmvalue // 10 / 10
             rs = RadioSetting(fmname, fmlabel,
                               RadioSettingValueFloat(76.0, 108.0,

--- a/chirp/drivers/kguv9dplus.py
+++ b/chirp/drivers/kguv9dplus.py
@@ -1,5 +1,5 @@
 # Copyright 2022 Mel Terechenok <melvin.terechenok@gmail.com>
-# Updated Driver to support Wouxon KG-UV9PX
+# Updated Driver to support Wouxun KG-UV9PX
 # based on prior driver for KG-UV9D Plus by
 # Jim Lieb <lieb@sea-troll.net>
 #

--- a/chirp/drivers/lt725uv.py
+++ b/chirp/drivers/lt725uv.py
@@ -1027,7 +1027,7 @@ class LT725UV(chirp_common.CloneModeRadio):
         basic.append(rs)
 
         tmp = str(int(_sets.sig_freq))
-        rs = RadioSetting("settings.sig_freq", "Single Signaling Tone (Htz)",
+        rs = RadioSetting("settings.sig_freq", "Single Signaling Tone (Hz)",
                           RadioSettingValueList(LIST_SSF, tmp))
         rs.set_apply_callback(my_val_list, _sets, "sig_freq")
         basic.append(rs)
@@ -1067,7 +1067,7 @@ class LT725UV(chirp_common.CloneModeRadio):
         a_band.append(rs)
 
         tmp = my_tone_strn(_vfoa, "is_rxdigtone", "rxdtcs_pol", "rx_tone")
-        rs = RadioSetting("rx_tone", "Default Recv CTCSS (Htz)",
+        rs = RadioSetting("rx_tone", "Default Recv CTCSS (Hz)",
                           RadioSettingValueList(LIST_CTCSS, tmp))
         rs.set_apply_callback(my_set_tone, _vfoa, "is_rxdigtone",
                               "rxdtcs_pol", "rx_tone")
@@ -1079,7 +1079,7 @@ class LT725UV(chirp_common.CloneModeRadio):
         a_band.append(rs)
 
         tmp = my_tone_strn(_vfoa, "is_txdigtone", "txdtcs_pol", "tx_tone")
-        rs = RadioSetting("tx_tone", "Default Xmit CTCSS (Htz)",
+        rs = RadioSetting("tx_tone", "Default Xmit CTCSS (Hz)",
                           RadioSettingValueList(LIST_CTCSS, tmp))
         rs.set_apply_callback(my_set_tone, _vfoa, "is_txdigtone",
                               "txdtcs_pol", "tx_tone")
@@ -1178,7 +1178,7 @@ class LT725UV(chirp_common.CloneModeRadio):
         b_band.append(rs)
 
         tmp = my_tone_strn(_vfob, "is_rxdigtone", "rxdtcs_pol", "rx_tone")
-        rs = RadioSetting("rx_tone", "Default Recv CTCSS (Htz)",
+        rs = RadioSetting("rx_tone", "Default Recv CTCSS (Hz)",
                           RadioSettingValueList(LIST_CTCSS, tmp))
         rs.set_apply_callback(my_set_tone, _vfob, "is_rxdigtone",
                               "rxdtcs_pol", "rx_tone")
@@ -1189,7 +1189,7 @@ class LT725UV(chirp_common.CloneModeRadio):
         b_band.append(rs)
 
         tmp = my_tone_strn(_vfob, "is_txdigtone", "txdtcs_pol", "tx_tone")
-        rs = RadioSetting("tx_tone", "Default Xmit CTCSS (Htz)",
+        rs = RadioSetting("tx_tone", "Default Xmit CTCSS (Hz)",
                           RadioSettingValueList(LIST_CTCSS, tmp))
         rs.set_apply_callback(my_set_tone, _vfob, "is_txdigtone",
                               "txdtcs_pol", "tx_tone")

--- a/chirp/drivers/puxing_px888k.py
+++ b/chirp/drivers/puxing_px888k.py
@@ -816,7 +816,7 @@ def encode_5tone(data, fieldlen):
 
 
 def decode_freq(data):
-    """decode frequency data for the broadcast fm radio memories"""
+    """decode frequency data for the broadcast FM radio memories"""
     data_out = ''
     if data[0] != 0xff:
         data_out = chirp_common.format_freq(
@@ -825,7 +825,7 @@ def decode_freq(data):
 
 
 def encode_freq(data, fieldlen):
-    """encode frequency data for the broadcast fm radio memories"""
+    """encode frequency data for the broadcast FM radio memories"""
     data_out = bytearray(b'\xff')*fieldlen
     if data != '':
         data_out = encode_halfbytes((('%%0%di' % (fieldlen << 1)) %
@@ -1826,7 +1826,7 @@ class Puxing_PX888K_Radio(chirp_common.CloneModeRadio):
                          NO_YES),
             ]
 
-        # broadcast fm radio settings
+        # broadcast FM radio settings
         broadcast_settings = [
             list_setting("band", "Frequency interval",
                          _broadcast.receive_range,

--- a/chirp/drivers/retevis_rt98.py
+++ b/chirp/drivers/retevis_rt98.py
@@ -30,8 +30,8 @@ from chirp.settings import RadioSettingGroup, RadioSetting, RadioSettings, \
 LOG = logging.getLogger(__name__)
 
 #
-#  Chirp Driver for Retevis RT98 models: RT98V (136-174 Mhz)
-#                                        RT98U (400-490 Mhz)
+#  Chirp Driver for Retevis RT98 models: RT98V (136-174 MHz)
+#                                        RT98U (400-490 MHz)
 #
 #
 #

--- a/chirp/drivers/th9000.py
+++ b/chirp/drivers/th9000.py
@@ -30,8 +30,8 @@ from chirp.settings import RadioSettingGroup, RadioSetting, RadioSettings, \
 LOG = logging.getLogger(__name__)
 
 #
-#  Chirp Driver for TYT TH-9000D (models: 2M (144 Mhz), 1.25M (220 Mhz)
-#                                 and 70cm (440 Mhz)  radios)
+#  Chirp Driver for TYT TH-9000D (models: 2M (144 MHz), 1.25M (220 MHz)
+#                                 and 70cm (440 MHz)  radios)
 #
 #  Version 1.0
 #
@@ -144,7 +144,7 @@ struct {
 """
 #  TH9000  memory map
 #  section: 5  TX/RX Range
-#     used to set the TX/RX range of the radio (e.g.  222-228Mhz for 220 meter)
+#     used to set the TX/RX range of the radio (e.g.  222-228MHz for 220 meter)
 #     possible to set range for tx/rx
 #
 MEM_FORMAT = MEM_FORMAT + """

--- a/chirp/drivers/th_uv8000.py
+++ b/chirp/drivers/th_uv8000.py
@@ -1390,7 +1390,7 @@ class THUV8000Radio(chirp_common.CloneModeRadio):
         mod_se = True     # UV8000SE has 3rd freq bank
         if mod_se:
             rx = RadioSettingValueBoolean(bool(_sets.frqr3))
-            rset = RadioSetting("setstuf.frqr3", "Freq Range 3 (220Mhz)", rx)
+            rset = RadioSetting("setstuf.frqr3", "Freq Range 3 (220MHz)", rx)
             rset.set_doc("Enable the 220MHz frequency bank.")
             frng.append(rset)
 

--- a/chirp/drivers/thd74.py
+++ b/chirp/drivers/thd74.py
@@ -375,7 +375,7 @@ class THD74Radio(chirp_common.CloneModeRadio):
         return rf
 
     def _get_raw_memory(self, number):
-        # Why kenwood ... WHY?
+        # Why Kenwood ... WHY?
         return self._memobj.memgroups[number // 6].memories[number % 6]
 
     def get_memory(self, number):

--- a/chirp/drivers/tk270.py
+++ b/chirp/drivers/tk270.py
@@ -407,7 +407,7 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         to the correct variant of the radio"""
         rid = get_radio_id(self._mmap)
 
-        # identify the radio variant and set the environment to it's values
+        # identify the radio variant and set the environment to its values
         try:
             self._upper, low, high, self._kind = self.VARIANTS[rid]
 
@@ -485,7 +485,7 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         actual = self.get_active(chan)
         if actual != bool(value):
             # DEBUG
-            # print "VALUE %s fliping" % int(not value)
+            # print "VALUE %s flipping" % int(not value)
 
             # I have to flip the value
             rbyte = self._memobj.active[byte]

--- a/chirp/drivers/tk760.py
+++ b/chirp/drivers/tk760.py
@@ -418,7 +418,7 @@ class Kenwood_M60_Radio(chirp_common.CloneModeRadio,
         to the correct variant of the radio"""
         rid = get_rid(self._mmap)
 
-        # identify the radio variant and set the environment to it's values
+        # identify the radio variant and set the environment to its values
         try:
             self._upper, low, high, self._kind = self.VARIANTS[rid]
 
@@ -560,7 +560,7 @@ class Kenwood_M60_Radio(chirp_common.CloneModeRadio,
 
         if _mem.get_raw()[0] == "\xFF" or not self.get_active(number - 1):
             mem.empty = True
-            # but is not enough, you have to crear the memory in the mmap
+            # but is not enough, you have to clear the memory in the mmap
             # to get it ready for the sync_out process
             _mem.set_raw("\xFF" * 8)
             return mem

--- a/chirp/drivers/tk760g.py
+++ b/chirp/drivers/tk760g.py
@@ -273,7 +273,7 @@ ACK_CMD = b"\x06"
 POWER_LEVELS = [chirp_common.PowerLevel("Low", watts=1),
                 chirp_common.PowerLevel("High", watts=5)]
 
-MODES = ["NFM", "FM"]  # 12.5 / 25 Khz
+MODES = ["NFM", "FM"]  # 12.5 / 25 KHz
 VALID_CHARS = chirp_common.CHARSET_UPPER_NUMERIC + "_-*()/\-+=)"
 SKIP_VALUES = ["", "S"]
 
@@ -559,7 +559,7 @@ def do_upload(radio):
         data = radio.get_mmap()[raddr:raddr+BLOCK_SIZE]
 
         # The blocks from x59-x5F are NOT programmable
-        # The blocks from x11-x1F are writed only if not empty
+        # The blocks from x11-x1F are written only if not empty
         if addr in RO_BLOCKS:
             # checking if in the range of optional blocks
             if addr >= 0x10 and addr <= 0x1F:
@@ -611,7 +611,7 @@ def model_match(cls, data):
 
 
 class Kenwood60GBankModel(chirp_common.BankModel):
-    """Testing the bank model on kennwood"""
+    """Testing the bank model on Kenwood"""
     channelAlwaysHasBank = True
 
     def get_num_mappings(self):
@@ -635,7 +635,7 @@ class Kenwood60GBankModel(chirp_common.BankModel):
                             (memory.number, bank))
 
         # We can't "Remove" it for good
-        # the kenwood paradigm don't allow it
+        # the Kenwood paradigm doesn't allow it
         # instead we move it to bank 0
         self._radio._set_bank(memory.number, 0)
 
@@ -652,7 +652,7 @@ class Kenwood60GBankModel(chirp_common.BankModel):
 
 
 class memBank(chirp_common.Bank):
-    """A bank model for kenwood"""
+    """A bank model for Kenwood"""
     # Integral index of the bank (not to be confused with per-memory
     # bank indexes
     index = 0
@@ -814,7 +814,7 @@ class Kenwood_Serie_60G(chirp_common.CloneModeRadio,
         to the correct variant of the radio"""
         rid = self._mmap[0xA7:0xAE]
 
-        # identify the radio variant and set the environment to it's values
+        # identify the radio variant and set the environment to its values
         try:
             self._upper, low, high, self._kind = self.VARIANTS[rid]
 
@@ -825,7 +825,7 @@ class Kenwood_Serie_60G(chirp_common.CloneModeRadio,
             self._range = [int(low * 1000000 * 0.96),
                            int(high * 1000000 * 1.04)]
 
-            # setting the bank data in the features, 8 & 16 CH dont have banks
+            # setting the bank data in the features, 8 & 16 CH don't have banks
             if self._upper < 32:
                 rf = chirp_common.RadioFeatures()
                 rf.has_bank = False

--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -455,7 +455,7 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
         group = RadioSettings(basic, disp, aud, aux, txrx, memz, pvfo, pfk,
                               bmsk, rptr, dtmf, skyk, pmm)
 
-        mhz1 = 1000000.   # Raw freq is stored with 0.1 Htz resolution
+        mhz1 = 1000000.   # Raw freq is stored with 0.1 Hz resolution
 
         def _adjraw(setting, obj, atrb, fix=0, ndx=-1):
             """Callback for Integer add or subtract fix from value."""
@@ -470,7 +470,7 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
             return
 
         def _mhz_val(setting, obj, atrb, ndx=-1, ndy=-1):
-            """ Callback to set freq back to Htz """
+            """ Callback to set freq back to Hz """
             vx = float(str(setting.value))
             vx = int(vx * mhz1)
             if ndx < 0:
@@ -765,7 +765,7 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
         aux.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_blk1.m10mz))
-        sx = "10 Mhz mode"
+        sx = "10 MHz mode"
         rset = RadioSetting("block1.m10mz", sx, rx)
         aux.append(rset)
 
@@ -961,7 +961,7 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
 
         # ===== Prog VFO Group =============
         for mx in range(0, 10):
-            # Raw freq is 0.1 Mhz resolution
+            # Raw freq is 0.1 MHz resolution
             vfx = int(_pmg[0].progvfo[mx].blow) / mhz1
             if vfx == 0:
                 vfx = 118
@@ -1028,52 +1028,52 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
 
         # ===== BMSK GROUP =====
         rx = RadioSettingValueBoolean(bool(_pmg[0].abnd118))
-        sx = "A/Left: 118Mhz Band"
+        sx = "A/Left: 118MHz Band"
         rset = RadioSetting("pmg/0.abnd118", sx, rx)
         bmsk.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_pmg[0].abnd144))
-        sx = "A/Left: 144Mhz Band"
+        sx = "A/Left: 144MHz Band"
         rset = RadioSetting("pmg/0.abnd144", sx, rx)
         bmsk.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_pmg[0].abnd220))
-        sx = "A/Left: 220Mhz Band"
+        sx = "A/Left: 220MHz Band"
         rset = RadioSetting("pmg/0.abnd220", sx, rx)
         bmsk.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_pmg[0].abnd300))
-        sx = "A/Left: 300Mhz Band"
+        sx = "A/Left: 300MHz Band"
         rset = RadioSetting("pmg/0.abnd300", sx, rx)
         bmsk.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_pmg[0].abnd430))
-        sx = "A/Left: 430Mhz Band"
+        sx = "A/Left: 430MHz Band"
         rset = RadioSetting("pmg/0.abnd430", sx, rx)
         bmsk.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_pmg[0].bbnd144))
-        sx = "B/Right: 144Mhz Band"
+        sx = "B/Right: 144MHz Band"
         rset = RadioSetting("pmg/0.bbnd144", sx, rx)
         bmsk.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_pmg[0].bbnd220))
-        sx = "B/Right: 220Mhz Band"
+        sx = "B/Right: 220MHz Band"
         rset = RadioSetting("pmg/0.bbnd220", sx, rx)
         bmsk.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_pmg[0].bbnd300))
-        sx = "B/Right: 300Mhz Band"
+        sx = "B/Right: 300MHz Band"
         rset = RadioSetting("pmg/0.bbnd300", sx, rx)
         bmsk.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_pmg[0].bbnd430))
-        sx = "B/Right: 430Mhz Band"
+        sx = "B/Right: 430MHz Band"
         rset = RadioSetting("pmg/0.bbnd430", sx, rx)
         bmsk.append(rset)
 
         rx = RadioSettingValueBoolean(bool(_pmg[0].bbnd800))
-        sx = "B/Right: 800Mhz Band"
+        sx = "B/Right: 800MHz Band"
         rset = RadioSetting("pmg/0.bbnd800", sx, rx)
         bmsk.append(rset)
 

--- a/chirp/drivers/ts480.py
+++ b/chirp/drivers/ts480.py
@@ -767,7 +767,7 @@ class TS480_CRadio(chirp_common.CloneModeRadio):
             return
 
         def my_mhz_val(setting, obj, atrb, ndx=-1):
-            """ Callback to set freq back to Htz"""
+            """ Callback to set freq back to Hz """
             vx = float(str(setting.value))
             vx = int(vx * mhz1)
             if ndx < 0:

--- a/chirp/drivers/ts590.py
+++ b/chirp/drivers/ts590.py
@@ -969,7 +969,7 @@ class TS590Radio(chirp_common.CloneModeRadio):
             return
 
         def my_mhz_val(setting, obj, atrb, ndx=-1):
-            """ Callback to set freq back to Htz"""
+            """ Callback to set freq back to Hz """
             vx = float(str(setting.value))
             vx = int(vx * mhz1)
             if ndx < 0:
@@ -1652,7 +1652,7 @@ class TS590SRadio(TS590Radio):
     ID = "ID021;"
     SG = False
     # This is the equivalent Menu A/B list for the TS-590S
-    # The equivalnt S param is stored in the SG Mem_Format slot
+    # The equivalent S param is stored in the SG Mem_Format slot
     EX = ["EX087", "EX000", "EX001", "EX003", "EX004", "EX005",
           "EX006", "EX007", "EX008", "EX009", "EX010", "EX011", "EX014",
           "EX014", "EX015", "EX016", "EX017", "EX018", "EX019", "EX020",

--- a/chirp/drivers/uvb5.py
+++ b/chirp/drivers/uvb5.py
@@ -704,7 +704,7 @@ class BaofengUVB5(chirp_common.CloneModeRadio,
         for power in range(0, 2):
             for index in range(0, 8):
                 key = "test.vhf%s%i" % (powerkeydata[power], index)
-                name = "%s Mhz %s Power" % (vhfdata[index],
+                name = "%s MHz %s Power" % (vhfdata[index],
                                             powernamedata[power])
                 rs = RadioSetting(
                         key, name, RadioSettingValueInteger(
@@ -716,7 +716,7 @@ class BaofengUVB5(chirp_common.CloneModeRadio,
         for power in range(0, 2):
             for index in range(0, 8):
                 key = "test.uhf%s%i" % (powerkeydata[power], index)
-                name = "%s Mhz %s Power" % (uhfdata[index],
+                name = "%s MHz %s Power" % (uhfdata[index],
                                             powernamedata[power])
                 rs = RadioSetting(
                         key, name, RadioSettingValueInteger(

--- a/chirp/drivers/vx8.py
+++ b/chirp/drivers/vx8.py
@@ -721,7 +721,7 @@ class VX8Radio(yaesu_clone.YaesuCloneModeRadio):
 
         label = "".join([chr(CHARSET.index(x)) for x in mem.name.rstrip()])
         _mem.label = self._add_ff_pad(label, 16)
-        # We only speak english here in chirpville
+        # We only speak English here in chirpville
         _mem.charsetbits[0] = 0x00
         _mem.charsetbits[1] = 0x00
 

--- a/chirp/drivers/wouxun.py
+++ b/chirp/drivers/wouxun.py
@@ -30,7 +30,7 @@ FREQ_ENCODE_TABLE = [0x7, 0xa, 0x0, 0x9, 0xb, 0x2, 0xe, 0x1, 0x3, 0xf]
 
 
 def encode_freq(freq):
-    """Convert frequency (4 decimal digits) to wouxun format (2 bytes)"""
+    """Convert frequency (4 decimal digits) to Wouxun format (2 bytes)"""
     enc = 0
     div = 1000
     for i in range(0, 4):
@@ -41,7 +41,7 @@ def encode_freq(freq):
 
 
 def decode_freq(data):
-    """Convert from wouxun format (2 bytes) to frequency (4 decimal digits)"""
+    """Convert from Wouxun format (2 bytes) to frequency (4 decimal digits)"""
     freq = 0
     shift = 12
     for i in range(0, 4):
@@ -240,7 +240,7 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
                 i += 1
 
     def _identify(self):
-        """Do the original wouxun identification dance"""
+        """Do the original Wouxun identification dance"""
         query = self._get_querymodel()
         for _i in range(0, 10):
             self.pipe.write(next(query))
@@ -268,7 +268,7 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
             raise Exception("Radio refused transfer mode")
 
     def _download(self):
-        """Talk to an original wouxun and do a download"""
+        """Talk to an original Wouxun and do a download"""
         try:
             self._identify()
             self._start_transfer()
@@ -279,7 +279,7 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
             raise errors.RadioError("Failed to communicate with radio: %s" % e)
 
     def _upload(self):
-        """Talk to an original wouxun and do an upload"""
+        """Talk to an original Wouxun and do an upload"""
         try:
             self._identify()
             self._start_transfer()
@@ -299,7 +299,7 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
     def process_mmap(self):
         if len(self._mmap.get_packed()) != 8192:
             LOG.info("Fixing old-style Wouxun image")
-            # Originally, CHIRP's wouxun image had eight bytes of
+            # Originally, CHIRP's Wouxun image had eight bytes of
             # static data, followed by the first memory at offset
             # 0x0008.  Between 0.1.11 and 0.1.12, this was fixed to 16
             # bytes of (whatever) followed by the first memory at

--- a/chirp/drivers/wouxun_common.py
+++ b/chirp/drivers/wouxun_common.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""vcommon function for wouxun (or similar) radios"""
+"""vcommon function for Wouxun (or similar) radios"""
 
 import struct
 import logging

--- a/chirp/import_logic.py
+++ b/chirp/import_logic.py
@@ -114,7 +114,7 @@ def _import_power(dst_radio, _srcrf, mem):
     # If both radios support discrete power levels, we need to decide how to
     # convert the source power level to a valid one for the destination
     # radio.  To do that, find the absolute level of the source value
-    # and calculate the different between it and all the levels of the
+    # and calculate the difference between it and all the levels of the
     # destination, choosing the one that matches most closely. Do this in
     # watts not dBm because we will make the wrong decision otherwise due
     # to the logarithmic scale.


### PR DESCRIPTION
This PR fixes the spelling of strings shown in the settings (mainly s/Mhz/MHz/ and s/Htz/Hz/), in other strings and in comments.