### PR TITLE
Retevis RB27: support full band TX/RX - fixes #10686

### DIFF
--- a/chirp/drivers/bf_t8.py
+++ b/chirp/drivers/bf_t8.py
@@ -875,7 +875,7 @@ class RetevisRB27B(BFT8Radio):
 class RetevisRB27(RetevisRB27B):
     VENDOR = "Retevis"
     MODEL = "RB27"
-    DUPLEXES = ["", "+", "off"]
+    DUPLEXES = ['', '-', '+', 'off']
     POWER_LEVELS = [chirp_common.PowerLevel("High", watts=5.00),
                     chirp_common.PowerLevel("Low", watts=0.50)]
     VALID_BANDS = [(136000000, 174000000),
@@ -883,29 +883,8 @@ class RetevisRB27(RetevisRB27B):
     ODD_SPLIT = False
 
     _upper = 99
-    _gmrs = True
+    _gmrs = False  # sold as GMRS radio but supports full band TX/RX
     _frs = _murs = _pmr = False
-
-    def validate_memory(self, mem):
-        msgs = super().validate_memory(mem)
-
-        _msg_duplex = 'Duplex must be "off" for this frequency'
-        _msg_offset = 'Only simplex or +5MHz offset allowed on GMRS'
-
-        if mem.freq not in GMRS_FREQS:
-            if mem.duplex != "off":
-                msgs.append(chirp_common.ValidationWarning(_msg_duplex))
-        if mem.freq in FRS_FREQS3:
-            if mem.duplex and mem.offset != 5000000:
-                msgs.append(chirp_common.ValidationWarning(_msg_offset))
-            if mem.duplex and mem.duplex != "+":
-                msgs.append(chirp_common.ValidationWarning(_msg_offset))
-
-        return msgs
-
-    def check_set_memory_immutable_policy(self, existing, new):
-        existing.immutable = []
-        super().check_set_memory_immutable_policy(existing, new)
 
 
 @directory.register

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -751,8 +751,7 @@ class TestOverrideRules(base.BaseTest):
         'Radioddity_DB25-G',
         'Retevis_RA85',
         'Retevis_RA685',
-        'Retevis_RB17P',
-        'Retevis_RB27',
+        'Retevis_RB17P'
     ]
 
     def _test_radio_override_immutable_policy(self, rclass):


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
