### PR TITLE
Fix import DVMemory to D74

### DIFF
--- a/chirp/drivers/thd74.py
+++ b/chirp/drivers/thd74.py
@@ -176,7 +176,8 @@ def get_used_flag(mem):
 
 
 @directory.register
-class THD74Radio(chirp_common.CloneModeRadio):
+class THD74Radio(chirp_common.CloneModeRadio,
+                 chirp_common.IcomDstarSupport):
     VENDOR = "Kenwood"
     MODEL = "TH-D74 (clone mode)"
     NEEDS_COMPAT_SERIAL = False


### PR DESCRIPTION
This radio needs to inherit from the IcomDstarSupport mixin to be
able to accept imported DV memories.

Fixes #10752
