### PR TITLE
Save backup images after every download

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@ The following must be true before PRs can be merged:
 * Commits in a single PR should be related.
 * Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
 * New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
+* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).
 
 Please also follow these guidelines:
 

--- a/tools/check_commit.sh
+++ b/tools/check_commit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BASE="$1"
+BASE=${1:-origin/master}
 RETCODE=0
 
 RED='\033[1;31m'
@@ -14,6 +14,7 @@ function fail() {
 
 echo -e "${GREEN}Checking from $(git rev-parse --short ${BASE}):${NC}"
 git log --pretty=oneline --no-merges --abbrev-commit ${BASE}..
+echo
 
 git diff ${BASE}.. '*.py' | grep '^+' > added_lines
 
@@ -51,6 +52,11 @@ fi
 
 if grep '/cpep8.blacklist' added_lines; then
     fail 'Do not add new files to cpep8.blacklist'
+fi
+
+grep -i 'license' added_lines > license_lines
+if grep -iv '(GNU General Public License|Free Software Foundation)' license_lines; then
+    fail 'Files must be GPLv3 licensed (or not contain any license language)'
 fi
 
 for file in $(git diff --name-only ${BASE}..); do


### PR DESCRIPTION
This makes us save a backup image of every radio we download from
in the CHIRP profile directory, under backups/. This will help people
who don't capture a first-time download image from their radio, as
well as people who make some change that they end up not liking.

We'll need to prune these somehow going forward, but that can be done
later.
