### PR TITLE
tox: use distro's default python

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ builtins =
     _,
 
 [testenv]
-basepython = python3
 sitepackages = True
 passenv =
   HOME
@@ -18,7 +17,6 @@ allowlist_externals = bash
 deps = future
 
 [testenv:style]
-basepython = python3
 deps =
     pep8
     future
@@ -31,7 +29,6 @@ commands =
     py3clean chirp tests
 
 [testenv:unit]
-basepython = python3
 setenv =
     PYTHONPATH=../..
 deps =
@@ -40,7 +37,6 @@ commands =
     pytest --disable-warnings --html=unit_report.html -v tests/unit {posargs}
 
 [testenv:driver]
-basepython = python3
 setenv =
     PYTHONPATH=../..
     CHIRP_DEBUG=y
@@ -51,7 +47,6 @@ commands =
     pytest --disable-warnings --html=driver_report.html -v tests/test_drivers.py -n auto {posargs}
 
 [testenv:fast-driver]
-basepython = python3
 setenv =
     PYTHONPATH=../..
     CHIRP_DEBUG=y
@@ -66,7 +61,6 @@ xfail_strict = true
 render_collapsed = True
 
 [testenv:makesupported]
-basepython = python3
 allowlist_externals =
     git
 deps =


### PR DESCRIPTION
I think it should used the distro's default python version and not override it, because otherwise e.g. on Fedora Rawhide (f40) it fails:

> py312: failed with env name py312 conflicting with base python python3
