### PR TITLE
Fix for #10198

### DIFF
--- a/chirp/drivers/ft4.py
+++ b/chirp/drivers/ft4.py
@@ -246,7 +246,7 @@ def variable_len_resp(pipe):
     return response
 
 
-def sendcmd(pipe, cmd, response_len):
+def sendcmd(pipe, cmd, response_len, retry=0):
     """
     send a command bytelist to radio,receive and return the resulting bytelist.
     Input: pipe         - serial port object to use
@@ -274,8 +274,13 @@ def sendcmd(pipe, cmd, response_len):
         response = b""
     ack = pipe.read(1)
     if ack != b'\x06':
-        LOG.debug("missing ack: expected 0x06, got" + util.hexprint(ack))
-        raise errors.RadioError("Incorrect ACK on serial port.")
+        if retry < 5:
+            LOG.debug("retry: " + str(retry))
+            retry += 1
+            return sendcmd(pipe, cmd, response_len, retry)
+        else:
+            LOG.debug("missing ack: expected 0x06, got" + util.hexprint(ack))
+            raise errors.RadioError("Incorrect ACK on serial port.")
     return response
 
 


### PR DESCRIPTION
yaesu ft-4xe: retry command multiple times when radio responds with no ack. Fixes #10198

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
