### PR TITLE
ft2800.py: initialize unknown memory objects - fixes #10916

### DIFF
--- a/chirp/drivers/ft2800.py
+++ b/chirp/drivers/ft2800.py
@@ -315,6 +315,12 @@ class FT2800Radio(YaesuCloneModeRadio):
             # Empty -> Non-empty, so initialize
             _mem.set_raw("\x00" * (_mem.size() // 8))
 
+        # initializing unknowns
+        _mem.unknown1 = (0xFF, 0xFF, 0xFF, 0xFF)
+        _mem.unknown2 = (0x00, 0x00)
+        _mem.unknown3 = 0x01
+        _mem.unknown4 = 0x3C
+
         _mem.freq = mem.freq / 10
         _mem.offset = mem.offset / 100000
         _mem.duplex = DUPLEX.index(mem.duplex)


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
