### PR TITLE
Bitwise strict checks and byte-compat deprecations

### DIFF
--- a/chirp/bitwise.py
+++ b/chirp/bitwise.py
@@ -219,7 +219,7 @@ class DataElement:
     def set_value(self, value):
         raise Exception("Not implemented for %s" % self.__class__)
 
-    def get_raw(self, asbytes=False):
+    def get_raw(self, asbytes=True):
         raw = self._data[self._offset:self._offset+self._size]
         return self._compat_bytes(raw, asbytes)
 
@@ -261,7 +261,7 @@ class arrayDataElement(DataElement):
     def get_value(self):
         return list(self.__items)
 
-    def get_raw(self, asbytes=False):
+    def get_raw(self, asbytes=True):
         raw = [item.get_raw(asbytes=True) for item in self.__items]
         return self._compat_bytes(bytes(b''.join(raw)), asbytes)
 
@@ -792,7 +792,7 @@ class structDataElement(DataElement):
                 size += el.size()
         return int(size)
 
-    def get_raw(self, asbytes=False):
+    def get_raw(self, asbytes=True):
         size = self.size() // 8
         raw = self._data[self._offset:self._offset+size]
         return self._compat_bytes(raw, asbytes)

--- a/chirp/bitwise.py
+++ b/chirp/bitwise.py
@@ -60,6 +60,7 @@
 import struct
 import os
 import logging
+import warnings
 
 import six
 from builtins import bytes
@@ -201,6 +202,8 @@ class DataElement:
         if asbytes:
             return bytes(bs)
         else:
+            warnings.warn('Driver is using non-byte-native get_raw()',
+                          DeprecationWarning, stacklevel=3)
             return string_straight_decode(bs)
 
     def size(self):
@@ -225,6 +228,8 @@ class DataElement:
 
     def set_raw(self, data):
         if isinstance(data, str):
+            warnings.warn('Driver is using non-byte-native set_raw()',
+                          DeprecationWarning, stacklevel=2)
             data = string_straight_encode(data)
         self._data[self._offset] = data[:self._size]
 
@@ -665,6 +670,8 @@ class bcdDataElement(DataElement):
         if isinstance(data, int):
             self._data[self._offset] = data & 0xFF
         elif isinstance(data, str):
+            warnings.warn('Driver is using non-byte-native set_raw()',
+                          DeprecationWarning, stacklevel=2)
             self._data[self._offset] = string_straight_encode(data[0])
         elif isinstance(data, bytes) and len(data) == 1:
             self._data[self._offset] = int(data[0]) & 0xFF
