### PR TITLE
[UV-K5] add Quansheng UV-K6 as alias to Quansheng UV-K5

### DIFF
--- a/chirp/share/model_alias_map.yaml
+++ b/chirp/share/model_alias_map.yaml
@@ -306,6 +306,8 @@ Quansheng:
 - alt: TG-UV2+
   model: TG-UV2
 - alt: UV-K5
+  model: UV-K6
+- alt: UV-K5
   model: UV-K5(8)
 - alt: UV-K5
   model: UV-5R Plus


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
