### PR TITLE
ft2800: Fix getting subtype from older images

### DIFF
--- a/chirp/drivers/ft2800.py
+++ b/chirp/drivers/ft2800.py
@@ -190,7 +190,10 @@ class FT2800Radio(YaesuCloneModeRadio):
 
     @property
     def subtype(self):
-        return bytes(self.metadata['subtype_idblock'])
+        # If our image is from before the subtype was stashed, assume
+        # the default unmodified US ID block
+        return bytes(self.metadata.get('subtype_idblock',
+                                       SUPPORTED_IDBLOCKS[0]))
 
     @subtype.setter
     def subtype(self, value):


### PR DESCRIPTION
The change to support multiple IDBLOCK types in the ft2800 driver
broke existing images without that metadata attached. This makes us
assume the previous IDBLOCK if none is found.

Fixes #10797
