### PR TITLE
Copy/Paste mem.extra

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -611,6 +611,8 @@ def FrozenMemory(source):
         def __init__(self, source):
             self.__dict__['_frozen'] = False
             for k, v in source.__dict__.items():
+                if k == '_frozen':
+                    continue
                 setattr(self, k, v)
 
             self.__dict__['_frozen'] = True

--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -632,6 +632,7 @@ def FrozenMemory(source):
         def dupe(self):
             m = Memory()
             m.clone(self)
+            delattr(m, '_frozen')
             return m
 
     return _FrozenMemory(source)

--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -42,8 +42,11 @@ class RadioSettingValue:
     def __init__(self):
         self._current = None
         self._has_changed = False
-        self._validate_callback = lambda x: x
+        self._validate_callback = self.null_callback
         self._mutable = True
+
+    def null_callback(self, x):
+        return x
 
     def set_mutable(self, mutable):
         self._mutable = mutable
@@ -492,6 +495,8 @@ class RadioSetting(RadioSettingGroup):
                 return self._elements[self._element_order[0]]
             else:
                 return list(self._elements.values())
+        elif name in ('__getstate__', '__setstate__'):
+            super().__getattr__(name)
         else:
             return self.__dict__[name]
 

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -2,6 +2,7 @@ import base64
 import copy
 import json
 import os
+import pickle
 import tempfile
 
 from unittest import mock
@@ -11,6 +12,7 @@ from chirp import CHIRP_VERSION
 from chirp import chirp_common
 from chirp import directory
 from chirp import errors
+from chirp import settings
 
 
 class TestUtilityFunctions(base.BaseTest):
@@ -783,3 +785,27 @@ class TestOverrideRules(base.BaseTest):
                 self._test_radio_override_calls_super(rclass)
             else:
                 self._test_radio_override_immutable_policy(rclass)
+
+
+class TestMemory(base.BaseTest):
+    def test_pickle_with_extra(self):
+        m = chirp_common.Memory()
+        m.extra = settings.RadioSettingGroup('extra', 'extra')
+        m.extra.append(settings.RadioSetting(
+            'test', 'test',
+            settings.RadioSettingValueString(1, 32, current='foo')))
+        n = pickle.loads(pickle.dumps(m))
+        self.assertEqual(str(n.extra['test'].value),
+                         str(m.extra['test'].value))
+
+    def test_frozen_from_frozen(self):
+        m = chirp_common.FrozenMemory(chirp_common.Memory(123))
+        n = chirp_common.FrozenMemory(m)
+        self.assertEqual(123, n.number)
+
+    def test_frozen_dupe_unfrozen(self):
+        FrozenMemory = chirp_common.FrozenMemory(
+            chirp_common.Memory()).__class__
+        m = chirp_common.FrozenMemory(chirp_common.Memory(123)).dupe()
+        self.assertNotIsInstance(m, FrozenMemory)
+        self.assertFalse(hasattr(m, '_frozen'))


### PR DESCRIPTION
- Avoid copying FrozenMemory internal state
- Make RadioSettingValue pickle-able
- Allow copying memory extra settings in some cases
