### PR TITLE
Add warnings and volatile flag to settings

### DIFF
--- a/chirp/drivers/uvk5.py
+++ b/chirp/drivers/uvk5.py
@@ -1862,6 +1862,12 @@ class UVK5Radio(chirp_common.CloneModeRadio):
         val = RadioSettingValueBoolean(self._expanded_limits)
         rs = RadioSetting("nolimits", "Limits disabled for modified firmware",
                           val)
+        rs.set_warning(_(
+            'This should only be enabled if you are using modified firmware '
+            'that supports wider frequency coverage. Enabling this will cause '
+            'CHIRP not to enforce OEM restrictions and may lead to undefined '
+            'or unregulated behavior. Use at your own risk!'),
+            safe_value=False)
         roinfo.append(rs)
 
         return top

--- a/chirp/locale/de.po
+++ b/chirp/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2012-10-02 22:11+0100\n"
 "Last-Translator: Benjamin, HB9EUK <hb9euk@hb9d.org>\n"
 "Language-Team: German\n"
@@ -648,7 +648,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Ein Fehler ist aufgetreten"
 
@@ -686,6 +686,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -943,7 +949,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "Lösche Speicher {loc}"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 #, fuzzy
 msgid "Error applying settings"
 msgstr "Fehler beim Setzen der Speicher"
@@ -1199,7 +1205,7 @@ msgstr "Frequenz"
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr ""
 
@@ -1551,7 +1557,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1664,6 +1670,10 @@ msgstr ""
 
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
+msgstr ""
+
+#: ../wxui/common.py:422
+msgid "Refresh required"
 msgstr ""
 
 #: ../wxui/common.py:310
@@ -1891,6 +1901,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1944,7 +1962,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Keine Änderungen bei diesem Modell möglich"
@@ -1989,12 +2007,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2016,6 +2034,10 @@ msgstr "Hersteller"
 #, fuzzy
 msgid "View"
 msgstr "_Ansicht"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/el.po
+++ b/chirp/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2023-02-11 15:12+0200\n"
 "Last-Translator: Sokratis Alichanidis <sv2hzs@posteo.net>\n"
 "Language-Team: Greek\n"
@@ -651,7 +651,7 @@ msgstr "Όλοι οι τύποι αρχείων|"
 msgid "Amateur"
 msgstr "Ραδιοερασιτέχνη"
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Παρουσιάστηκε ένα σφάλμα"
 
@@ -690,6 +690,12 @@ msgstr "Δημιουργία Περιηγητή Πομποδεκτών"
 #: ../wxui/query_sources.py:525
 msgid "Canada"
 msgstr "Καναδάς"
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
+msgstr ""
 
 #: ../wxui/memedit.py:1173
 #, python-format
@@ -940,7 +946,7 @@ msgstr "Εισάγετε προσαρμοσμένη θύρα:"
 msgid "Erased memory %s"
 msgstr "Διεγράφη η μνήμη %s"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 msgid "Error applying settings"
 msgstr "Σφάλμα εφαρμογής ρυθμίσεων"
 
@@ -1190,7 +1196,7 @@ msgstr "Συχνότητα"
 msgid "GMRS"
 msgstr "GMRS"
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr "Λήψη ρυθμίσεων"
 
@@ -1531,7 +1537,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, fuzzy, python-format
 msgid "Path %s does not exist"
 msgstr "Το αρχείο δεν υπάρχει: %s"
@@ -1644,6 +1650,11 @@ msgstr ""
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
+
+#: ../wxui/common.py:422
+#, fuzzy
+msgid "Refresh required"
+msgstr "Απαιτείται επανεκκίνηση"
 
 #: ../wxui/common.py:310
 #, python-format
@@ -1870,6 +1881,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1920,7 +1939,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
@@ -1964,12 +1983,12 @@ msgstr "Χρήση μεγαλύτερης γραμματοσειράς"
 msgid "Value does not fit in %i bits"
 msgstr "Η τιμή δεν χωράει σε %i bits"
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Η τιμή πρέπει να είναι τουλάχιστον %.4f"
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Η τιμή πρέπει να είναι το πολύ  %.4f"
@@ -1990,6 +2009,10 @@ msgstr "Προμηθευτής"
 #: ../wxui/main.py:938
 msgid "View"
 msgstr "Εμφάνιση"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/en_US.po
+++ b/chirp/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2011-11-29 16:07-0800\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr ""
 
