### PR TITLE
Remove unreachable code

### DIFF
--- a/chirp/drivers/ft1d.py
+++ b/chirp/drivers/ft1d.py
@@ -934,8 +934,6 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
         rf.valid_special_chans = [name for s in SPECIALS for name in s[1]]
         return rf
 
-        return rf
-
     def get_raw_memory(self, number):
         return "\n".join([repr(self._memobj.memory[number - 1]),
                           repr(self._memobj.flag[number - 1])])

--- a/chirp/drivers/ft2900.py
+++ b/chirp/drivers/ft2900.py
@@ -79,7 +79,6 @@ def _download(radio):
         if len(chunk) != 32:
             LOG.debug("len chunk is %i\n" % (len(chunk)))
             raise Exception("Failed to get full data block")
-            break
         else:
             data += chunk
 

--- a/chirp/drivers/tk270.py
+++ b/chirp/drivers/tk270.py
@@ -179,7 +179,6 @@ def recv(radio):
     if len(rxdata) != 12:
         raise errors.RadioError(
             "Received a length of data that is not possible")
-        return
 
     cmd, addr, length = struct.unpack(">BHB", rxdata[0:4])
     data = ""

--- a/chirp/drivers/tk760.py
+++ b/chirp/drivers/tk760.py
@@ -175,7 +175,6 @@ def recv(radio):
     if len(rxdata) != 12:
         raise errors.RadioError(
             "Received a length of data that is not possible")
-        return
 
     cmd, addr, length = struct.unpack(">BHB", rxdata[0:4])
     data = ""

--- a/chirp/drivers/tk760g.py
+++ b/chirp/drivers/tk760g.py
@@ -841,7 +841,6 @@ class Kenwood_Serie_60G(chirp_common.CloneModeRadio,
             LOG.debug(util.hexprint(rid))
             raise errors.RadioError(
                 "Wrong Kenwood radio, ID or unknown variant, see LOG output.")
-            return False
 
     def sync_in(self):
         """Do a download of the radio eeprom"""

--- a/chirp/drivers/ts480.py
+++ b/chirp/drivers/ts480.py
@@ -170,7 +170,6 @@ def _connect_radio(radio):
                 (RADIO_IDS[resp], radio.MODEL)
             raise errors.RadioError(msg)
     raise errors.RadioError("No response from radio")
-    return
 
 
 def read_str(radio, trm=";"):

--- a/chirp/drivers/ts590.py
+++ b/chirp/drivers/ts590.py
@@ -204,7 +204,6 @@ def _connect_radio(radio):
                 (RADIO_IDS[resp], radio.MODEL)
             raise errors.RadioError(msg)
     raise errors.RadioError("No response from radio")
-    return
 
 
 def read_str(radio, trm=";"):

--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -694,7 +694,6 @@ def _do_upload(radio):
             "This is NOT an error.\n"
             "The upload has finished successfully.\n"
             "Please restart CHIRP.")
-        return
 
     if radio._aux_block and not imagev_matched_radiov:
         msg = ("This is NOT an error. The upload finished successfully.\n"

--- a/tools/cpep8.manifest
+++ b/tools/cpep8.manifest
@@ -18,14 +18,12 @@
 ./chirp/drivers/ft2900.py
 ./chirp/drivers/ft60.py
 ./chirp/drivers/ft7800.py
-./chirp/drivers/ft857.py
 ./chirp/drivers/ft90.py
 ./chirp/drivers/ga510.py
 ./chirp/drivers/generic_csv.py
 ./chirp/drivers/gmrsv2.py
 ./chirp/drivers/h777.py
 ./chirp/drivers/ic2730.py
-./chirp/drivers/ic9x.py
 ./chirp/drivers/icf.py
 ./chirp/drivers/icomciv.py
 ./chirp/drivers/iradio_uv_5118.py


### PR DESCRIPTION
This PR removes unreachable code, found with the tool vulture, and updates the cpep8.manifest (although for files not changed by the other commit.)

There is still some unreachable code that it's not clear how to fix:
```
chirp/drivers/ga510.py:59: unreachable code after 'raise' (100% confidence)
chirp/drivers/ga510.py:89: unreachable code after 'raise' (100% confidence)
chirp/drivers/ga510.py:93: unreachable code after 'raise' (100% confidence)
chirp/drivers/ga510.py:125: unreachable code after 'raise' (100% confidence)
chirp/drivers/template.py:42: unreachable code after 'return' (100% confidence)
chirp/drivers/template.py:60: unreachable code after 'raise' (100% confidence)
chirp/drivers/th_uvf8d.py:624: unreachable code after 'return' (100% confidence)
chirp/drivers/ts590.py:1019: unreachable code after 'raise' (100% confidence)
chirp/drivers/ts590.py:1025: unreachable code after 'raise' (100% confidence)
chirp/drivers/vxa700.py:45: unreachable code after 'continue' (100% confidence)
```