### PR TITLE
Update window title after save-as

### DIFF
--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1245,6 +1245,7 @@ class ChirpMain(wx.Frame):
             eset.save(filename)
             self.adj_menu_open_recent(filename)
             self._update_editorset_title(eset)
+            self._update_window_for_editor()
             return True
 
     def _menu_save(self, event):


### PR DESCRIPTION
When multiple window support was added, we had to show the file of
the currently-selected tab in the title bar so you can tell the windows
apart in the task list. This needs to be updated after a save-as
operation so it doesn't remain incorrect.

Related to #10634