@@ -684,6 +684,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -937,7 +943,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "E_xchange"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 msgid "Error applying settings"
 msgstr ""
 
@@ -1189,7 +1195,7 @@ msgstr ""
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr ""
 
@@ -1533,7 +1539,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1644,6 +1650,10 @@ msgstr ""
 
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
+msgstr ""
+
+#: ../wxui/common.py:422
+msgid "Refresh required"
 msgstr ""
 
 #: ../wxui/common.py:310
@@ -1868,6 +1878,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1918,7 +1936,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
@@ -1963,12 +1981,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -1990,6 +2008,10 @@ msgstr ""
 #, fuzzy
 msgid "View"
 msgstr "_View"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/es.po
+++ b/chirp/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2023-06-29 01:01-0400\n"
 "Last-Translator: MELERIX\n"
 "Language-Team: \n"
@@ -1021,7 +1021,7 @@ msgstr "Todos los formatos soportados|"
 msgid "Amateur"
 msgstr "Aficionado"
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Ha ocurrido un error"
 
@@ -1060,6 +1060,12 @@ msgstr "Construyendo navegador de radio"
 #: ../wxui/query_sources.py:525
 msgid "Canada"
 msgstr "Canada"
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
+msgstr ""
 
 #: ../wxui/memedit.py:1173
 #, python-format
@@ -1318,7 +1324,7 @@ msgstr "Ingresar puerto personalizado:"
 msgid "Erased memory %s"
 msgstr "Memoria borrada %s"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 msgid "Error applying settings"
 msgstr "Error aplicando ajustes"
 
@@ -1663,7 +1669,7 @@ msgstr "Frecuencia"
 msgid "GMRS"
 msgstr "GMRS"
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr "Obteniendo ajustes"
 
@@ -2007,7 +2013,7 @@ msgstr "Las memorias pegadas sobrescribirán la memoria %s"
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria pegada sobrescribirá la memoria %s"
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr "La ruta %s no existe"
@@ -2147,6 +2153,11 @@ msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 "RadioReference Canadá requiere un inicio de sesión antes de que puedas "
 "consultar"
+
+#: ../wxui/common.py:422
+#, fuzzy
+msgid "Refresh required"
+msgstr "Reinicio requerido"
 
 #: ../wxui/common.py:310
 #, python-format
@@ -2401,6 +2412,14 @@ msgstr ""
 "veces.\n"
 "Si puede ingresar, por favor comprueba la radio y el cable.\n"
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr "Esto va a cargar un módulo desde un problema del sitio web"
@@ -2456,7 +2475,7 @@ msgstr ""
 "seleccionado es de EE.UU pero la radio no es una de EE.UU (o de banda "
 "ancha). Por favor elije el modelo correcto e intenta de nuevo."
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "No se puede revelar %s en este sistema"
@@ -2500,12 +2519,12 @@ msgstr "Usar fuente más grande"
 msgid "Value does not fit in %i bits"
 msgstr "Valor no cabe en %i bits"
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Valor debe ser al menos %.4f"
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Valor debe ser como máximo %.4f"
@@ -2526,6 +2545,10 @@ msgstr "Vendedor"
 #: ../wxui/main.py:938
 msgid "View"
 msgstr "Ver"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/fr.po
+++ b/chirp/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2014-04-05 22:18+0100\n"
 "Last-Translator: Matthieu Lapadu-Hargues <mlhpub@free.fr>\n"
 "Language-Team: French\n"
@@ -648,7 +648,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Une erreur s'est produite"
 
@@ -686,6 +686,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -942,7 +948,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "Effacer la memoire {loc}"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 #, fuzzy
 msgid "Error applying settings"
 msgstr "Erreur ecriture memoire"
@@ -1195,7 +1201,7 @@ msgstr "Frequence"
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr ""
 
@@ -1546,7 +1552,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1658,6 +1664,10 @@ msgstr ""
 
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
+msgstr ""
+
+#: ../wxui/common.py:422
+msgid "Refresh required"
 msgstr ""
 
 #: ../wxui/common.py:310
@@ -1883,6 +1893,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1936,7 +1954,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Impossible de realiser des changements pour ce modele"
@@ -1981,12 +1999,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2008,6 +2026,10 @@ msgstr "Fabricant"
 #, fuzzy
 msgid "View"
 msgstr "_Voir"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/hu.po
