### PR TITLE
ft450: Fix IF filter setting breaking UI

### DIFF
--- a/chirp/drivers/ft450d.py
+++ b/chirp/drivers/ft450d.py
@@ -1123,7 +1123,6 @@ class FT450DRadio(yaesu_clone.YaesuCloneModeRadio):
                     elif stx == "N/A":
                         _mem.mode = 5
                         _mem.mode2 = 2
-                        setting.value = "USER-U"   # default moving to DIG mode
                     else:
                         LOG.error("In _set_memory invalid digital data type %s", stx)
             elif setting.get_name() == "bpfilter":

--- a/tests/xfails.txt
+++ b/tests/xfails.txt
@@ -6,7 +6,3 @@
 # One line per test nodeid with a comment above citing a bug number, example:
 # Bug #10931: FT-450 mem.extra fields cause UI corruption
 # tests/test_drivers.py::TestCaseBruteForce_Yaesu_FT-450D::test_mode
-
-# Bug #10931: FT-450 mem.extra fields cause UI corruption
-tests/test_drivers.py::TestCaseBruteForce_Yaesu_FT-450::test_mode
-tests/test_drivers.py::TestCaseBruteForce_Yaesu_FT-450D::test_mode


### PR DESCRIPTION
This driver exposed a different setting for each memory in extra
depending on the mode of that memory. That's not compatible with the
UI's exploding of extra fields into columns, and in general breaks
the ability to edit a whole memory in the properties dialog.

This makes it expose one setting with all the available options, but
ensures that only filters valid for a given mode are selected by
rounding to the nearest available filter width per memory.

Fixes #10929