@@ -801,6 +808,8 @@ class structDataElement(DataElement):
         if len(buffer) != (self.size() // 8):
             raise ValueError("Struct size mismatch during set_raw()")
         if isinstance(buffer, str):
+            warnings.warn('Driver is using non-byte-native set_raw()',
+                          DeprecationWarning, stacklevel=2)
             buffer = string_straight_encode(buffer)
         self._data[self._offset] = buffer
 

--- a/chirp/bitwise.py
+++ b/chirp/bitwise.py
@@ -197,6 +197,12 @@ class DataElement:
         self._offset = int(offset)
         self._count = count
 
+    def _compat_bytes(self, bs, asbytes):
+        if asbytes:
+            return bytes(bs)
+        else:
+            return string_straight_decode(bs)
+
     def size(self):
         return int(self._size * 8)
 
@@ -215,10 +221,7 @@ class DataElement:
 
     def get_raw(self, asbytes=False):
         raw = self._data[self._offset:self._offset+self._size]
-        if asbytes:
-            return bytes(raw)
-        else:
-            return string_straight_decode(raw)
+        return self._compat_bytes(raw, asbytes)
 
     def set_raw(self, data):
         if isinstance(data, str):
@@ -259,11 +262,8 @@ class arrayDataElement(DataElement):
         return list(self.__items)
 
     def get_raw(self, asbytes=False):
-        raw = [item.get_raw(asbytes=asbytes) for item in self.__items]
-        if asbytes:
-            return bytes(b''.join(raw))
-        else:
-            return "".join(raw)
+        raw = [item.get_raw(asbytes=True) for item in self.__items]
+        return self._compat_bytes(bytes(b''.join(raw)), asbytes)
 
     def __setitem__(self, index, val):
         self.__items[index].set_value(val)
@@ -795,10 +795,7 @@ class structDataElement(DataElement):
     def get_raw(self, asbytes=False):
         size = self.size() // 8
         raw = self._data[self._offset:self._offset+size]
-        if asbytes:
-            return bytes(raw)
-        else:
-            return string_straight_decode(raw)
+        return self._compat_bytes(raw, asbytes)
 
     def set_raw(self, buffer):
         if len(buffer) != (self.size() // 8):

--- a/chirp/drivers/__init__.py
+++ b/chirp/drivers/__init__.py
@@ -1,6 +1,12 @@
 import os
 import sys
 from glob import glob
+import warnings
+
+# This won't be here in the frozen build because we convert this file to
+# a static list of driver modules to import.
+warnings.filterwarnings('once', category=DeprecationWarning,
+                        module=__name__)
 
 module_dir = os.path.dirname(sys.modules["chirp.drivers"].__file__)
 __all__ = []

--- a/chirp/drivers/alinco.py
+++ b/chirp/drivers/alinco.py
@@ -787,7 +787,7 @@ class AlincoDJG7(AlincoStyleRadio):
             if _mem.skip:
                 mem.skip = "S"
             # FIXME find out what every other byte is used for. Japanese?
-            mem.name = str(_mem.name.get_raw()[::2]).rstrip('\0')
+            mem.name = str(_mem.name.get_raw(asbytes=False)[::2]).rstrip('\0')
         return mem
 
     def set_memory(self, mem):

--- a/chirp/drivers/anytone.py
+++ b/chirp/drivers/anytone.py
@@ -192,7 +192,7 @@ class FlagObj(object):
 
 
 def _is_loc_used(memobj, loc):
-    return memobj.flags[loc / 2].get_raw() != "\xFF"
+    return memobj.flags[loc / 2].get_raw(asbytes=False) != "\xFF"
 
 
 def _addr_to_loc(addr):

--- a/chirp/drivers/anytone_ht.py
+++ b/chirp/drivers/anytone_ht.py
@@ -557,7 +557,7 @@ class AnyToneTERMN8RRadio(chirp_common.CloneModeRadio,
             return
         _usd &= ~bitpos
 
-        if _mem.get_raw() == ("\xFF" * 32):
+        if _mem.get_raw(asbytes=False) == ("\xFF" * 32):
             LOG.debug("Initializing empty memory")
             _mem.set_raw("\x00" * 32)
             _mem.squelch = 3

--- a/chirp/drivers/baofeng_common.py
+++ b/chirp/drivers/baofeng_common.py
@@ -417,7 +417,7 @@ class BaofengCommonHT(chirp_common.CloneModeRadio,
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.txfreq[i].get_raw()
+            raw_tx += _mem.txfreq[i].get_raw(asbytes=False)
         return raw_tx == "\xFF\xFF\xFF\xFF"
 
     def get_memory(self, number):
@@ -427,7 +427,7 @@ class BaofengCommonHT(chirp_common.CloneModeRadio,
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/baofeng_uv3r.py
+++ b/chirp/drivers/baofeng_uv3r.py
@@ -235,7 +235,7 @@ class UV3RRadio(chirp_common.CloneModeRadio):
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/bf_t1.py
+++ b/chirp/drivers/bf_t1.py
@@ -634,7 +634,7 @@ class BFT1(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
         else:
             mem.number = number
 
-        if _mem.get_raw()[0] == "\xFF":
+        if _mem.get_raw(asbytes=False)[0] == "\xFF":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/bf_t8.py
+++ b/chirp/drivers/bf_t8.py
@@ -417,7 +417,7 @@ class BFT8Radio(chirp_common.CloneModeRadio):
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.txfreq[i].get_raw()
+            raw_tx += _mem.txfreq[i].get_raw(asbytes=False)
         return raw_tx == "\xFF\xFF\xFF\xFF"
 
     def _get_mem(self, number):
@@ -441,12 +441,12 @@ class BFT8Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
 
-        if _mem.get_raw() == ("\xFF" * 16):
+        if _mem.get_raw(asbytes=False) == ("\xFF" * 16):
             LOG.debug("Initializing empty memory")
             _mem.set_raw("\x00" * 13 + "\xFF" * 3)
 

--- a/chirp/drivers/bj9900.py
+++ b/chirp/drivers/bj9900.py
@@ -322,7 +322,7 @@ class BJ9900Radio(chirp_common.CloneModeRadio,
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/boblov_x3plus.py
+++ b/chirp/drivers/boblov_x3plus.py
@@ -260,13 +260,14 @@ class BoblovX3Plus(chirp_common.CloneModeRadio,
         mem.freq = int(rmem.rxfreq) * 10
 
         # A blank (0 MHz) or 0xFFFFFFFF frequency is considered empty
-        if mem.freq == 0 or rmem.rxfreq.get_raw() == '\xFF\xFF\xFF\xFF':
+        if mem.freq == 0 or (
+                rmem.rxfreq.get_raw(asbytes=False) == '\xFF\xFF\xFF\xFF'):
             LOG.debug('empty channel %d', number)
             mem.freq = 0
             mem.empty = True
             return mem
 
-        if rmem.txfreq.get_raw() == '\xFF\xFF\xFF\xFF':
+        if rmem.txfreq.get_raw(asbytes=False) == '\xFF\xFF\xFF\xFF':
             mem.duplex = 'off'
             mem.offset = 0
         elif int(rmem.rxfreq) == int(rmem.txfreq):

--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -827,14 +827,14 @@ class BTechMobileCommon(chirp_common.CloneModeRadio,
         # Memory number
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xFF":
+        if _mem.get_raw(asbytes=False)[0] == "\xFF":
             mem.empty = True
             return mem
 
         # Freq and offset
         mem.freq = int(_mem.rxfreq) * 10
         # tx freq can be blank
-        if _mem.get_raw()[4] == "\xFF":
+        if _mem.get_raw(asbytes=False)[4] == "\xFF":
             # TX freq not set
             mem.offset = 0
             mem.duplex = "off"
@@ -1005,7 +1005,7 @@ class BTechMobileCommon(chirp_common.CloneModeRadio,
         mem_was_empty = False
         # same method as used in get_memory for determining if mem is empty
         # doing this BEFORE overwriting it with new values ...
-        if _mem.get_raw()[0] == "\xFF":
+        if _mem.get_raw(asbytes=False)[0] == "\xFF":
             LOG.debug("This mem was empty before")
             mem_was_empty = True
 

--- a/chirp/drivers/fd268.py
+++ b/chirp/drivers/fd268.py
@@ -379,7 +379,7 @@ class FeidaxinFD2x8yRadio(chirp_common.CloneModeRadio):
 
     def _decode_tone(self, val):
         """Parse the tone data to decode from mem, it returns"""
-        if val.get_raw() == "\xFF\xFF":
+        if val.get_raw(asbytes=False) == "\xFF\xFF":
             return '', None, None
 
         val = int(val)
@@ -418,7 +418,7 @@ class FeidaxinFD2x8yRadio(chirp_common.CloneModeRadio):
         mem.number = number
 
         # empty
-        if _mem.get_raw()[0] == "\xFF":
+        if _mem.get_raw(asbytes=False)[0] == "\xFF":
             mem.empty = True
             return mem
 
@@ -427,7 +427,7 @@ class FeidaxinFD2x8yRadio(chirp_common.CloneModeRadio):
 
         # checking if tx freq is empty, this is "possible" on the
         # original soft after a warning, and radio is happy with it
-        if _mem.tx_freq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.tx_freq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.duplex = "off"
             mem.offset = 0
         else:
@@ -567,7 +567,7 @@ class FeidaxinFD2x8yRadio(chirp_common.CloneModeRadio):
         work.append(active_ch)
 
         # vfo rx validation
-        if _mem.vfo.vrx_freq.get_raw()[0] == "\xFF":
+        if _mem.vfo.vrx_freq.get_raw(asbytes=False)[0] == "\xFF":
             # if the vfo is not set, the UI cares about the
             # length of the field, so set a default
             LOG.debug("Setting VFO to default %s" % self._VFO_DEFAULT)
@@ -601,7 +601,7 @@ class FeidaxinFD2x8yRadio(chirp_common.CloneModeRadio):
         work.append(shift)
 
         # vfo shift validation if none set it to ZERO
-        if _mem.settings.vfo_shift.get_raw()[0] == "\xFF":
+        if _mem.settings.vfo_shift.get_raw(asbytes=False)[0] == "\xFF":
             # if the shift is not set, the UI cares about the
             # length of the field, so set to zero
             LOG.debug("VFO shift not set, setting it to zero")

--- a/chirp/drivers/ft2800.py
+++ b/chirp/drivers/ft2800.py
@@ -286,7 +286,7 @@ class FT2800Radio(YaesuCloneModeRadio):
 
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xFF":
+        if _mem.get_raw(asbytes=False)[0] == "\xFF":
             mem.empty = True
             return mem
 
@@ -311,7 +311,7 @@ class FT2800Radio(YaesuCloneModeRadio):
             _mem.set_raw("\xFF" * (_mem.size() // 8))
             return
 
-        if _mem.get_raw()[0] == "\xFF":
+        if _mem.get_raw(asbytes=False)[0] == "\xFF":
             # Empty -> Non-empty, so initialize
             _mem.set_raw("\x00" * (_mem.size() // 8))
 

--- a/chirp/drivers/ft2900.py
+++ b/chirp/drivers/ft2900.py
@@ -572,7 +572,7 @@ class FT2900Radio(YaesuCloneModeRadio):
 
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xFF" or not valid or not used:
+        if _mem.get_raw(asbytes=False)[0] == "\xFF" or not valid or not used:
             mem.empty = True
             return mem
 
@@ -710,7 +710,8 @@ class FT2900Radio(YaesuCloneModeRadio):
         _mem.unknown4 = 0
         _mem.unknown5 = 0
 
-        LOG.debug("encoded mem\n%s\n" % (util.hexprint(_mem.get_raw()[0:20])))
+        LOG.debug("encoded mem\n%s\n" % (util.hexprint(
+            _mem.get_raw(asbytes=False)[0:20])))
 
     def get_settings(self):
         _settings = self._memobj.settings

--- a/chirp/drivers/ft7100.py
+++ b/chirp/drivers/ft7100.py
@@ -771,7 +771,8 @@ class FT7100Radio(YaesuCloneModeRadio):
             else:
                 setattr(_mem, setting.get_name(), setting.value)
 
-        LOG.debug("encoded mem\n%s\n", (util.hexprint(_mem.get_raw()[0:25])))
+        LOG.debug("encoded mem\n%s\n",
+                  (util.hexprint(_mem.get_raw(asbytes=False)[0:25])))
         LOG.debug(repr(_mem))
 
     def get_settings(self):
@@ -839,7 +840,7 @@ class FT7100Radio(YaesuCloneModeRadio):
                 RadioSettingValueList(opts, opts[_overlay.cwid])))
 
         # 6  Callsign during ARTS operation.
-        cwidw = _overlay.cwidw.get_raw()
+        cwidw = _overlay.cwidw.get_raw(asbytes=False)
         cwidw = cwidw.rstrip('\x00')
         val = RadioSettingValueString(0, 6, cwidw)
         val.set_charset(CHARSET)

--- a/chirp/drivers/ga510.py
+++ b/chirp/drivers/ga510.py
@@ -493,7 +493,7 @@ class RadioddityGA510Radio(chirp_common.CloneModeRadio):
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.txfreq[i].get_raw()
+            raw_tx += _mem.txfreq[i].get_raw(asbytes=False)
         return raw_tx == "\xFF\xFF\xFF\xFF"
 
     def _get_mem(self, num):

--- a/chirp/drivers/gmrsuv1.py
+++ b/chirp/drivers/gmrsuv1.py
@@ -413,13 +413,13 @@ class GMRSV1(baofeng_common.BaofengCommonHT):
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 
         mem.freq = int(_mem.rxfreq) * 10
 
-        if _mem.txfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.txfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.duplex = "off"
             mem.offset = 0
         elif int(_mem.rxfreq) == int(_mem.txfreq):

--- a/chirp/drivers/gmrsv2.py
+++ b/chirp/drivers/gmrsv2.py
@@ -385,7 +385,7 @@ class GMRSV2base(baofeng_common.BaofengCommonHT):
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/h777.py
+++ b/chirp/drivers/h777.py
@@ -399,12 +399,12 @@ class H777Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
 
-        if _mem.txfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.txfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.duplex = "off"
             mem.offset = 0
         elif int(_mem.rxfreq) == int(_mem.txfreq):

--- a/chirp/drivers/hg_uv98.py
+++ b/chirp/drivers/hg_uv98.py
@@ -31,20 +31,7 @@ from chirp.settings import RadioSettings
 
 LOG = logging.getLogger(__name__)
 
-# Gross hack to handle missing future module on un-updatable
-# platforms like MacOS. Just avoid registering these radio
-# classes for now.
-try:
-    from builtins import bytes
-    has_future = True
-except ImportError:
-    has_future = False
-    LOG.debug('python-future package is not '
-              'available; %s requires it' % __name__)
-
-
 MEM_FORMAT = """
-#seekto 0x0000;
 struct {
   lbcd rx_freq[4];
   lbcd tx_freq[4];
@@ -217,10 +204,8 @@ def do_ident(radio):
     LOG.debug('ident string was %r' % ident)
     if ident != radio.IDENT:
         raise errors.RadioError(
-            "Incorrect model: {}, expected {!r}".format(
-                util.hexprint(ident), radio.IDENT,
-            )
-        )
+            "Incorrect model: %s, expected %r" % (
+                util.hexprint(ident), radio.IDENT))
     LOG.info("Model: %s (%s)" % (radio.MODEL, util.hexprint(ident)))
     radio.pipe.write(b"\x06")
     ack = radio.pipe.read(1)
@@ -261,9 +246,6 @@ def do_upload(radio):
     do_ident(radio)
 
     mmap = radio._mmap
-    if callable(getattr(mmap, "get_byte_compatible", None)):
-        # for py3-CHIRP
-        mmap = mmap.get_byte_compatible()
     for addr in range(0, MAX_ADDR, CHUNK_SIZE):
         send(radio, make_frame(b"W", addr, CHUNK_SIZE, mmap[addr:addr + CHUNK_SIZE]))
         ack = radio.pipe.read(1)
@@ -297,27 +279,22 @@ class RadioSettingValueChannel(RadioSettingValueList):
         current_mem = radio.get_memory(current)
         options = [
             self._format_memory(mem)
-            for mem in [
-                radio.get_memory(n)
-                for n in range(*radio.get_features().memory_bounds)
-            ]
-        ]
-        RadioSettingValueList.__init__(
-            self,
-            options,
-            self._format_memory(current_mem),
-        )
+            for mem in [radio.get_memory(n)
+                        for n in range(*radio.get_features().memory_bounds)]]
+        RadioSettingValueList.__init__(self, options,
+                                       self._format_memory(current_mem))
 
     @staticmethod
     def _format_memory(m):
         if m.empty:
             return str(int(m.number))
-        return "{} {:.4f} {}".format(int(m.number), m.freq / float(1e6), m.name)
+        return "%i %.4f %s" % (m.number, m.freq / 1e6, m.name)
 
     def __int__(self):
         return int(self.get_value().partition(" ")[0])
 
 
+@directory.register
 class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
     """
     Lanchonlh HG-UV98
@@ -340,8 +317,7 @@ class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRad
             "This Lanchonlh HG-UV98 driver is an alpha version. "
             "Proceed with Caution and backup your data. "
             "Always confirm the correctness of your settings with the "
-            "official programming tool."
-        )
+            "official programming tool.")
         return rp
 
     def get_features(self):
@@ -442,7 +418,7 @@ class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRad
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw(asbytes=False)[:4] == "\xFF\xFF\xFF\xFF":
+        if _mem.get_raw()[:4] == b"\xFF\xFF\xFF\xFF":
             mem.empty = True
             return mem
 
@@ -450,7 +426,8 @@ class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRad
             mem.name, mem.extd_number = SPECIAL_CHANNELS[mem.number]
         else:
             _name = self._memobj.name[number - 1]
-            mem.name, _, _ = _name.name.get_raw(asbytes=False).partition("\xFF")
+            mem.name, _, _ = _name.name.get_raw().partition(b"\xFF")
+            mem.name = mem.name.decode('ascii')
         # XXX: other drivers rstrip the name and test_badname enforces this
         mem.name = mem.name.rstrip()
         mem.freq = int(_mem.rx_freq) * 10
@@ -519,7 +496,7 @@ class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRad
         _mem = self._memobj.memory[mem.number - 1]
 
         if mem.empty:
-            _mem.set_raw("\xFF" * 16)
+            _mem.set_raw(b"\xFF" * 16)
             return
 
         if mem.number not in SPECIAL_CHANNELS:
@@ -567,327 +544,187 @@ class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRad
         top = RadioSettings(basic, display, scan, buttons, vfo, advanced, aprs)
 
         basic.append(
-            RadioSetting(
-                "save",
-                "Power Save",
-                RadioSettingValueBoolean(_settings.save),
-            )
-        )
+            RadioSetting("save", "Power Save",
+                         RadioSettingValueBoolean(_settings.save)))
         basic.append(
-            RadioSetting(
-                "roger",
-                "Roger Beep",
-                RadioSettingValueList(ROGER_LIST, ROGER_LIST[_settings.roger]),
-            )
-        )
+            RadioSetting("roger", "Roger Beep",
+                         RadioSettingValueList(ROGER_LIST,
+                                               ROGER_LIST[_settings.roger])))
         basic.append(
-            RadioSetting(
-                "beep",
-                "System Beep",
-                RadioSettingValueBoolean(_settings.beep),
-            )
-        )
+            RadioSetting("beep", "System Beep",
+                         RadioSettingValueBoolean(_settings.beep)))
         basic.append(
-            RadioSetting(
-                "tot",
-                "Timeout Timer (sec)",
-                RadioSettingValueList(TOT_LIST, TOT_LIST[_settings.tot]),
-            )
-        )
+            RadioSetting("tot", "Timeout Timer (sec)",
+                         RadioSettingValueList(TOT_LIST,
+                                               TOT_LIST[_settings.tot])))
         basic.append(
-            RadioSetting(
-                "toa",
-                "Timeout Timer Alarm",
-                RadioSettingValueList(TOA_LIST, TOA_LIST[_settings.toa]),
-            )
-        )
+            RadioSetting("toa", "Timeout Timer Alarm",
+                         RadioSettingValueList(TOA_LIST,
+                                               TOA_LIST[_settings.toa])))
         basic.append(
-            RadioSetting(
-                "lockmode",
-                "Lock Mode",
-                RadioSettingValueList(LOCKMODE_LIST, LOCKMODE_LIST[_settings.lockmode]),
-            )
-        )
+            RadioSetting("lockmode", "Lock Mode",
+                         RadioSettingValueList(
+                            LOCKMODE_LIST,
+                            LOCKMODE_LIST[_settings.lockmode])))
         basic.append(
-            RadioSetting(
-                "autolock",
-                "Auto Lock",
-                RadioSettingValueList(AUTOLOCK_LIST, AUTOLOCK_LIST[_settings.autolock]),
-            )
-        )
+            RadioSetting("autolock", "Auto Lock",
+                         RadioSettingValueList(
+                            AUTOLOCK_LIST,
+                            AUTOLOCK_LIST[_settings.autolock])))
         basic.append(
-            RadioSetting(
-                "auto_lock_dly",
-                "Auto Lock Delay",
-                RadioSettingValueList(AUTOLOCK_DLY_LIST, AUTOLOCK_DLY_LIST[_settings.auto_lock_dly]),
-            )
-        )
+            RadioSetting("auto_lock_dly", "Auto Lock Delay",
+                         RadioSettingValueList(
+                            AUTOLOCK_DLY_LIST,
+                            AUTOLOCK_DLY_LIST[_settings.auto_lock_dly])))
         display.append(
-            RadioSetting(
-                "abr",
-                "Screen Save",
-                RadioSettingValueList(ABR_LIST, ABR_LIST[_settings.abr]),
-            )
-        )
+            RadioSetting("abr", "Screen Save",
+                         RadioSettingValueList(ABR_LIST,
+                                               ABR_LIST[_settings.abr])))
         display.append(
-            RadioSetting(
-                "abr_lv",
-                "Back Light Brightness",
-                RadioSettingValueList(ABR_LV_LIST, ABR_LV_LIST[_settings.abr_lv]),
-            )
-        )
+            RadioSetting("abr_lv", "Back Light Brightness",
+                         RadioSettingValueList(ABR_LV_LIST,
+                                               ABR_LV_LIST[_settings.abr_lv])))
         display.append(
-            RadioSetting(
-                "night_mode",
-                "Night Mode (Light on Dark)",
-                RadioSettingValueBoolean(_settings.night_mode),
-            )
-        )
+            RadioSetting("night_mode", "Night Mode (Light on Dark)",
+                         RadioSettingValueBoolean(_settings.night_mode)))
         display.append(
-            RadioSetting(
-                "menu_dly",
-                "Menu Delay",
-                RadioSettingValueList(MENU_DLY_LIST, MENU_DLY_LIST[_settings.menu_dly]),
-            )
-        )
+            RadioSetting("menu_dly", "Menu Delay",
+                         RadioSettingValueList(
+                            MENU_DLY_LIST,
+                            MENU_DLY_LIST[_settings.menu_dly])))
         display.append(
-            RadioSetting(
-                "english",
-                "Language",
-                RadioSettingValueList(LANG_LIST, LANG_LIST[_settings.english]),
-            )
-        )
+            RadioSetting("english", "Language",
+                         RadioSettingValueList(LANG_LIST,
+                                               LANG_LIST[_settings.english])))
         scan.append(
-            RadioSetting(
-                "pri_scn",
-                "Priority Scan",
-                RadioSettingValueBoolean(_settings.pri_scn),
-            )
-        )
+            RadioSetting("pri_scn", "Priority Scan",
+                         RadioSettingValueBoolean(_settings.pri_scn)))
         scan.append(
-            RadioSetting(
-                "pri_ch",
-                "Priority Channel",
-                RadioSettingValueChannel(self, _settings.pri_ch),
-            )
-        )
+            RadioSetting("pri_ch", "Priority Channel",
+                         RadioSettingValueChannel(self, _settings.pri_ch)))
         scan.append(
-            RadioSetting(
-                "sc_rev",
-                "Scan Resume",
-                RadioSettingValueList(SC_REV_LIST, SC_REV_LIST[_settings.sc_rev]),
-            )
-        )
+            RadioSetting("sc_rev", "Scan Resume",
+                         RadioSettingValueList(SC_REV_LIST,
+                                               SC_REV_LIST[_settings.sc_rev])))
         scan.append(
-            RadioSetting(
-                "sc_qt",
-                "Code Save",
-                RadioSettingValueList(SC_QT_LIST, SC_QT_LIST[_settings.sc_qt]),
-            )
-        )
+            RadioSetting("sc_qt", "Code Save",
+                         RadioSettingValueList(SC_QT_LIST,
+                                               SC_QT_LIST[_settings.sc_qt])))
         buttons.append(
-            RadioSetting(
-                "pf1_short",
-                "PF1 (Side, Upper) Button Short Press",
-                RadioSettingValueList(PF1_LIST, PF1_LIST[_settings.pf1_short]),
-            )
-        )
+            RadioSetting("pf1_short", "PF1 (Side, Upper) Button Short Press",
+                         RadioSettingValueList(PF1_LIST,
+                                               PF1_LIST[_settings.pf1_short])))
         buttons.append(
-            RadioSetting(
-                "pf1_long",
-                "PF1 (Side, Upper) Button Long Press",
-                RadioSettingValueList(PF1_LIST, PF1_LIST[_settings.pf1_long]),
-            )
-        )
+            RadioSetting("pf1_long", "PF1 (Side, Upper) Button Long Press",
+                         RadioSettingValueList(PF1_LIST,
+                                               PF1_LIST[_settings.pf1_long])))
         buttons.append(
-            RadioSetting(
-                "pf2_short",
-                "PF2 (Side, Lower) Button Short Press",
-                RadioSettingValueList(PF2_LIST, PF2_LIST[_settings.pf2_short]),
-            )
-        )
+            RadioSetting("pf2_short", "PF2 (Side, Lower) Button Short Press",
+                         RadioSettingValueList(PF2_LIST,
+                                               PF2_LIST[_settings.pf2_short])))
         buttons.append(
-            RadioSetting(
-                "pf2_long",
-                "PF2 (Side, Lower) Button Long Press",
-                RadioSettingValueList(PF2_LIST, PF2_LIST[_settings.pf2_long]),
-            )
-        )
+            RadioSetting("pf2_long", "PF2 (Side, Lower) Button Long Press",
+                         RadioSettingValueList(PF2_LIST,
+                                               PF2_LIST[_settings.pf2_long])))
         buttons.append(
-            RadioSetting(
-                "top_short",
-                "Top Button Short Press",
-                RadioSettingValueList(TOP_LIST, TOP_LIST[_settings.top_short]),
-            )
-        )
+            RadioSetting("top_short", "Top Button Short Press",
+                         RadioSettingValueList(TOP_LIST,
+                                               TOP_LIST[_settings.top_short])))
         buttons.append(
-            RadioSetting(
-                "top_long",
-                "Top Button Long Press",
-                RadioSettingValueList(TOP_LIST, TOP_LIST[_settings.top_long]),
-            )
-        )
+            RadioSetting("top_long", "Top Button Long Press",
+                         RadioSettingValueList(TOP_LIST,
+                                               TOP_LIST[_settings.top_long])))
         vfo.append(
-            RadioSetting(
-                "tdr",
-                "VFO B Enabled",
-                RadioSettingValueBoolean(_settings.tdr),
-            )
-        )
+            RadioSetting("tdr", "VFO B Enabled",
+                         RadioSettingValueBoolean(_settings.tdr)))
         vfo.append(
-            RadioSetting(
-                "ch_a_step",
-                "VFO Frequency Step (A)",
-                RadioSettingValueList(STEP_LIST, STEP_LIST[_settings.ch_a_step]),
-            )
-        )
+            RadioSetting("ch_a_step", "VFO Frequency Step (A)",
+                         RadioSettingValueList(
+                            STEP_LIST,
+                            STEP_LIST[_settings.ch_a_step])))
         vfo.append(
-            RadioSetting(
-                "ch_b_step",
-                "VFO Frequency Step (B)",
-                RadioSettingValueList(STEP_LIST, STEP_LIST[_settings.ch_b_step]),
-            )
-        )
+            RadioSetting("ch_b_step", "VFO Frequency Step (B)",
+                         RadioSettingValueList(
+                            STEP_LIST,
+                            STEP_LIST[_settings.ch_b_step])))
         vfo.append(
-            RadioSetting(
-                "ch_a_sql",
-                "Squelch (A)",
-                RadioSettingValueList(SQL_LIST, SQL_LIST[_settings.ch_a_sql]),
-            )
-        )
+            RadioSetting("ch_a_sql", "Squelch (A)",
+                RadioSettingValueList(SQL_LIST,
+                                      SQL_LIST[_settings.ch_a_sql])))
         vfo.append(
-            RadioSetting(
-                "ch_b_sql",
-                "Squelch (B)",
-                RadioSettingValueList(SQL_LIST, SQL_LIST[_settings.ch_b_sql]),
-            )
-        )
+            RadioSetting("ch_b_sql", "Squelch (B)",
+                         RadioSettingValueList(SQL_LIST,
+                                               SQL_LIST[_settings.ch_b_sql])))
         vfo.append(
-            RadioSetting(
-                "ch_a_mem_ch",
-                "Memory Channel (A)",
-                RadioSettingValueChannel(self, _settings.ch_a_mem_ch),
-            )
-        )
+            RadioSetting("ch_a_mem_ch", "Memory Channel (A)",
+                         RadioSettingValueChannel(self,
+                                                  _settings.ch_a_mem_ch)))
         vfo.append(
-            RadioSetting(
-                "ch_b_mem_ch",
-                "Memory Channel (B)",
-                RadioSettingValueChannel(self, _settings.ch_b_mem_ch),
-            )
-        )
+            RadioSetting("ch_b_mem_ch", "Memory Channel (B)",
+                         RadioSettingValueChannel(self,
+                                                  _settings.ch_b_mem_ch)))
         vfo.append(
-            RadioSetting(
-                "ch_a_ch_mdf",
-                "Memory Display Format (A)",
-                RadioSettingValueList(MDF_LIST, MDF_LIST[_settings.ch_a_ch_mdf]),
-            )
-        )
+            RadioSetting("ch_a_ch_mdf", "Memory Display Format (A)",
+                         RadioSettingValueList(
+                            MDF_LIST,
+                            MDF_LIST[_settings.ch_a_ch_mdf])))
         vfo.append(
-            RadioSetting(
-                "ch_b_ch_mdf",
-                "Memory Display Format (B)",
-                RadioSettingValueList(MDF_LIST, MDF_LIST[_settings.ch_b_ch_mdf]),
-            )
-        )
+            RadioSetting("ch_b_ch_mdf", "Memory Display Format (B)",
+                         RadioSettingValueList(
+                            MDF_LIST,
+                            MDF_LIST[_settings.ch_b_ch_mdf])))
         vfo.append(
-            RadioSetting(
-                "ch_a_v_m",
-                "VFO/MEM (A)",
-                RadioSettingValueList(VM_LIST, VM_LIST[_settings.ch_a_v_m]),
-            )
-        )
+            RadioSetting("ch_a_v_m", "VFO/MEM (A)",
+                         RadioSettingValueList(
+                             VM_LIST, VM_LIST[_settings.ch_a_v_m])))
         vfo.append(
-            RadioSetting(
-                "ch_b_v_m",
-                "VFO/MEM (B)",
-                RadioSettingValueList(VM_LIST, VM_LIST[_settings.ch_b_v_m]),
-            )
-        )
+            RadioSetting("ch_b_v_m", "VFO/MEM (B)",
+                         RadioSettingValueList(
+                             VM_LIST, VM_LIST[_settings.ch_b_v_m])))
         advanced.append(
-            RadioSetting(
-                "vox_grd",
-                "VOX Sensitivity",
-                RadioSettingValueList(VOX_LIST, VOX_LIST[_settings.vox_grd]),
-            )
-        )
+            RadioSetting("vox_grd", "VOX Sensitivity",
+                         RadioSettingValueList(
+                             VOX_LIST, VOX_LIST[_settings.vox_grd])))
         advanced.append(
-            RadioSetting(
-                "vox_dly",
-                "VOX Delay",
-                RadioSettingValueList(VOX_DLY_LIST, VOX_DLY_LIST[_settings.vox_dly]),
-            )
-        )
+            RadioSetting("vox_dly", "VOX Delay",
+                         RadioSettingValueList(
+                             VOX_DLY_LIST, VOX_DLY_LIST[_settings.vox_dly])))
         advanced.append(
-            RadioSetting(
-                "voice",
-                "Voice Assist",
-                RadioSettingValueBoolean(_settings.voice),
-            )
-        )
+            RadioSetting("voice", "Voice Assist",
+                         RadioSettingValueBoolean(_settings.voice)))
         advanced.append(
-            RadioSetting(
-                "rpt_rct",
-                "RPT Roger",
-                RadioSettingValueBoolean(_settings.rpt_rct),
-            )
-        )
+            RadioSetting("rpt_rct", "RPT Roger",
+                         RadioSettingValueBoolean(_settings.rpt_rct)))
         aprs.append(
-            RadioSetting(
-                "aprs_rx_band",
-                "RX Band",
-                RadioSettingValueList(APRS_RX_LIST, APRS_RX_LIST[_settings.aprs_rx_band]),
-            )
-        )
+            RadioSetting("aprs_rx_band", "RX Band",
+                         RadioSettingValueList(
+                             APRS_RX_LIST,
+                             APRS_RX_LIST[_settings.aprs_rx_band])))
         aprs.append(
-            RadioSetting(
-                "ch_a_mute",
-                "Band A Mute",
-                RadioSettingValueBoolean(_settings.ch_a_mute),
-            )
-        )
+            RadioSetting("ch_a_mute", "Band A Mute",
+                         RadioSettingValueBoolean(_settings.ch_a_mute)))
         aprs.append(
-            RadioSetting(
-                "ch_b_mute",
-                "Band B Mute",
-                RadioSettingValueBoolean(_settings.ch_b_mute),
-            )
-        )
+            RadioSetting("ch_b_mute", "Band B Mute",
+                         RadioSettingValueBoolean(_settings.ch_b_mute)))
         aprs.append(
-            RadioSetting(
-                "tx_priority",
-                "TX Priority",
-                RadioSettingValueList(TX_PRIORITY_LIST, TX_PRIORITY_LIST[_settings.tx_priority]),
-            )
-        )
+            RadioSetting("tx_priority", "TX Priority",
+                RadioSettingValueList(
+                    TX_PRIORITY_LIST,
+                    TX_PRIORITY_LIST[_settings.tx_priority])))
         aprs.append(
-            RadioSetting(
-                "aprs_rx_popup",
-                "APRS Popup",
-                RadioSettingValueBoolean(_settings.aprs_rx_popup),
-            )
-        )
+            RadioSetting("aprs_rx_popup", "APRS Popup",
+                         RadioSettingValueBoolean(_settings.aprs_rx_popup)))
         aprs.append(
-            RadioSetting(
-                "aprs_rx_tone",
-                "RX Tone",
-                RadioSettingValueBoolean(_settings.aprs_rx_tone),
-            )
-        )
+            RadioSetting("aprs_rx_tone", "RX Tone",
+                         RadioSettingValueBoolean(_settings.aprs_rx_tone)))
         aprs.append(
-            RadioSetting(
-                "aprs_tx_tone",
-                "TX Tone",
-                RadioSettingValueBoolean(_settings.aprs_tx_tone),
-            )
-        )
+            RadioSetting("aprs_tx_tone", "TX Tone",
+                         RadioSettingValueBoolean(_settings.aprs_tx_tone)))
         aprs.append(
-            RadioSetting(
-                "beacon_exit_dly",
-                "Beacon Message Delay",
-                RadioSettingValueList(BEACON_EXIT_DLY_LIST, BEACON_EXIT_DLY_LIST[_settings.beacon_exit_dly]),
-            )
-        )
+            RadioSetting("beacon_exit_dly", "Beacon Message Delay",
+                         RadioSettingValueList(
+                             BEACON_EXIT_DLY_LIST,
+                             BEACON_EXIT_DLY_LIST[_settings.beacon_exit_dly])))
 
         return top
 