+++ b/chirp/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2015-01-28 13:47+0100\n"
 "Last-Translator: Attila Joubert <joubert.attila@gmail.com>\n"
 "Language-Team: English\n"
@@ -647,7 +647,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Hiba történt"
 
@@ -685,6 +685,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -943,7 +949,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "A(z) {loc}. memóriahely törlése"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 #, fuzzy
 msgid "Error applying settings"
 msgstr "Hiba a(z) %s érték beállításakor"
@@ -1199,7 +1205,7 @@ msgstr "Frekvencia"
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 #, fuzzy
 msgid "Getting settings"
 msgstr "%s információk beolvasása"
@@ -1554,7 +1560,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1668,6 +1674,10 @@ msgstr ""
 
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
+msgstr ""
+
+#: ../wxui/common.py:422
+msgid "Refresh required"
 msgstr ""
 
 #: ../wxui/common.py:310
@@ -1895,6 +1905,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1948,7 +1966,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Ennél a modellnél nem változtatható"
@@ -1994,12 +2012,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2021,6 +2039,10 @@ msgstr "Gyártó"
 #, fuzzy
 msgid "View"
 msgstr "Né_zet"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/it.po
+++ b/chirp/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2014-11-08 17:58+0100\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -647,7 +647,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Si e' verificato un errore"
 
@@ -685,6 +685,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -941,7 +947,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "Cancellazione memoria {loc}"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 #, fuzzy
 msgid "Error applying settings"
 msgstr "Errore di scrittura della memoria"
@@ -1194,7 +1200,7 @@ msgstr "Frequenza"
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr ""
 
@@ -1545,7 +1551,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1657,6 +1663,10 @@ msgstr ""
 
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
+msgstr ""
+
+#: ../wxui/common.py:422
+msgid "Refresh required"
 msgstr ""
 
 #: ../wxui/common.py:310
@@ -1883,6 +1893,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1936,7 +1954,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Impossibile effettuare modifiche su questo modello"
@@ -1981,12 +1999,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2008,6 +2026,10 @@ msgstr "Produttore"
 #, fuzzy
 msgid "View"
 msgstr "Vista"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/nl.po
+++ b/chirp/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2012-03-18 12:01+0100\n"
 "Last-Translator: Michael Tel <m.tel@xs4all.nl>\n"
 "Language-Team: Dutch\n"
@@ -647,7 +647,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Er is een fout opgetreden"
 
@@ -685,6 +685,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -941,7 +947,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "Wis kanaal {loc}"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 #, fuzzy
 msgid "Error applying settings"
 msgstr "Fout bij het instellen van het geheugen"
@@ -1194,7 +1200,7 @@ msgstr "Frequentie"
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr ""
 
@@ -1545,7 +1551,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1657,6 +1663,10 @@ msgstr ""
 
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
+msgstr ""
+
+#: ../wxui/common.py:422
+msgid "Refresh required"
 msgstr ""
 
 #: ../wxui/common.py:310
@@ -1882,6 +1892,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1935,7 +1953,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Niet in staat om wijzigingen voor dit model te maken"
@@ -1980,12 +1998,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2007,6 +2025,10 @@ msgstr "Merk"
 #, fuzzy
 msgid "View"
 msgstr "Bee_ld"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/pl.po
+++ b/chirp/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2011-12-07 11:35+0100\n"
 "Last-Translator: Grzegorz Błoński-Kubiak <mancymonek@wp.pl>\n"
 "Language-Team: Polish\n"
@@ -647,7 +647,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Wystąpił błąd"
 
@@ -686,6 +686,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -946,7 +952,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "Kasowanie pamięci {loc}"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 #, fuzzy
 msgid "Error applying settings"
 msgstr "Błąd ustawiania pamięci"
@@ -1199,7 +1205,7 @@ msgstr "Częstotliwość"
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr ""
 
@@ -1553,7 +1559,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1666,6 +1672,10 @@ msgstr ""
 
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
+msgstr ""
+
+#: ../wxui/common.py:422
+msgid "Refresh required"
 msgstr ""
 
 #: ../wxui/common.py:310
@@ -1893,6 +1903,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1946,7 +1964,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Nie potrafię wprowadzić zmian w tym modelu"
@@ -1991,12 +2009,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2018,6 +2036,10 @@ msgstr "Producent"
 #, fuzzy
 msgid "View"
 msgstr "_Podgląd"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/pt_BR.po
