### PR TITLE
Fix for issue #10226

### DIFF
--- a/chirp/drivers/tg_uv2p.py
+++ b/chirp/drivers/tg_uv2p.py
@@ -114,9 +114,7 @@ struct name names[200];
 """
 
 
-def do_ident(radio):
-    radio.pipe.timeout = 3
-    radio.pipe.stopbits = serial.STOPBITS_TWO
+def do_program_mode(radio):
     radio.pipe.write(b"\x02PnOGdAM")
     for x in range(10):
         ack = radio.pipe.read(1)
@@ -124,11 +122,23 @@ def do_ident(radio):
             break
     else:
         raise errors.RadioError("Radio did not ack programming mode")
-    radio.pipe.write(b"\x40\x02")
+
+
+def do_ident(radio):
+    radio.pipe.timeout = 3
+    radio.pipe.stopbits = serial.STOPBITS_TWO
+    do_program_mode(radio)
+    radio.pipe.write(b"\x4D\x02")
     ident = radio.pipe.read(8)
     LOG.debug(util.hexprint(ident))
     if not ident.startswith(b'P5555'):
-        raise errors.RadioError("Unsupported model")
+        LOG.debug("First ident attempt (x4D, x02) failed trying 0x40,x02")
+        do_program_mode(radio)
+        radio.pipe.write(b"\x40\x02")
+        ident = radio.pipe.read(8)
+        LOG.debug(util.hexprint(ident))
+        if not ident.startswith(b'P5555'):
+            raise errors.RadioError("Unsupported model")
     radio.pipe.write(b"\x06")
     ack = radio.pipe.read(1)
     if ack != b"\x06":


### PR DESCRIPTION
Added Identity command x4Dx02 as a first attempt (probably the correct one anyway), kept teh previous (x40x02) as a second attempt.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
