### PR TITLE
Fix commit 1d1df46a

### DIFF
--- a/chirp/drivers/ft857.py
+++ b/chirp/drivers/ft857.py
@@ -1101,7 +1101,7 @@ class FT857Radio(ft817.FT817Radio):
                     setattr(self._memobj, setting + "_offset", abs(val))
                 else:
                     setattr(obj, setting, element.value)
-            except Except:
+            except Exception:
                 LOG.debug(element.get_name())
                 raise
 


### PR DESCRIPTION
This PR fixes an error made by me in a previous commit which unfortunately wasn't catched by the tests.

Fixes:
chirp/drivers/ft857.py:1104:19: E0602: Undefined variable 'Except' (undefined-variable)