+++ b/chirp/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2013-03-30 22:04-0300\n"
 "Last-Translator: Crezivando <crezivando@gmail.com>\n"
 "Language-Team: Language pt-BR\n"
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Ocorreu um erro"
 
@@ -684,6 +684,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -940,7 +946,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "Apagando memória {loc}"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 #, fuzzy
 msgid "Error applying settings"
 msgstr "Erro gravando memória"
@@ -1193,7 +1199,7 @@ msgstr "Frequência"
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr ""
 
@@ -1544,7 +1550,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1656,6 +1662,10 @@ msgstr ""
 
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
+msgstr ""
+
+#: ../wxui/common.py:422
+msgid "Refresh required"
 msgstr ""
 
 #: ../wxui/common.py:310
@@ -1881,6 +1891,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1934,7 +1952,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Incapaz de efetuar alterações para este modelo"
@@ -1979,12 +1997,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2006,6 +2024,10 @@ msgstr "Fornecedor"
 #, fuzzy
 msgid "View"
 msgstr "_Visualizar"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/ru.po
+++ b/chirp/locale/ru.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -638,7 +638,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Ошибка"
 
@@ -676,6 +676,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -936,7 +942,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "Стирание памяти {loc}"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 #, fuzzy
 msgid "Error applying settings"
 msgstr "Ошибка установки памяти"
@@ -1189,7 +1195,7 @@ msgstr "Частота"
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr ""
 
@@ -1542,7 +1548,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1655,6 +1661,10 @@ msgstr ""
 
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
+msgstr ""
+
+#: ../wxui/common.py:422
+msgid "Refresh required"
 msgstr ""
 
 #: ../wxui/common.py:310
@@ -1881,6 +1891,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1934,7 +1952,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Невозможно внести изменения в эту модель"
@@ -1979,12 +1997,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2006,6 +2024,10 @@ msgstr "Изготовитель"
 #, fuzzy
 msgid "View"
 msgstr "Вид_"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/tr_TR.po
+++ b/chirp/locale/tr_TR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2023-03-11 18:37+0300\n"
 "Last-Translator: Abdullah YILMAZ (TA1AUB) <h.abdullahyilmaz@hotmail.com>\n"
 "Language-Team: TURKISH\n"
@@ -988,7 +988,7 @@ msgstr "Desteklenen tüm biçimler|"
 msgid "Amateur"
 msgstr "Amatör"
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Bir hata oluştu"
 
@@ -1027,6 +1027,12 @@ msgstr "Telsiz Tarayıcısı oluşturuluyor"
 #: ../wxui/query_sources.py:525
 msgid "Canada"
 msgstr "Kanada"
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
+msgstr ""
 
 #: ../wxui/memedit.py:1173
 #, python-format
@@ -1286,7 +1292,7 @@ msgstr "Özel bağlantı noktasını girin:"
 msgid "Erased memory %s"
 msgstr "%s kaydı silindi"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 msgid "Error applying settings"
 msgstr "Ayarlar uygulanırken hata oluştu"
 
@@ -1625,7 +1631,7 @@ msgstr "Frekans"
 msgid "GMRS"
 msgstr "GMRS"
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr "Ayarlar alınıyor"
 
@@ -1976,7 +1982,7 @@ msgstr "Yapıştırılan kayıtlar, %s kaydının üzerine yazılacak"
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Yapıştırılan kayıt, %s kaydının üzerine yazacak"
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, fuzzy, python-format
 msgid "Path %s does not exist"
 msgstr "Dosya mevcut değil: %s"
@@ -2114,6 +2120,11 @@ msgstr ""
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 "RadioReference Kanada, sorgulayabilmeniz için önce oturum açmanız gerekir"
+
+#: ../wxui/common.py:422
+#, fuzzy
+msgid "Refresh required"
+msgstr "Yeniden Başlatma Gerekiyor"
 
 #: ../wxui/common.py:310
 #, python-format
