### PR TITLE
Constrain port box width

### DIFF
--- a/chirp/wxui/clone.py
+++ b/chirp/wxui/clone.py
@@ -234,6 +234,7 @@ class ChirpCloneDialog(wx.Dialog):
                      flag=wx.EXPAND | wx.RIGHT | wx.LEFT)
 
         self._port = wx.Choice(self, choices=[])
+        self._port.SetMaxSize((50, -1))
         self.set_ports()
         self.Bind(wx.EVT_CHOICE, self._selected_port, self._port)
         _add_grid(_('Port'), self._port)


### PR DESCRIPTION
Avoid letting the port dialog grow to insane widths due to
ridiculous system port names (I'm glaring at you Prolific).

Fixes #10675
