### PR TITLE
Update ft2800.py - Add support for extended TX version of radio

### DIFF
--- a/chirp/drivers/ft2800.py
+++ b/chirp/drivers/ft2800.py
@@ -33,7 +33,12 @@ def _send(s, data):
             raise Exception("Failed to read echo chunk")
 
 
-IDBLOCK = b"\x0c\x01\x41\x33\x35\x02\x00\xb8"
+# The IDBLOCK is the first thing sent during an upload or download
+# and indicates the radio subtype:
+#   USA Unmodified:            b"\x0c\x01\x41\x33\x35\x02\x00\xb8"
+#   USA With extended TX mod:  b"\x0c\x01\x41\x33\x35\x03\x00\xb9"
+SUPPORTED_IDBLOCKS = [b"\x0c\x01\x41\x33\x35\x02\x00\xb8",
+                      b"\x0c\x01\x41\x33\x35\x03\x00\xb9"]
 TRAILER = b"\x0c\x02\x41\x33\x35\x00\x00\xb7"
 ACK = b"\x0C\x06\x00"
 
@@ -43,7 +48,8 @@ def _download(radio):
     attempts = 30
     for _i in range(0, attempts):
         data = radio.pipe.read(8)
-        if data == IDBLOCK:
+        if data in SUPPORTED_IDBLOCKS:
+            radio.subtype = data
             break
         LOG.debug('Download attempt %i received %i: %s',
                   _i, len(data), util.hexprint(data))
@@ -103,7 +109,7 @@ def _upload(radio):
             break
         LOG.debug("What is this garbage?\n%s" % util.hexprint(data))
 
-    _send(radio.pipe, IDBLOCK)
+    _send(radio.pipe, radio.subtype)
     time.sleep(1)
     ack = radio.pipe.read(300)
     LOG.debug("Ack was (%i):\n%s" % (len(ack), util.hexprint(ack)))
@@ -181,6 +187,14 @@ class FT2800Radio(YaesuCloneModeRadio):
 
     _block_sizes = [8, 7680]
     _memsize = 7680
+
+    @property
+    def subtype(self):
+        return bytes(self.metadata['subtype_idblock'])
+
+    @subtype.setter
+    def subtype(self, value):
+        self.metadata = {'subtype_idblock': [x for x in value]}
 
     @classmethod
     def get_prompts(cls):


### PR DESCRIPTION
Add new class for radios with extended transmit modification (MARS/CAP) that uses a different ID_BLOCK value.

https://chirp.danplanet.com/issues/3919

Succesfully bench tested upload and download with an FT-2800M with TX mod. 