@@ -904,7 +741,3 @@ class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRad
 
             if hasattr(_settings, name):
                 setattr(_settings, name, value)
-
-
-if has_future:
-    LanchonlhHG_UV98 = directory.register(LanchonlhHG_UV98)

--- a/chirp/drivers/hg_uv98.py
+++ b/chirp/drivers/hg_uv98.py
@@ -314,7 +314,7 @@ class RadioSettingValueChannel(RadioSettingValueList):
             return str(int(m.number))
         return "{} {:.4f} {}".format(int(m.number), m.freq / float(1e6), m.name)
 
-    def __trunc__(self):
+    def __int__(self):
         return int(self.get_value().partition(" ")[0])
 
 

--- a/chirp/drivers/hg_uv98.py
+++ b/chirp/drivers/hg_uv98.py
@@ -442,7 +442,7 @@ class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRad
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[:4] == "\xFF\xFF\xFF\xFF":
+        if _mem.get_raw(asbytes=False)[:4] == "\xFF\xFF\xFF\xFF":
             mem.empty = True
             return mem
 
@@ -450,7 +450,7 @@ class LanchonlhHG_UV98(chirp_common.CloneModeRadio, chirp_common.ExperimentalRad
             mem.name, mem.extd_number = SPECIAL_CHANNELS[mem.number]
         else:
             _name = self._memobj.name[number - 1]
-            mem.name, _, _ = _name.name.get_raw().partition("\xFF")
+            mem.name, _, _ = _name.name.get_raw(asbytes=False).partition("\xFF")
         # XXX: other drivers rstrip the name and test_badname enforces this
         mem.name = mem.name.rstrip()
         mem.freq = int(_mem.rx_freq) * 10

--- a/chirp/drivers/ic2100.py
+++ b/chirp/drivers/ic2100.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from chirp.drivers import icf
-from chirp import chirp_common, util, directory, bitwise, memmap
+from chirp import chirp_common, util, directory, bitwise
 from chirp.settings import RadioSetting, RadioSettingGroup, \
     RadioSettingValueBoolean
 
@@ -132,13 +132,13 @@ def _set_freq(mem, freq):
 
 
 def _get_offset(mem):
-    raw = memmap.MemoryMap(mem.get_raw(asbytes=False))
-    if ord(raw[5]) & 0x0A:
-        raw[5] = ord(raw[5]) & 0xF0
-        mem.set_raw(raw.get_packed())
+    raw = bytearray(mem.get_raw())
+    if raw[5] & 0x0A:
+        raw[5] = raw[5] & 0xF0
+        mem.set_raw(raw)
         offset = int(mem.offset) * 1000 + 5000
-        raw[5] = ord(raw[5]) | 0x0A
-        mem.set_raw(raw.get_packed())
+        raw[5] = raw[5] | 0x0A
+        mem.set_raw(bytes(raw))
         return offset
     else:
         return int(mem.offset) * 1000
@@ -152,9 +152,9 @@ def _set_offset(mem, offset):
         extra = 0x00
 
     mem.offset = offset / 1000
-    raw = memmap.MemoryMap(mem.get_raw(asbytes=False))
-    raw[5] = ord(raw[5]) | extra
-    mem.set_raw(raw.get_packed())
+    raw = bytearray(mem.get_raw())
+    raw[5] = raw[5] | extra
+    mem.set_raw(bytes(raw))
 
 
 def _wipe_memory(mem, char):

--- a/chirp/drivers/ic2100.py
+++ b/chirp/drivers/ic2100.py
@@ -132,7 +132,7 @@ def _set_freq(mem, freq):
 
 
 def _get_offset(mem):
-    raw = memmap.MemoryMap(mem.get_raw())
+    raw = memmap.MemoryMap(mem.get_raw(asbytes=False))
     if ord(raw[5]) & 0x0A:
         raw[5] = ord(raw[5]) & 0xF0
         mem.set_raw(raw.get_packed())
@@ -152,7 +152,7 @@ def _set_offset(mem, offset):
         extra = 0x00
 
     mem.offset = offset / 1000
-    raw = memmap.MemoryMap(mem.get_raw())
+    raw = memmap.MemoryMap(mem.get_raw(asbytes=False))
     raw[5] = ord(raw[5]) | extra
     mem.set_raw(raw.get_packed())
 

--- a/chirp/drivers/ict8.py
+++ b/chirp/drivers/ict8.py
@@ -117,7 +117,7 @@ class ICT8ARadio(icf.IcomCloneModeRadio):
         mem.duplex = DUPLEX[_flg.duplex]
         mem.tmode = TMODES[_flg.tmode]
         mem.skip = _flg.skip and "S" or ""
-        if _name.name.get_raw() != "\xFF\xFF\xFF\xFF":
+        if _name.name.get_raw(asbytes=False) != "\xFF\xFF\xFF\xFF":
             mem.name = str(_name.name).rstrip()
 
         return mem

--- a/chirp/drivers/iradio_uv_5118.py
+++ b/chirp/drivers/iradio_uv_5118.py
@@ -455,12 +455,12 @@ class IradioUV5118(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
 
-        if _mem.get_raw() == ("\xFF" * 16):
+        if _mem.get_raw(asbytes=False) == ("\xFF" * 16):
             LOG.debug("Initializing empty memory")
             _mem.set_raw("\xFF" * 4 + "\x00\x30" + "\xFF" * 4 + "\x00\x30" +
                          "\x00" * 4)

--- a/chirp/drivers/iradio_uv_5118plus.py
+++ b/chirp/drivers/iradio_uv_5118plus.py
@@ -498,7 +498,7 @@ class IradioUV5118plus(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem

--- a/chirp/drivers/kyd.py
+++ b/chirp/drivers/kyd.py
@@ -312,7 +312,7 @@ class NC630aRadio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem

--- a/chirp/drivers/kyd_IP620.py
+++ b/chirp/drivers/kyd_IP620.py
@@ -372,7 +372,7 @@ class IP620Radio(chirp_common.CloneModeRadio,
 
         def _is_empty():
             for i in range(0, 4):
-                if _mem.rx_freq[i].get_raw() != "\xFF":
+                if _mem.rx_freq[i].get_raw(asbytes=False) != "\xFF":
                     return False
             return True
 

--- a/chirp/drivers/leixen.py
+++ b/chirp/drivers/leixen.py
@@ -474,7 +474,7 @@ class LeixenVV898Radio(chirp_common.CloneModeRadio):
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.tx_freq[i].get_raw()
+            raw_tx += _mem.tx_freq[i].get_raw(asbytes=False)
         return raw_tx == b"\xFF\xFF\xFF\xFF"
 
     def _get_memobjs(self, number):
@@ -488,7 +488,7 @@ class LeixenVV898Radio(chirp_common.CloneModeRadio):
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[:4] == "\xFF\xFF\xFF\xFF":
+        if _mem.get_raw(asbytes=False)[:4] == "\xFF\xFF\xFF\xFF":
             mem.empty = True
             return mem
 
@@ -590,7 +590,7 @@ class LeixenVV898Radio(chirp_common.CloneModeRadio):
         if mem.empty:
             _mem.set_raw(b"\xFF" * 16)
             return
-        elif _mem.get_raw() == (b"\xFF" * 16):
+        elif _mem.get_raw(asbytes=False) == (b"\xFF" * 16):
             _mem.set_raw(b"\xFF" * 8 + b"\xFF\x00\xFF\x00\xFF\xFE\xF0\xFC")
 
         _mem.rx_freq = mem.freq / 10

--- a/chirp/drivers/lt725uv.py
+++ b/chirp/drivers/lt725uv.py
@@ -595,7 +595,7 @@ class LT725UV(chirp_common.CloneModeRadio):
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/mml_jc8810.py
+++ b/chirp/drivers/mml_jc8810.py
@@ -493,7 +493,7 @@ class JC8810base(chirp_common.CloneModeRadio):
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.txfreq[i].get_raw()
+            raw_tx += _mem.txfreq[i].get_raw(asbytes=False)
         return raw_tx == "\xFF\xFF\xFF\xFF"
 
     def get_memory(self, number):
@@ -506,14 +506,14 @@ class JC8810base(chirp_common.CloneModeRadio):
         # Memory number
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 
         # Freq and offset
         mem.freq = int(_mem.rxfreq) * 10
         # tx freq can be blank
-        if _mem.get_raw()[4] == "\xFF":
+        if _mem.get_raw(asbytes=False)[4] == "\xFF":
             # TX freq not set
             mem.offset = 0
             mem.duplex = "off"

--- a/chirp/drivers/mursv1.py
+++ b/chirp/drivers/mursv1.py
@@ -369,7 +369,7 @@ class MURSV1(baofeng_common.BaofengCommonHT):
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/puxing.py
+++ b/chirp/drivers/puxing.py
@@ -218,12 +218,12 @@ class Puxing777Radio(chirp_common.CloneModeRadio):
 
         def _is_empty():
             for i in range(0, 4):
-                if _mem.rx_freq[i].get_raw() != "\xFF":
+                if _mem.rx_freq[i].get_raw(asbytes=False) != "\xFF":
                     return False
             return True
 
         def _is_no_tone(field):
-            return field.get_raw() in ["\x00\x00", "\xFF\xFF"]
+            return field.get_raw(asbytes=False) in ["\x00\x00", "\xFF\xFF"]
 
         def _get_dtcs(value):
             # Upper nibble 0x80 -> DCS, 0xC0 -> Inv. DCS
@@ -238,12 +238,12 @@ class Puxing777Radio(chirp_common.CloneModeRadio):
             if int(txfield) < 8000 or int(rxfield) < 8000:
                 raise Exception("Split tone not supported")
 
-            if txfield[0].get_raw() == "\xFF":
+            if txfield[0].get_raw(asbytes=False) == "\xFF":
                 tp, tx = "N", None
             else:
                 tp, tx = _get_dtcs(int(txfield))
 
-            if rxfield[0].get_raw() == "\xFF":
+            if rxfield[0].get_raw(asbytes=False) == "\xFF":
                 rp, rx = "N", None
             else:
                 rp, rx = _get_dtcs(int(rxfield))
@@ -328,8 +328,10 @@ class Puxing777Radio(chirp_common.CloneModeRadio):
             # Argh.  Set the high order two bits to signal DCS or Inv. DCS
             txm = mem.dtcs_polarity[0] == "N" and 0x80 or 0xC0
             rxm = mem.dtcs_polarity[1] == "N" and 0x80 or 0xC0
-            _mem.tx_tone[1].set_raw(chr(ord(_mem.tx_tone[1].get_raw()) | txm))
-            _mem.rx_tone[1].set_raw(chr(ord(_mem.rx_tone[1].get_raw()) | rxm))
+            _mem.tx_tone[1].set_raw(
+                chr(ord(_mem.tx_tone[1].get_raw(asbytes=False)) | txm))
+            _mem.rx_tone[1].set_raw(
+                chr(ord(_mem.rx_tone[1].get_raw(asbytes=False)) | rxm))
 
         elif mem.tmode:
             _mem.tx_tone = int(mem.rtone * 10)
@@ -459,7 +461,7 @@ class Puxing2RRadio(chirp_common.CloneModeRadio):
 
         mem = chirp_common.Memory()
         mem.number = number
-        if _mem.get_raw()[0:4] == "\xff\xff\xff\xff":
+        if _mem.get_raw(asbytes=False)[0:4] == "\xff\xff\xff\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/radioddity_r2.py
+++ b/chirp/drivers/radioddity_r2.py
@@ -399,7 +399,7 @@ class RadioddityR2(chirp_common.CloneModeRadio):
     def decode_tone(self, val):
         """Parse the tone data to decode from mem, it returns:
         Mode (''|DTCS|Tone), Value (None|###), Polarity (None,N,R)"""
-        if val.get_raw() == "\xFF\xFF":
+        if val.get_raw(asbytes=False) == "\xFF\xFF":
             return '', None, None
 
         val = int(val)
@@ -449,7 +449,7 @@ class RadioddityR2(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rx_freq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rx_freq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
@@ -541,7 +541,7 @@ class RadioddityR2(chirp_common.CloneModeRadio):
         # Get a low-level memory object mapped to the image
         _mem = self._memobj.memory[mem.number - 1]
 
-        _rsvd = _mem.reserved.get_raw()
+        _rsvd = _mem.reserved.get_raw(asbytes=False)
 
         if mem.empty:
             _mem.set_raw("\xFF" * 13 + _rsvd)

--- a/chirp/drivers/radtel_t18.py
+++ b/chirp/drivers/radtel_t18.py
@@ -485,12 +485,12 @@ class T18Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
 
-        if _mem.txfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.txfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.duplex = "off"
             mem.offset = 0
         elif int(_mem.rxfreq) == int(_mem.txfreq):

--- a/chirp/drivers/retevis_rb15.py
+++ b/chirp/drivers/retevis_rb15.py
@@ -472,19 +472,19 @@ class RB15RadioBase(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
 
-        if _mem.get_raw() == ("\xFF" * 16):
+        if _mem.get_raw(asbytes=False) == ("\xFF" * 16):
             LOG.debug("Initializing empty memory")
             _mem.set_raw("\x00" * 16)
 
         # Freq and offset
         mem.freq = int(_mem.rxfreq) * 10
         # tx freq can be blank
-        if _mem.get_raw()[4] == "\xFF":
+        if _mem.get_raw(asbytes=False)[4] == "\xFF":
             # TX freq not set
             mem.offset = 0
             mem.duplex = "off"

--- a/chirp/drivers/retevis_rb17p.py
+++ b/chirp/drivers/retevis_rb17p.py
@@ -325,12 +325,12 @@ class RB17P_Base(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
 
-        if _mem.txfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.txfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.duplex = "off"
             mem.offset = 0
         elif int(_mem.rxfreq) == int(_mem.txfreq):

--- a/chirp/drivers/retevis_rb28.py
+++ b/chirp/drivers/retevis_rb28.py
@@ -394,7 +394,7 @@ class RB28Radio(chirp_common.CloneModeRadio):
         _mem = self._memobj.memory[number - 1]
 
         if self._reserved:
-            _rsvd = _mem.reserved.get_raw()
+            _rsvd = _mem.reserved.get_raw(asbytes=False)
 
         mem.freq = int(_mem.rxfreq) * 10
 
@@ -403,7 +403,7 @@ class RB28Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
@@ -511,7 +511,7 @@ class RB28Radio(chirp_common.CloneModeRadio):
         _mem = self._memobj.memory[mem.number - 1]
 
         if self._reserved:
-            _rsvd = _mem.reserved.get_raw()
+            _rsvd = _mem.reserved.get_raw(asbytes=False)
 
         if mem.empty:
             if self._reserved:

--- a/chirp/drivers/retevis_rt1.py
+++ b/chirp/drivers/retevis_rt1.py
@@ -381,7 +381,7 @@ class RT1Radio(chirp_common.CloneModeRadio):
     def decode_tone(self, val):
         """Parse the tone data to decode from mem, it returns:
         Mode (''|DTCS|Tone), Value (None|###), Polarity (None,N,R)"""
-        if val.get_raw() == "\xFF\xFF":
+        if val.get_raw(asbytes=False) == "\xFF\xFF":
             return '', None, None
 
         val = int(val)
@@ -426,7 +426,7 @@ class RT1Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem

--- a/chirp/drivers/retevis_rt21.py
+++ b/chirp/drivers/retevis_rt21.py
@@ -901,7 +901,7 @@ class RT21Radio(chirp_common.CloneModeRadio):
             _mem = self._memobj.memory[number - 1]
 
         if self._reserved:
-            _rsvd = _mem.reserved.get_raw()
+            _rsvd = _mem.reserved.get_raw(asbytes=False)
 
         mem.freq = int(_mem.rxfreq) * 10
 
@@ -910,7 +910,7 @@ class RT21Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
@@ -1176,7 +1176,7 @@ class RT21Radio(chirp_common.CloneModeRadio):
             _mem = self._memobj.memory[mem.number - 1]
 
         if self._reserved:
-            _rsvd = _mem.reserved.get_raw()
+            _rsvd = _mem.reserved.get_raw(asbytes=False)
 
         if self.MODEL == "RT86":
             _freqhops = self._memobj.freqhops[mem.number - 1]

--- a/chirp/drivers/retevis_rt22.py
+++ b/chirp/drivers/retevis_rt22.py
@@ -462,7 +462,7 @@ class RT22Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem

--- a/chirp/drivers/retevis_rt23.py
+++ b/chirp/drivers/retevis_rt23.py
@@ -430,7 +430,7 @@ class RT23Radio(chirp_common.CloneModeRadio):
     def decode_tone(self, val):
         """Parse the tone data to decode from mem, it returns:
         Mode (''|DTCS|Tone), Value (None|###), Polarity (None,N,R)"""
-        if val.get_raw() == "\xFF\xFF":
+        if val.get_raw(asbytes=False) == "\xFF\xFF":
             return '', None, None
 
         val = int(val)
@@ -481,18 +481,18 @@ class RT23Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.empty = True
             return mem
 
-        if _mem.get_raw() == ("\xFF" * 16):
+        if _mem.get_raw(asbytes=False) == ("\xFF" * 16):
             LOG.debug("Initializing empty memory")
             _mem.set_raw("\x00" * 16)
 
         # Freq and offset
         mem.freq = int(_mem.rxfreq) * 10
         # tx freq can be blank
-        if _mem.get_raw()[4] == "\xFF":
+        if _mem.get_raw(asbytes=False)[4] == "\xFF":
             # TX freq not set
             mem.offset = 0
             mem.duplex = "off"
@@ -568,7 +568,7 @@ class RT23Radio(chirp_common.CloneModeRadio):
         else:
             _usd |= bitpos
 
-        if _mem.get_raw() == ("\xFF" * 16):
+        if _mem.get_raw(asbytes=False) == ("\xFF" * 16):
             LOG.debug("Initializing empty memory")
             _mem.set_raw("\x00" * 16)
             _scn |= bitpos

--- a/chirp/drivers/retevis_rt26.py
+++ b/chirp/drivers/retevis_rt26.py
@@ -393,7 +393,7 @@ class RT26Radio(chirp_common.CloneModeRadio):
     def decode_tone(self, val):
         """Parse the tone data to decode from mem, it returns:
         Mode (''|DTCS|Tone), Value (None|###), Polarity (None,N,R)"""
-        if val.get_raw() == "\xFF\xFF":
+        if val.get_raw(asbytes=False) == "\xFF\xFF":
             return '', None, None
 
         val = int(val)
@@ -438,7 +438,7 @@ class RT26Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw() == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem

--- a/chirp/drivers/retevis_rt76p.py
+++ b/chirp/drivers/retevis_rt76p.py
@@ -411,7 +411,7 @@ class RT76PRadio(chirp_common.CloneModeRadio):
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.txfreq[i].get_raw()
+            raw_tx += _mem.txfreq[i].get_raw(asbytes=False)
         return raw_tx == "\xFF\xFF\xFF\xFF"
 
     def get_memory(self, number):
@@ -421,7 +421,7 @@ class RT76PRadio(chirp_common.CloneModeRadio):
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/retevis_rt87.py
+++ b/chirp/drivers/retevis_rt87.py
@@ -448,7 +448,7 @@ class Rt87BaseRadio(chirp_common.CloneModeRadio):
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.tx_freq[i].get_raw()
+            raw_tx += _mem.tx_freq[i].get_raw(asbytes=False)
         return raw_tx == "\xFF\xFF\xFF\xFF"
 
     def _bbcd2num(self, bcdarr, strlen=8):
@@ -478,7 +478,7 @@ class Rt87BaseRadio(chirp_common.CloneModeRadio):
         else:
             mem.number = number
 
-        if _mem.get_raw().startswith("\xFF\xFF\xFF\xFF"):
+        if _mem.get_raw(asbytes=False).startswith("\xFF\xFF\xFF\xFF"):
             mem.empty = True
             return mem
 

--- a/chirp/drivers/retevis_rt98.py
+++ b/chirp/drivers/retevis_rt98.py
@@ -860,7 +860,7 @@ class Rt98BaseRadio(chirp_common.CloneModeRadio,
             mem.empty = True
             return mem
 
-        if _mem.get_raw()[0] == "\xFF":
+        if _mem.get_raw(asbytes=False)[0] == "\xFF":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/rh5r_v2.py
+++ b/chirp/drivers/rh5r_v2.py
@@ -220,7 +220,7 @@ class TYTTHUVF8_V2(chirp_common.CloneModeRadio):
         else:
             mem.number = number
 
-        if _mem.get_raw().startswith("\xFF\xFF\xFF\xFF"):
+        if _mem.get_raw(asbytes=False).startswith("\xFF\xFF\xFF\xFF"):
             mem.empty = True
             return mem
 

--- a/chirp/drivers/tdh8.py
+++ b/chirp/drivers/tdh8.py
@@ -783,7 +783,7 @@ class TDH8(chirp_common.CloneModeRadio):
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/tdxone_tdq8a.py
+++ b/chirp/drivers/tdxone_tdq8a.py
@@ -531,7 +531,7 @@ class TDXoneTDQ8A(chirp_common.CloneModeRadio,
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.txfreq[i].get_raw()
+            raw_tx += _mem.txfreq[i].get_raw(asbytes=False)
         return raw_tx == "\xFF\xFF\xFF\xFF"
 
     def _get_mem(self, number):
@@ -547,7 +547,7 @@ class TDXoneTDQ8A(chirp_common.CloneModeRadio,
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/tg_uv2p.py
+++ b/chirp/drivers/tg_uv2p.py
@@ -352,13 +352,14 @@ class QuanshengTGUV2P(chirp_common.CloneModeRadio,
         else:
             mem.number = number
 
-        if (_mem.freq.get_raw()[0] == "\xFF") or (_bf.band == "\x0F"):
+        if ((_mem.freq.get_raw(asbytes=False)[0] == "\xFF") or
+                (_bf.band == "\x0F")):
             mem.empty = True
             return mem
 
         mem.freq = int(_mem.freq) * 10
 
-        if _mem.offset.get_raw()[0] == "\xFF":
+        if _mem.offset.get_raw(asbytes=False)[0] == "\xFF":
             mem.offset = 0
         else:
             mem.offset = int(_mem.offset) * 10
@@ -701,7 +702,8 @@ class QuanshengTGUV2P(chirp_common.CloneModeRadio,
         if ch_num == 0xFF:
             return True
         _mem, _bf, _nam = self._get_memobjs(ch_num)
-        if (_mem.freq.get_raw()[0] == "\xFF") or (_bf.band == "\x0F"):
+        if ((_mem.freq.get_raw(asbytes=False)[0] == "\xFF") or
+                (_bf.band == "\x0F")):
             return False
         elif _bf.band == 0x00:
             return False

--- a/chirp/drivers/th_uv8000.py
+++ b/chirp/drivers/th_uv8000.py
@@ -635,7 +635,7 @@ class THUV8000Radio(chirp_common.CloneModeRadio):
         """Convert raw channel memory data into UI columns"""
         mem.extra = RadioSettingGroup("extra", "Extra")
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/th_uvf8d.py
+++ b/chirp/drivers/th_uvf8d.py
@@ -367,7 +367,7 @@ class TYTUVF8DRadio(chirp_common.CloneModeRadio):
         else:
             mem.number = number
 
-        if _mem.get_raw().startswith("\xFF\xFF\xFF\xFF"):
+        if _mem.get_raw(asbytes=False).startswith("\xFF\xFF\xFF\xFF"):
             mem.empty = True
             return mem
 
@@ -447,7 +447,7 @@ class TYTUVF8DRadio(chirp_common.CloneModeRadio):
         else:
             e.flags[7 - ((mem.number - 1) % 8)] = True
 
-        if _mem.get_raw() == ("\xFF" * 32):
+        if _mem.get_raw(asbytes=False) == ("\xFF" * 32):
             LOG.debug("Initializing empty memory")
             _mem.set_raw("\x00" * 32)
 

--- a/chirp/drivers/thuv1f.py
+++ b/chirp/drivers/thuv1f.py
@@ -286,14 +286,14 @@ class TYTTHUVF1Radio(chirp_common.CloneModeRadio):
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.tx_freq[i].get_raw()
+            raw_tx += _mem.tx_freq[i].get_raw(asbytes=False)
         return raw_tx == "\xFF\xFF\xFF\xFF"
 
     def get_memory(self, number):
         _mem = self._memobj.memory[number - 1]
         mem = chirp_common.Memory()
         mem.number = number
-        if _mem.get_raw().startswith("\xFF\xFF\xFF\xFF"):
+        if _mem.get_raw(asbytes=False).startswith("\xFF\xFF\xFF\xFF"):
             mem.empty = True
             return mem
 
@@ -357,7 +357,7 @@ class TYTTHUVF1Radio(chirp_common.CloneModeRadio):
             _mem.set_raw(b"\xFF" * 16)
             return
 
-        if _mem.get_raw() == ("\xFF" * 16):
+        if _mem.get_raw(asbytes=False) == ("\xFF" * 16):
             LOG.debug("Initializing empty memory")
             _mem.set_raw(b"\x00" * 16)
 

--- a/chirp/drivers/tk270.py
+++ b/chirp/drivers/tk270.py
@@ -493,7 +493,7 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
     def decode_tone(self, val):
         """Parse the tone data to decode from mem, it returns:
         Mode (''|DTCS|Tone), Value (None|###), Polarity (None,N,R)"""
-        if val.get_raw() == "\xFF\xFF":
+        if val.get_raw(asbytes=False) == "\xFF\xFF":
             return '', None, None
 
         val = int(val)
@@ -556,7 +556,7 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         # Memory number
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xFF":
+        if _mem.get_raw(asbytes=False)[0] == "\xFF":
             mem.empty = True
             # but is not enough, you have to clear the memory in the mmap
             # to get it ready for the sync_out process, just in case
@@ -568,7 +568,7 @@ class Kenwood_P60_Radio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRa
         # Freq and offset
         mem.freq = int(_mem.rxfreq) * 10
         # tx freq can be blank
-        if _mem.get_raw()[4] == "\xFF" or int(_mem.txen) == 255:
+        if _mem.get_raw(asbytes=False)[4] == "\xFF" or int(_mem.txen) == 255:
             # TX freq not set
             mem.offset = 0
             mem.duplex = "off"

--- a/chirp/drivers/tk3140.py
+++ b/chirp/drivers/tk3140.py
@@ -505,7 +505,7 @@ class KenwoodTKx140Radio(chirp_common.CloneModeRadio):
         mask = 1 << (slot % 8)
         m.freq = int(_mem.rx_freq) * 10
         offset = int(_mem.tx_freq) * 10 - m.freq
-        if _mem.tx_freq.get_raw(asbytes=True) == b'\xFF\xFF\xFF\xFF':
+        if _mem.tx_freq.get_raw() == b'\xFF\xFF\xFF\xFF':
             m.offset = 0
             m.duplex = 'off'
         elif offset < 0:

--- a/chirp/drivers/tk760.py
+++ b/chirp/drivers/tk760.py
@@ -470,7 +470,7 @@ class Kenwood_M60_Radio(chirp_common.CloneModeRadio,
     def decode_tone(self, val):
         """Parse the tone data to decode from mem, it returns:
         Mode (''|DTCS|Tone), Value (None|###), Polarity (None,N,R)"""
-        if val.get_raw() == "\xFF\xFF":
+        if val.get_raw(asbytes=False) == "\xFF\xFF":
             return '', None, None
 
         val = int(val)
@@ -556,7 +556,8 @@ class Kenwood_M60_Radio(chirp_common.CloneModeRadio,
         # Memory number
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xFF" or not self.get_active(number - 1):
+        if (_mem.get_raw(asbytes=False)[0] == "\xFF" or
+                not self.get_active(number - 1)):
             mem.empty = True
             # but is not enough, you have to clear the memory in the mmap
             # to get it ready for the sync_out process
@@ -566,7 +567,7 @@ class Kenwood_M60_Radio(chirp_common.CloneModeRadio,
         # Freq and offset
         mem.freq = int(_mem.rxfreq) * 10
         # tx freq can be blank
-        if _mem.get_raw()[4] == "\xFF":
+        if _mem.get_raw(asbytes=False)[4] == "\xFF":
             # TX freq not set
             mem.offset = 0
             mem.duplex = "off"

--- a/chirp/drivers/tk760g.py
+++ b/chirp/drivers/tk760g.py
@@ -942,14 +942,14 @@ class Kenwood_Serie_60G(chirp_common.CloneModeRadio,
         mem.number = number
 
         # A "blank" rxfreq is the indication of an empty memory
-        if _mem.rxfreq[0].get_raw() == '\xFF':
+        if _mem.rxfreq[0].get_raw(asbytes=False) == '\xFF':
             mem.empty = True
             return mem
 
         # Freq and offset
         mem.freq = int(_mem.rxfreq) * 10
         # tx freq can be blank
-        if _mem.get_raw()[16] == "\xFF":
+        if _mem.get_raw(asbytes=False)[16] == "\xFF":
             # TX freq not set
             mem.offset = 0
             mem.duplex = "off"

--- a/chirp/drivers/tk8102.py
+++ b/chirp/drivers/tk8102.py
@@ -297,7 +297,7 @@ class KenwoodTKx102Radio(chirp_common.CloneModeRadio):
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[:4] == "\xFF\xFF\xFF\xFF":
+        if _mem.get_raw(asbytes=False)[:4] == "\xFF\xFF\xFF\xFF":
             mem.empty = True
             return mem
 

--- a/chirp/drivers/tk8160.py
+++ b/chirp/drivers/tk8160.py
@@ -492,7 +492,7 @@ class TKx160Radio(chirp_common.CloneModeRadio):
 
         m.freq = int(_mem.rx_freq) * 10
         offset = int(_mem.tx_freq) * 10 - m.freq
-        if _mem.tx_freq.get_raw(asbytes=True) == b'\xFF\xFF\xFF\xFF':
+        if _mem.tx_freq.get_raw() == b'\xFF\xFF\xFF\xFF':
             m.offset = 0
             m.duplex = 'off'
         elif offset < 0:

--- a/chirp/drivers/tk8180.py
+++ b/chirp/drivers/tk8180.py
@@ -554,12 +554,12 @@ class KenwoodTKx180Radio(chirp_common.CloneModeRadio):
 
                 # Copy the zone record from the source, but then update
                 # the count
-                dest_zoneinfo.set_raw(source_zoneinfo.get_raw())
+                dest_zoneinfo.set_raw(source_zoneinfo.get_raw(asbytes=False))
                 dest_zoneinfo.count = count
 
                 source_i = 0
                 for dest_i in range(0, min(count, old_count)):
-                    dest[dest_i].set_raw(source[dest_i].get_raw())
+                    dest[dest_i].set_raw(source[dest_i].get_raw(asbytes=False))
             else:
                 LOG.debug('New zone %i' % zone_number)
                 dest_zone.zoneinfo.number = zone_number + 1
@@ -586,7 +586,8 @@ class KenwoodTKx180Radio(chirp_common.CloneModeRadio):
         if current == memories:
             LOG.debug('Shuffle not required')
             return
-        raw_data = [raw_memories[i].get_raw() for i, n in memories]
+        raw_data = [raw_memories[i].get_raw(asbytes=False)
+                    for i, n in memories]
         for i, raw_mem in enumerate(raw_data):
             raw_memories[i].set_raw(raw_mem)
 
@@ -712,7 +713,7 @@ class KenwoodTKx180Radio(chirp_common.CloneModeRadio):
         mem.power = POWER_LEVELS[_mem.highpower]
 
         offset = (int(_mem.tx_freq) - int(_mem.rx_freq)) * 10
-        if _mem.tx_freq.get_raw(asbytes=True) == b'\xFF\xFF\xFF\xFF':
+        if _mem.tx_freq.get_raw() == b'\xFF\xFF\xFF\xFF':
             mem.offset = 0
             mem.duplex = 'off'
         elif offset == 0:

--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -910,7 +910,7 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.txfreq[i].get_raw()
+            raw_tx += _mem.txfreq[i].get_raw(asbytes=False)
         return raw_tx == "\xFF\xFF\xFF\xFF"
 
     def _get_mem(self, number):
@@ -926,7 +926,7 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
             return mem
 
@@ -1060,7 +1060,7 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
         was_empty = False
         # same method as used in get_memory to find
         # out whether a raw memory is empty
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             was_empty = True
             LOG.debug("UV5R: this mem was empty")
         else:

--- a/chirp/drivers/uvb5.py
+++ b/chirp/drivers/uvb5.py
@@ -406,7 +406,7 @@ class BaofengUVB5(chirp_common.CloneModeRadio,
         else:
             mem.number = number
 
-        if _mem.freq.get_raw(asbytes=True)[0] == 0xff:
+        if _mem.freq.get_raw()[0] == 0xff:
             mem.empty = True
             return mem
 
@@ -462,7 +462,7 @@ class BaofengUVB5(chirp_common.CloneModeRadio,
             _mem.set_raw("\xFF" * 16)
             return
 
-        if _mem.get_raw() == ("\xFF" * 16):
+        if _mem.get_raw(asbytes=False) == ("\xFF" * 16):
             _mem.set_raw("\x00" * 13 + "\xFF" * 3)
 
         _mem.freq = mem.freq / 10

--- a/chirp/drivers/uvk5.py
+++ b/chirp/drivers/uvk5.py
@@ -1939,18 +1939,18 @@ class UVK5Radio(chirp_common.CloneModeRadio):
             return mem
 
         # clean the channel memory, restore some bits if it was used before
-        if _mem.get_raw()[0] == "\xff":
+        if _mem.get_raw(asbytes=False)[0] == "\xff":
             # this was an empty memory
             _mem.set_raw("\x00" * 16)
         else:
             # this memory wasn't empty, save some bits that we don't know the
             # meaning of, or that we don't support yet
-            prev_0a = _mem.get_raw(asbytes=True)[0x0a] & SAVE_MASK_0A
-            prev_0b = _mem.get_raw(asbytes=True)[0x0b] & SAVE_MASK_0B
-            prev_0c = _mem.get_raw(asbytes=True)[0x0c] & SAVE_MASK_0C
-            prev_0d = _mem.get_raw(asbytes=True)[0x0d] & SAVE_MASK_0D
-            prev_0e = _mem.get_raw(asbytes=True)[0x0e] & SAVE_MASK_0E
-            prev_0f = _mem.get_raw(asbytes=True)[0x0f] & SAVE_MASK_0F
+            prev_0a = _mem.get_raw()[0x0a] & SAVE_MASK_0A
+            prev_0b = _mem.get_raw()[0x0b] & SAVE_MASK_0B
+            prev_0c = _mem.get_raw()[0x0c] & SAVE_MASK_0C
+            prev_0d = _mem.get_raw()[0x0d] & SAVE_MASK_0D
+            prev_0e = _mem.get_raw()[0x0e] & SAVE_MASK_0E
+            prev_0f = _mem.get_raw()[0x0f] & SAVE_MASK_0F
             _mem.set_raw("\x00" * 10 +
                          chr(prev_0a) + chr(prev_0b) + chr(prev_0c) +
                          chr(prev_0d) + chr(prev_0e) + chr(prev_0f))

--- a/chirp/drivers/vgc.py
+++ b/chirp/drivers/vgc.py
@@ -691,7 +691,7 @@ class VGCStyleRadio(chirp_common.CloneModeRadio,
     def decode_tone(self, val):
         """Parse the tone data to decode from mem, it returns:
         Mode (''|DTCS|Tone), Value (None|###), Polarity (None,N,R)"""
-        if val.get_raw() == "\xFF\xFF":
+        if val.get_raw(asbytes=False) == "\xFF\xFF":
             return '', None, None
 
         val = int(val)
@@ -757,7 +757,7 @@ class VGCStyleRadio(chirp_common.CloneModeRadio,
         # Freq and offset
         mem.freq = int(_mem.rxfreq) * 10
         # tx freq can be blank
-        if _mem.get_raw()[4] == "\xFF":
+        if _mem.get_raw(asbytes=False)[4] == "\xFF":
             # TX freq not set
             mem.offset = 0
             mem.duplex = "off"

--- a/chirp/drivers/vxa700.py
+++ b/chirp/drivers/vxa700.py
@@ -223,7 +223,7 @@ class VXA700Radio(chirp_common.CloneModeRadio):
 
     def get_raw_memory(self, number):
         _mem = self._get_mem(number)
-        return repr(_mem) + util.hexprint(_mem.get_raw())
+        return repr(_mem) + util.hexprint(_mem.get_raw(asbytes=False))
 
     def get_memory(self, number):
         _mem = self._get_mem(number)

--- a/chirp/drivers/wouxun.py
+++ b/chirp/drivers/wouxun.py
@@ -745,7 +745,7 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
     def _is_txinh(self, _mem):
         raw_tx = ""
         for i in range(0, 4):
-            raw_tx += _mem.tx_freq[i].get_raw()
+            raw_tx += _mem.tx_freq[i].get_raw(asbytes=False)
         return raw_tx == "\xFF\xFF\xFF\xFF"
 
     def get_memory(self, number):
@@ -755,7 +755,7 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
         mem = chirp_common.Memory()
         mem.number = number
 
-        if _mem.get_raw() == ("\xff" * 16):
+        if _mem.get_raw(asbytes=False) == ("\xff" * 16):
             mem.empty = True
             return mem
 
@@ -851,7 +851,7 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
             wipe_memory(_mem, "\xFF")
             return
 
-        if _mem.get_raw() == ("\xFF" * 16):
+        if _mem.get_raw(asbytes=False) == ("\xFF" * 16):
             wipe_memory(_mem, "\x00")
 
         _mem.rx_freq = int(mem.freq / 10)

--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -77,6 +77,9 @@ class RadioSettingValue:
     def __trunc__(self):
         return int(self.get_value())
 
+    def __int__(self):
+        return int(self.get_value())
+
     def __float__(self):
         return float(self.get_value())
 
@@ -203,6 +206,9 @@ class RadioSettingValueList(RadioSettingValue):
     def __trunc__(self):
         return self._options.index(self._current)
 
+    def __int__(self):
+        return self._options.index(self._current)
+
 
 class RadioSettingValueString(RadioSettingValue):
 
@@ -291,6 +297,12 @@ class RadioSettingValueMap(RadioSettingValueList):
         return self._mem_vals[self._options.index(self.get_value())]
 
     def __trunc__(self):
+        """Return memory value that matches current user option"""
+        index = self._options.index(self._current)
+        value = self._mem_vals[index]
+        return value
+
+    def __int__(self):
         """Return memory value that matches current user option"""
         index = self._options.index(self._current)
         value = self._mem_vals[index]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -64,6 +64,7 @@ def _load_tests(loader, tests, pattern, suite=None):
         pattern = None
 
     driver_test_cases = (test_edges.TestCaseEdges,
+                         test_edges.TestBitwiseStrict,
                          test_brute_force.TestCaseBruteForce,
                          test_banks.TestCaseBanks,
                          test_detect.TestCaseDetect,

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -1,3 +1,7 @@
+import pytest
+from unittest import mock
+
+from chirp import bitwise
 from chirp import chirp_common
 from chirp import errors
 from tests import base
@@ -163,3 +167,23 @@ class TestCaseEdges(base.DriverTest):
         self.assertEqual(m2.name.rstrip(), m2.name,
                          'Radio set and returned a memory with trailing '
                          'whitespace in the name')
+
+
+class TestBitwiseStrict(base.DriverTest):
+    def setUp(self):
+        pass
+
+    def _raise(self, message):
+        raise SyntaxError(message)
+
+    @pytest.mark.xfail(strict=False)
+    @mock.patch.object(bitwise.Processor, 'assert_negative_seek',
+                       side_effect=_raise)
+    def test_bitwise_negative_seek(self, mock_assert):
+        super().setUp()
+
+    @pytest.mark.xfail(strict=False)
+    @mock.patch.object(bitwise.Processor, 'assert_unnecessary_seek',
+                       side_effect=_raise)
+    def test_bitwise_unnecessary_seek(self, mock_assert):
+        super().setUp()

--- a/tests/unit/test_bitwise.py
+++ b/tests/unit/test_bitwise.py
@@ -251,8 +251,8 @@ class TestBitwiseCharTypes(BaseTest):
     def test_string_get_raw(self):
         data = memmap.MemoryMapBytes(bytes(b"foobar"))
         obj = bitwise.parse("char foo[6];", data)
-        self.assertEqual('foobar', obj.foo.get_raw())
-        self.assertEqual(b'foobar', obj.foo.get_raw(asbytes=True))
+        self.assertEqual(b'foobar', obj.foo.get_raw())
+        self.assertEqual('foobar', obj.foo.get_raw(asbytes=False))
 
 
 class TestBitwiseStructTypes(BaseTest):
@@ -283,15 +283,24 @@ class TestBitwiseStructTypes(BaseTest):
         data = memmap.MemoryMapBytes(bytes(b".."))
         defn = "struct { u8 bar; u8 baz; } foo;"
         obj = bitwise.parse(defn, data)
-        self.assertEqual('..', obj.get_raw())
-        self.assertEqual(b'..', obj.get_raw(asbytes=True))
+        self.assertEqual(b'..', obj.get_raw())
+        self.assertEqual('..', obj.get_raw(asbytes=False))
 
     def test_struct_get_raw_small(self):
         data = memmap.MemoryMapBytes(bytes(b"."))
         defn = "struct { u8 bar; } foo;"
         obj = bitwise.parse(defn, data)
-        self.assertEqual('.', obj.get_raw())
-        self.assertEqual(b'.', obj.get_raw(asbytes=True))
+        self.assertEqual(b'.', obj.get_raw())
+        self.assertEqual('.', obj.get_raw(asbytes=False))
+
+    def test_struct_set_raw(self):
+        data = memmap.MemoryMapBytes(bytes(b"."))
+        defn = "struct { u8 bar; } foo;"
+        obj = bitwise.parse(defn, data)
+        obj.set_raw(b'1')
+        self.assertEqual(b'1', data.get_packed())
+        obj.set_raw('2')
+        self.assertEqual(b'2', data.get_packed())
 
 
 class TestBitwiseSeek(BaseTest):

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ passenv =
   HOME
   CHIRP_TESTS
   CHIRP_TESTIMG
+  CHIRP_TEST_BITWISE_STRICT_BYTES
   PIP_INDEX_URL
   PIP_TRUSTED_HOST
 allowlist_externals = bash


### PR DESCRIPTION
- Add a way to test for compat bytes usage
- Default bitwise's get_raw() to byte-native
- Fix deprecated __trunc__ instead of __int__
- Add warnings for non-byte-clean raw methods
- Add test for strict bitwise seeks
