### PR TITLE
ga510.py: Retevis RA85 and RA685 full band support - fixes #10726

### DIFF
--- a/chirp/drivers/ga510.py
+++ b/chirp/drivers/ga510.py
@@ -536,39 +536,6 @@ class RadioddityGA510Radio(chirp_common.CloneModeRadio):
         except:
             LOG.exception('Failed to get extra for %i' % num)
 
-        immutable = []
-
-        if self._gmrs:
-            if mem.freq in bandplan_na.ALL_GMRS_FREQS:
-                if mem.freq in bandplan_na.GMRS_LOW:
-                    mem.duplex = ''
-                    mem.offset = 0
-                    immutable = ["duplex", "offset"]
-                if mem.freq in bandplan_na.GMRS_HHONLY:
-                    mem.duplex = 'off'
-                    mem.offset = 0
-                    immutable = ["duplex", "offset"]
-                if mem.freq in bandplan_na.GMRS_HIRPT:
-                    immutable = ["freq"]
-                    if mem.duplex == '+':
-                        mem.offset = 5000000
-                    else:
-                        mem.duplex = ''
-                        mem.offset = 0
-            else:
-                mem.duplex = 'off'
-                mem.offset = 0
-                immutable = ["duplex", "offset"]
-
-        if self.MODEL == "RA685":
-            if not ((mem.freq >= self.vhftx[0] and mem.freq < self.vhftx[1]) or
-                    (mem.freq >= self.uhftx[0] and mem.freq < self.uhftx[1])):
-                mem.duplex = 'off'
-                mem.offset = 0
-                immutable = ["duplex", "offset"]
-
-        mem.immutable = immutable
-
         return mem
 
     def _set_mem(self, number):
@@ -980,29 +947,12 @@ class RetevisRA685Radio(RadioddityGA510Radio):
 
     _magic = b'PROGROMWLTU'
 
-    def check_set_memory_immutable_policy(self, existing, new):
-        existing.immutable = []
-        super().check_set_memory_immutable_policy(existing, new)
-
     def get_features(self):
         rf = RadioddityGA510Radio.get_features(self)
         rf.memory_bounds = (1, 128)
         rf.valid_bands = [(136000000, 174000000),
                           (400000000, 520000000)]
         return rf
-
-    def validate_memory(self, mem):
-        msgs = super().validate_memory(mem)
-
-        _msg_duplex = 'Duplex must be "off" for this frequency'
-        _msg_offset = 'Only simplex or +5MHz offset allowed on GMRS'
-
-        if not ((mem.freq >= self.vhftx[0] and mem.freq < self.vhftx[1]) or
-                (mem.freq >= self.uhftx[0] and mem.freq < self.uhftx[1])):
-            if mem.duplex != "off":
-                msgs.append(chirp_common.ValidationWarning(_msg_duplex))
-
-        return msgs
 
     def _get_mem(self, num):
         return self._memobj.memories[num - 1]
@@ -1030,26 +980,6 @@ class RetevisRA85Radio(RadioddityGA510Radio):
         chirp_common.PowerLevel('M', watts=0.6)]
 
     _magic = b'PROGROMWLTU'
-    _gmrs = True
-
-    def validate_memory(self, mem):
-        msgs = super().validate_memory(mem)
-
-        _msg_duplex = 'Duplex must be "off" for this frequency'
-        _msg_offset = 'Only simplex or +5MHz offset allowed on GMRS'
-
-        if mem.freq not in bandplan_na.ALL_GMRS_FREQS:
-            if mem.duplex != "off":
-                msgs.append(chirp_common.ValidationWarning(_msg_duplex))
-        if mem.freq in bandplan_na.GMRS_HIRPT:
-            if mem.duplex and mem.offset != 5000000:
-                msgs.append(chirp_common.ValidationWarning(_msg_offset))
-
-        return msgs
-
-    def check_set_memory_immutable_policy(self, existing, new):
-        existing.immutable = []
-        super().check_set_memory_immutable_policy(existing, new)
 
     def get_features(self):
         rf = RadioddityGA510Radio.get_features(self)

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -749,8 +749,6 @@ class TestOverrideRules(base.BaseTest):
         'BTECH_GMRS-V2',
         'BTECH_MURS-V2',
         'Radioddity_DB25-G',
-        'Retevis_RA85',
-        'Retevis_RA685',
         'Retevis_RB17P'
     ]
 


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
