### PR TITLE
Retevis RB15/RB615 use all 99 Memory Slots / Update retevis_rb15.py

### DIFF
--- a/chirp/drivers/retevis_rb15.py
+++ b/chirp/drivers/retevis_rb15.py
@@ -779,7 +779,7 @@ class RB15Radio(RB15RadioBase):
               ]
     _memsize = 0x07A0
 
-    _upper = 22
+    _upper = 99
     _frs = True
 
 
@@ -797,5 +797,5 @@ class RB615RadioBase(RB15RadioBase):
               ]
     _memsize = 0x07A0
 
-    _upper = 16
+    _upper = 99
     _pmr = True


### PR DESCRIPTION
Retevis RB15/RB615 does have 99 Memory Slots. The Driver limits CHIRP to read/write only 16 and 21 Memory Slots. The official Retevis programming tool allows to Program 99 Slots on both models. And the Radio shows the 99 Channels. See Pictures attached.

I'm not sure if only changing the _upper value fixes it, or if the _memsize or _ranges value has to be changed as well. I dont understand their function tbh.

![VirtualBox_Windows XP_14_08_2023_18_51_17](https://github.com/mxbchr/chirp/assets/75482460/4752648d-64e4-4108-841e-4b957b2ec4bd)

![1692032585120](https://github.com/mxbchr/chirp/assets/75482460/ec4c02cf-3e13-4574-ad17-835e01f83d4b)