@@ -2358,6 +2369,14 @@ msgstr ""
 "birkaç saniye sürebilir, işe yaramazsa birkaç kez tekrar deneyin.\n"
 "İşe yaramazsa, lütfen telsizi ve kabloyu kontrol edin.\n"
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr "Bu, bir web sitesi kaydından bir modül yükleyecektir"
@@ -2413,7 +2432,7 @@ msgstr ""
 "telsiz ABD dışı bir telsizdir (veya geniş bantlıdır). Lütfen doğru modeli "
 "seçin ve tekrar deneyin."
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "%s bu sistemde gösterilemiyor"
@@ -2457,12 +2476,12 @@ msgstr "Daha büyük yazı tipi kullan"
 msgid "Value does not fit in %i bits"
 msgstr "Değer %i bit'e sığmıyor"
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Değer en az %.4f olmalıdır"
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Değer en fazla %.4f olmalıdır"
@@ -2483,6 +2502,10 @@ msgstr "Tedarikçi"
 #: ../wxui/main.py:938
 msgid "View"
 msgstr "Göster"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/uk_UA.po
+++ b/chirp/locale/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2015-11-30 10:36+0200\n"
 "Last-Translator: laser <student.laser@gmail.com>\n"
 "Language-Team: laser <student.laser@gmail.com>\n"
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "Сталася помилка"
 
@@ -684,6 +684,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -944,7 +950,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "Стирання пам'яті {loc}"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 #, fuzzy
 msgid "Error applying settings"
 msgstr "Помилка настройки пам'яті"
@@ -1197,7 +1203,7 @@ msgstr "Частота"
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 msgid "Getting settings"
 msgstr ""
 
@@ -1550,7 +1556,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1663,6 +1669,10 @@ msgstr ""
 
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
+msgstr ""
+
+#: ../wxui/common.py:422
+msgid "Refresh required"
 msgstr ""
 
 #: ../wxui/common.py:310
@@ -1889,6 +1899,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1942,7 +1960,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Не вдається внести зміни до цієї моделі"
@@ -1987,12 +2005,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2014,6 +2032,10 @@ msgstr "Виробник"
 #, fuzzy
 msgid "View"
 msgstr "В_игляд"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"

--- a/chirp/locale/zh_CN.po
+++ b/chirp/locale/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-28 17:09-0700\n"
+"POT-Creation-Date: 2023-07-02 14:20-0700\n"
 "PO-Revision-Date: 2022-06-04 02:01+0800\n"
 "Last-Translator: DuckSoft, BH2UEP <realducksoft@gmail.com>\n"
 "Language: zh_CN\n"
@@ -645,7 +645,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:499 ../wxui/common.py:525
+#: ../wxui/common.py:531 ../wxui/common.py:557
 msgid "An error has occurred"
 msgstr "发生错误"
 
@@ -683,6 +683,12 @@ msgstr ""
 
 #: ../wxui/query_sources.py:525
 msgid "Canada"
+msgstr ""
+
+#: ../wxui/common.py:420
+msgid ""
+"Changing this setting requires refreshing the settings from the image, which "
+"will happen now."
 msgstr ""
 
 #: ../wxui/memedit.py:1173
@@ -943,7 +949,7 @@ msgstr ""
 msgid "Erased memory %s"
 msgstr "正在擦除存储 {loc}"
 
-#: ../wxui/settingsedit.py:114
+#: ../wxui/settingsedit.py:116
 #, fuzzy
 msgid "Error applying settings"
 msgstr "设置值有误：%s"
@@ -1199,7 +1205,7 @@ msgstr "频率"
 msgid "GMRS"
 msgstr ""
 
-#: ../wxui/settingsedit.py:54
+#: ../wxui/settingsedit.py:55
 #, fuzzy
 msgid "Getting settings"
 msgstr "正在获取 %s 信息"
@@ -1555,7 +1561,7 @@ msgstr ""
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/common.py:564
+#: ../wxui/common.py:596
 #, python-format
 msgid "Path %s does not exist"
 msgstr ""
@@ -1670,6 +1676,11 @@ msgstr ""
 #: ../wxui/query_sources.py:665
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
+
+#: ../wxui/common.py:422
+#, fuzzy
+msgid "Refresh required"
+msgstr "刷新"
 
 #: ../wxui/common.py:310
 #, fuzzy, python-format
@@ -1894,6 +1905,14 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1866
+msgid ""
+"This should only be enabled if you are using modified firmware that supports "
+"wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM "
+"restrictions and may lead to undefined or unregulated behavior. Use at your "
+"own risk!"
+msgstr ""
+
 #: ../wxui/developer.py:484
 msgid "This will load a module from a website issue"
 msgstr ""
