### PR TITLE
ga510.py: add 'reset' after clone error and upload

### DIFF
--- a/chirp/drivers/ga510.py
+++ b/chirp/drivers/ga510.py
@@ -56,6 +56,7 @@ def start_program(radio):
     if not ack.endswith(b'\x06'):
         LOG.debug('Ack was %r' % ack)
         raise errors.RadioError('Radio did not respond to clone request')
+        reset(radio)
 
     radio.pipe.write(b'F')
 
@@ -85,9 +86,11 @@ def do_download(radio):
         if raddr != addr:
             raise errors.RadioError('Radio send address %04x, expected %04x' %
                                     (raddr, addr))
+            reset(radio)
         if rlen != 0x40 or len(block) != 0x40:
             raise errors.RadioError('Radio sent %02x (%02x) bytes, '
                                     'expected %02x' % (rlen, len(block), 0x40))
+            reset(radio)
 
         data += block
 
@@ -119,9 +122,12 @@ def do_upload(radio):
         ack = radio.pipe.read(1)
         if ack != b'\x06':
             raise errors.RadioError('Radio refused block at addr %04x' % addr)
+            reset(radio)
 
         s.cur = addr
         radio.status_fn(s)
+
+    reset(radio)
 
 
 BASE_FORMAT = """


### PR DESCRIPTION
The radio has to be power cycled after upload or clone errors. This patch fixes issue by adding missing 'resets' to close communicatons.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