@@ -1947,7 +1966,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:571
+#: ../wxui/common.py:603
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "无法变更此型号电台"
@@ -1993,12 +2012,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:422
+#: ../wxui/common.py:454
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:426
+#: ../wxui/common.py:458
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2020,6 +2039,10 @@ msgstr "厂商"
 #, fuzzy
 msgid "View"
 msgstr "查看 (_V)"
+
+#: ../wxui/common.py:406
+msgid "WARNING!"
+msgstr ""
 
 #: ../wxui/memedit.py:1324
 msgid "Warning"
@@ -2432,9 +2455,6 @@ msgstr ""
 #, python-brace-format
 #~ msgid "Raw memory {number}"
 #~ msgstr "原始存储 {number}"
-
-#~ msgid "Refresh"
-#~ msgstr "刷新"
 
 #~ msgid "Repeater callsign"
 #~ msgstr "中继台的呼号"

--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -430,6 +430,16 @@ class RadioSetting(RadioSettingGroup):
     def __init__(self, *args):
         super(RadioSetting, self).__init__(*args)
         self._apply_callback = None
+        self._warning_text = None
+        self._safe_value = None
+        self._volatile = False
+
+    @property
+    def volatile(self):
+        return self._volatile
+
+    def set_volatile(self, value):
+        self._volatile = value
 
     def set_apply_callback(self, callback, *args):
         self._apply_callback = lambda: callback(self, *args)
@@ -439,6 +449,22 @@ class RadioSetting(RadioSettingGroup):
 
     def run_apply_callback(self):
         return self._apply_callback()
+
+    def set_warning(self, warning_text, safe_value=None):
+        """Set a warning message to be shown to the user when changed.
+
+        This should not be over-used as it will be annoying (on purpose). This
+        message will be shown to the user with an option to continue to abort.
+        It should be used to warn the user of potential invalid operation or
+        compatibility issues. If safe_value is set, this will only warn the
+        user if the value is changed *to* something other than the safe_value.
+        """
+        self._warning_text = warning_text
+        self._safe_value = safe_value
+
+    def get_warning(self, value):
+        if value != self._safe_value:
+            return self._warning_text
 
     def _validate(self, value):
         # RadioSetting can only contain RadioSettingValue objects

--- a/chirp/wxui/settingsedit.py
+++ b/chirp/wxui/settingsedit.py
@@ -30,6 +30,7 @@ class ChirpSettingsEdit(common.ChirpEditor):
 
         self._radio = radio
         self._settings = None
+        self._propgrid = None
 
         sizer = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(sizer)
@@ -67,6 +68,7 @@ class ChirpSettingsEdit(common.ChirpEditor):
 
     def _add_group(self, group, parent=None):
         propgrid = common.ChirpSettingGrid(group, self._group_control)
+        self._propgrid = propgrid
         self.Bind(common.EVT_EDITOR_CHANGED, self._changed, propgrid)
         LOG.debug('Adding page for %s (parent=%s)' % (group.get_shortname(),
                                                       parent))
@@ -128,11 +130,18 @@ class ChirpSettingsEdit(common.ChirpEditor):
         if isinstance(job.result, Exception):
             common.error_proof.show_error(str(job.result))
 
+    def _reload(self):
+        self.refresh()
+        self.selected()
+
     def _changed(self, event):
         if not self._apply_settings():
             return
         self.do_radio(self._set_settings_cb, 'set_settings', self._settings)
         wx.PostEvent(self, common.EditorChanged(self.GetId()))
+        if self._propgrid.needs_reload:
+            LOG.warning('Settings grid needs a reload')
+            wx.CallAfter(self._reload)
 
     def saved(self):
         for i in range(self._group_control.GetPageCount()):

--- a/tests/test_drivers.py
+++ b/tests/test_drivers.py
@@ -1,6 +1,8 @@
 from chirp import directory
 from tests import load_tests
 
+__builtins__['_'] = lambda s: s
+
 
 class TestSuiteAdapter(object):
     """Adapter for pytest since it doesn't support the loadTests() protocol"""


### PR DESCRIPTION
This adds two functions for settings. A warning message can be added,
which will either always be displayed to the user when they change the
value, or only when they change it away from some default. They are
given the opportunity to cancel the change if the warning makes them
reconsider.

Also, a setting can be marked "volatile" which will cause the settings
tab to be fully reloaded when it has been changed. This resets the
view as well, so it's not ideal, but this can be used when one setting
necessarily impacts another.
