### PR TITLE
repeaterbook: Support digital-as-FM conversion

### DIFF
--- a/chirp/locale/de.po
+++ b/chirp/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2012-10-02 22:11+0100\n"
 "Last-Translator: Benjamin, HB9EUK <hb9euk@hb9d.org>\n"
 "Language-Team: German\n"
@@ -631,7 +631,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Alle"
 
@@ -644,7 +644,7 @@ msgstr "CSV Datei"
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr ""
 
@@ -664,7 +664,7 @@ msgstr ""
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr ""
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Importieren von:"
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr ""
 
@@ -796,12 +796,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "Kopieren"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr ""
 
@@ -868,6 +872,11 @@ msgstr "Vergleiche Rohspeicher"
 msgid "Digital Code"
 msgstr "Digital Code"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Digital Code"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr ""
@@ -877,7 +886,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Aktiviert"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -908,6 +917,10 @@ msgstr "Download vom Gerät"
 #, fuzzy
 msgid "Download instructions"
 msgstr "Download vom Gerät"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -991,7 +1004,7 @@ msgstr "In Datei exportieren"
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1091,7 +1104,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1206,7 +1219,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1233,8 +1246,8 @@ msgstr ""
 msgid "Frequency"
 msgstr "Frequenz"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr ""
 
@@ -1273,7 +1286,7 @@ msgid "Hide empty memories"
 msgstr "Überschreiben?"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
@@ -1351,7 +1364,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
@@ -1360,7 +1373,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr ""
 
@@ -1368,11 +1381,11 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
@@ -1405,7 +1418,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1427,7 +1440,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1436,7 +1449,7 @@ msgstr "Mode"
 msgid "Model"
 msgstr "Model"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Modes"
 msgstr "Mode"
@@ -1497,7 +1510,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr ""
 
@@ -1509,7 +1522,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr ""
 
@@ -1521,7 +1534,7 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr ""
 
@@ -1560,16 +1573,16 @@ msgstr ""
 msgid "Open stock config directory"
 msgstr "Vorgaben öffnen {name}"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Optionen"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1723,7 +1736,7 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
@@ -1800,12 +1813,12 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "Spalten auswählen"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 #, fuzzy
 msgid "Select Bands"
 msgstr "Spalten auswählen"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Select Modes"
 msgstr "Spalten auswählen"
@@ -1873,7 +1886,7 @@ msgstr "Überschreiben?"
 msgid "Sorting"
 msgstr "Einstellungen"
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr ""
 
@@ -1939,16 +1952,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr ""
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 
@@ -2054,7 +2067,7 @@ msgstr "Keine Änderungen bei diesem Modell möglich"
 msgid "Unable to set %s on this memory"
 msgstr "Keine Änderungen bei diesem Modell möglich"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr ""
 

--- a/chirp/locale/el.po
+++ b/chirp/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2023-02-11 15:12+0200\n"
 "Last-Translator: Sokratis Alichanidis <sv2hzs@posteo.net>\n"
 "Language-Team: Greek\n"
@@ -635,7 +635,7 @@ msgstr "Σχετικά"
 msgid "About CHIRP"
 msgstr "Σχετικά με το CHIRP"
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Όλες"
 
@@ -647,7 +647,7 @@ msgstr "Όλα τα αρχεία"
 msgid "All supported formats|"
 msgstr "Όλοι οι τύποι αρχείων|"
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr "Ραδιοερασιτέχνη"
 
@@ -667,7 +667,7 @@ msgstr ""
 msgid "Bandplan"
 msgstr "Χάρτης συχνοτήτων"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr "Μπάντες"
 
@@ -687,7 +687,7 @@ msgstr "Περιηγητής"
 msgid "Building Radio Browser"
 msgstr "Δημιουργία Περιηγητή Πομποδεκτών"
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr "Καναδάς"
 
@@ -735,7 +735,7 @@ msgstr "Επιλογή duplex"
 msgid "Choose the module to load from issue %i:"
 msgstr ""
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr "Πόλη"
 
@@ -796,12 +796,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr ""
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr "Χώρα"
 
@@ -869,6 +873,11 @@ msgstr ""
 msgid "Digital Code"
 msgstr "Ψηφιακός Κωδικός"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Ψηφιακός Κωδικός"
+
 #: ../wxui/main.py:1678
 #, fuzzy
 msgid "Disable reporting"
@@ -878,7 +887,7 @@ msgstr "Αναφορές απενεργοποιημένες"
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Απόσταση"
 
@@ -907,6 +916,10 @@ msgstr "Λήψη Από Πομποδέκτη"
 #: ../wxui/clone.py:515
 msgid "Download instructions"
 msgstr "Οδηγίες λήψης"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -986,7 +999,7 @@ msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 msgid "Extra"
 msgstr "Περισσότερα"
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1084,7 +1097,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1199,7 +1212,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1226,8 +1239,8 @@ msgstr ""
 msgid "Frequency"
 msgstr "Συχνότητα"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1266,7 +1279,7 @@ msgid "Hide empty memories"
 msgstr "Αντικατάσταση μνημών;"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
@@ -1344,7 +1357,7 @@ msgstr ""
 msgid "LIVE"
 msgstr "LIVE"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Γεωγραφικό πλάτος"
 
@@ -1353,7 +1366,7 @@ msgstr "Γεωγραφικό πλάτος"
 msgid "Length must be %i"
 msgstr "Το μήκος πρέπει να είναι %i"
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr "Περιορισμός Μπαντών"
 
@@ -1361,12 +1374,12 @@ msgstr "Περιορισμός Μπαντών"
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 #, fuzzy
 msgid "Limit Status"
 msgstr "Περιορισμός Μπαντών"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
@@ -1399,7 +1412,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr "Φόρτωση ρυθμίσεων"
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Γεωγραφικό μήκος"
 
@@ -1421,7 +1434,7 @@ msgstr "Η μνήμη πρέπει να βρίσκεται σε ομάδα γι�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Η μνήμη {num} δεν βρίσκεται στην ομάδα μνημών {bank}"
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 #, fuzzy
 msgid "Mode"
 msgstr "Λειτουργία"
@@ -1430,7 +1443,7 @@ msgstr "Λειτουργία"
 msgid "Model"
 msgstr "Μοντέλο"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Modes"
 msgstr ""
 
@@ -1486,7 +1499,7 @@ msgstr ""
 msgid "No results"
 msgstr "Κανένα αποτέλεσμα!"
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr "Κανένα αποτέλεσμα!"
 
@@ -1498,7 +1511,7 @@ msgstr "Αριθμός"
 msgid "Offset"
 msgstr ""
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr "Μόνο ορισμένες μπάντες"
 
@@ -1510,7 +1523,7 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr "Μόνο οι καρτέλες μνημών μπορούν να εξαχθούν"
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr ""
 
@@ -1547,15 +1560,15 @@ msgstr ""
 msgid "Open stock config directory"
 msgstr "Άνοιγμα προεπιλεγμένων ρυθμίσεων"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr "Προαιρετικό: -122.0000"
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 msgid "Optional: 100"
 msgstr "Προαιρετικό: 100"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr "Προαιρετικό: 45.0000"
 
@@ -1708,7 +1721,7 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
@@ -1784,11 +1797,11 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "Επιλογή χάρτη συχνοτήτων"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Select Bands"
 msgstr "Επιλογή Μπαντών"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Select Modes"
 msgstr ""
 
@@ -1853,7 +1866,7 @@ msgstr "Αντικατάσταση μνημών;"
 msgid "Sorting"
 msgstr "Εκτύπωση"
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr "Πολιτεία"
 
@@ -1919,16 +1932,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr ""
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 
@@ -2038,7 +2051,7 @@ msgstr ""
 msgid "Unable to set %s on this memory"
 msgstr "Πατήστε enter για καταχώρηση στη μνήμη"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr "Ηνωμένες Πολιτείες"
 

--- a/chirp/locale/en_US.po
+++ b/chirp/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2011-11-29 16:07-0800\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -629,7 +629,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr ""
 
@@ -642,7 +642,7 @@ msgstr "CSV Files"
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr ""
 
@@ -662,7 +662,7 @@ msgstr ""
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr ""
 
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr ""
 
@@ -729,7 +729,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr ""
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr ""
 
@@ -792,13 +792,17 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 #, fuzzy
 msgid "Copy"
 msgstr "_Copy"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr ""
 
@@ -865,6 +869,10 @@ msgstr "Diff raw memories"
 msgid "Digital Code"
 msgstr ""
 
+#: ../wxui/query_sources.py:335
+msgid "Digital Modes"
+msgstr ""
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr ""
@@ -873,7 +881,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -904,6 +912,10 @@ msgstr "Download From Radio"
 #, fuzzy
 msgid "Download instructions"
 msgstr "Download From Radio"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -983,7 +995,7 @@ msgstr "Import from RFinder"
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1080,7 +1092,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1195,7 +1207,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1222,8 +1234,8 @@ msgstr ""
 msgid "Frequency"
 msgstr ""
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr ""
 
@@ -1262,7 +1274,7 @@ msgid "Hide empty memories"
 msgstr "Diff raw memories"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
@@ -1339,7 +1351,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
@@ -1348,7 +1360,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr ""
 
@@ -1356,11 +1368,11 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
@@ -1390,7 +1402,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1413,7 +1425,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 msgid "Mode"
 msgstr ""
 
@@ -1421,7 +1433,7 @@ msgstr ""
 msgid "Model"
 msgstr ""
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Modes"
 msgstr ""
 
@@ -1477,7 +1489,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr ""
 
@@ -1489,7 +1501,7 @@ msgstr ""
 msgid "Offset"
 msgstr ""
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr ""
 
@@ -1501,7 +1513,7 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr ""
 
@@ -1538,15 +1550,15 @@ msgstr ""
 msgid "Open stock config directory"
 msgstr ""
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 msgid "Optional: 100"
 msgstr ""
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1699,7 +1711,7 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
@@ -1774,12 +1786,12 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "Select Columns"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 #, fuzzy
 msgid "Select Bands"
 msgstr "Select Columns"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Select Modes"
 msgstr "Select Columns"
@@ -1845,7 +1857,7 @@ msgstr "Diff raw memories"
 msgid "Sorting"
 msgstr ""
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr ""
 
@@ -1911,16 +1923,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr ""
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 
@@ -2023,7 +2035,7 @@ msgstr ""
 msgid "Unable to set %s on this memory"
 msgstr ""
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr ""
 

--- a/chirp/locale/es.po
+++ b/chirp/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2023-11-20 23:35-0300\n"
 "Last-Translator: MELERIX\n"
 "Language-Team: \n"
@@ -1005,7 +1005,7 @@ msgstr "Acerca de"
 msgid "About CHIRP"
 msgstr "Acerca de CHIRP"
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Todo"
 
@@ -1017,7 +1017,7 @@ msgstr "Todos los archivos"
 msgid "All supported formats|"
 msgstr "Todos los formatos soportados|"
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr "Aficionado"
 
@@ -1037,7 +1037,7 @@ msgstr "Módulos disponibles"
 msgid "Bandplan"
 msgstr "Plan de banda"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr "Bandas"
 
@@ -1057,7 +1057,7 @@ msgstr "Navegador"
 msgid "Building Radio Browser"
 msgstr "Construyendo navegador de radio"
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr "Canada"
 
@@ -1108,7 +1108,7 @@ msgstr "Elegir Dúplex"
 msgid "Choose the module to load from issue %i:"
 msgstr "Elige el módulo para cargar desde problema %i:"
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr "Ciudad"
 
@@ -1178,12 +1178,16 @@ msgstr ""
 "Conecta tu cable de interfaz al Puerto de PC en la\n"
 "espalda de la unidad 'TX/RX'. NO el Puerto Com en la cabeza.\n"
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr "País"
 
@@ -1250,6 +1254,11 @@ msgstr "Diferenciar memorias en bruto"
 msgid "Digital Code"
 msgstr "Código digital"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Código digital"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr "Deshabilitar reportes"
@@ -1258,7 +1267,7 @@ msgstr "Deshabilitar reportes"
 msgid "Disabled"
 msgstr "Desahbilitado"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Distancia"
 
@@ -1286,6 +1295,10 @@ msgstr "Descargar desde radio..."
 #: ../wxui/clone.py:515
 msgid "Download instructions"
 msgstr "Descargar instrucciones"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -1363,7 +1376,7 @@ msgstr "Exportar a CSV..."
 msgid "Extra"
 msgstr "Extra"
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1484,7 +1497,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1662,7 +1675,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1699,8 +1712,8 @@ msgstr "Encontrado valor de lista vacía para %(name)s: %(value)r"
 msgid "Frequency"
 msgstr "Frecuencia"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1737,7 +1750,7 @@ msgid "Hide empty memories"
 msgstr "Ocultar memorias vacías"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Si se establece, ordenar los resultados por distancia desde estas coordenadas"
@@ -1813,7 +1826,7 @@ msgstr "Número de problema:"
 msgid "LIVE"
 msgstr "EN VIVO"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Latitud"
 
@@ -1822,7 +1835,7 @@ msgstr "Latitud"
 msgid "Length must be %i"
 msgstr "Largo debe ser %i"
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr "Bandas límite"
 
@@ -1830,11 +1843,11 @@ msgstr "Bandas límite"
 msgid "Limit Modes"
 msgstr "Modos límite"
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr "Estado límite"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Limitar resultados a esta distancia (km) desde coordenadas"
 
@@ -1870,7 +1883,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr "Cargando ajustes"
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Longitud"
 
@@ -1892,7 +1905,7 @@ msgstr "Memoria debe estar en un banco para ser editada"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Memoria {num} no en banco {bank}"
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 msgid "Mode"
 msgstr "Modo"
 
@@ -1900,7 +1913,7 @@ msgstr "Modo"
 msgid "Model"
 msgstr "Modelo"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Modes"
 msgstr "Modos"
 
@@ -1954,7 +1967,7 @@ msgstr "No se encontraron módulos en problema %i"
 msgid "No results"
 msgstr "No hay resultados"
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr "¡No hay resultados!"
 
@@ -1966,7 +1979,7 @@ msgstr "Numero"
 msgid "Offset"
 msgstr "Desplazamiento"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr "Solo ciertas bandas"
 
@@ -1978,7 +1991,7 @@ msgstr "Solo ciertos modos"
 msgid "Only memory tabs may be exported"
 msgstr "Solo pestañas de memorias pueden ser exportadas"
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr "Sólo repetidores funcionando"
 
@@ -2014,15 +2027,15 @@ msgstr "Abrir en nueva ventana"
 msgid "Open stock config directory"
 msgstr "Abrir directorio de configuración original"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr "Opcional: -122.0000"
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 msgid "Optional: 100"
 msgstr "Opcional: 100"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr "Opcional: 45.0000"
 
@@ -2202,7 +2215,7 @@ msgstr ""
 "el modelo seleccionado no es de EE.UU pero la radio es una de EE.UU. Por "
 "favor elije el modelo correcto e intenta de nuevo."
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 "RadioReference Canadá requiere un inicio de sesión antes de que puedas "
@@ -2280,11 +2293,11 @@ msgstr "Riesgo de seguridad"
 msgid "Select Bandplan..."
 msgstr "Seleccionar plan de banda..."
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Select Bands"
 msgstr "Seleccionar bandas"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Select Modes"
 msgstr "Seleccionar modos"
 
@@ -2347,7 +2360,7 @@ msgstr "Ordenar memorias"
 msgid "Sorting"
 msgstr "Ordenando"
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr "Estado"
 
@@ -2444,16 +2457,16 @@ msgstr ""
 "un registro de depuración para que podamos agregar soporte para las otras "
 "revisiones."
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr "Este es un controlador beta de etapa temprana\n"
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 "Este es un controlador beta de etapa temprana - cargar bajo tu propio "
@@ -2575,7 +2588,7 @@ msgstr "No se puede revelar %s en este sistema"
 msgid "Unable to set %s on this memory"
 msgstr "No se puede establecer %s en esta memoria"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr "Estados Unidos"
 

--- a/chirp/locale/fr.po
+++ b/chirp/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2014-04-05 22:18+0100\n"
 "Last-Translator: Matthieu Lapadu-Hargues <mlhpub@free.fr>\n"
 "Language-Team: French\n"
@@ -631,7 +631,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Tout"
 
@@ -644,7 +644,7 @@ msgstr "Fichiers CSV"
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr ""
 
@@ -664,7 +664,7 @@ msgstr ""
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr ""
 
@@ -732,7 +732,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Selectionner importation depuis : "
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr ""
 
@@ -796,12 +796,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "Copier"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr ""
 
@@ -869,6 +873,11 @@ msgstr "Comparaison memoires brutes"
 msgid "Digital Code"
 msgstr "Digital code"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Digital code"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr ""
@@ -877,7 +886,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -908,6 +917,10 @@ msgstr "Telecharger depuis la radio - Lire"
 #, fuzzy
 msgid "Download instructions"
 msgstr "Telecharger depuis la radio - Lire"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -989,7 +1002,7 @@ msgstr "Exporter vers un fichier"
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1086,7 +1099,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1201,7 +1214,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1228,8 +1241,8 @@ msgstr ""
 msgid "Frequency"
 msgstr "Frequence"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr ""
 
@@ -1268,7 +1281,7 @@ msgid "Hide empty memories"
 msgstr "Ecraser ?"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
@@ -1347,7 +1360,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
@@ -1356,7 +1369,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr ""
 
@@ -1364,11 +1377,11 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
@@ -1401,7 +1414,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1423,7 +1436,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1432,7 +1445,7 @@ msgstr "Mode"
 msgid "Model"
 msgstr "Modele"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Modes"
 msgstr "Mode"
@@ -1490,7 +1503,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr ""
 
@@ -1502,7 +1515,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Decalage"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr ""
 
@@ -1514,7 +1527,7 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr ""
 
@@ -1553,16 +1566,16 @@ msgstr ""
 msgid "Open stock config directory"
 msgstr "Ouvrir la base de donnees {name}"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Options"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1715,7 +1728,7 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
@@ -1791,12 +1804,12 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "Selectionner les colonnes"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 #, fuzzy
 msgid "Select Bands"
 msgstr "Selectionner les colonnes"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Select Modes"
 msgstr "Selectionner les colonnes"
@@ -1862,7 +1875,7 @@ msgstr "Ecraser ?"
 msgid "Sorting"
 msgstr ""
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr ""
 
@@ -1928,16 +1941,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr ""
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 
@@ -2043,7 +2056,7 @@ msgstr "Impossible de realiser des changements pour ce modele"
 msgid "Unable to set %s on this memory"
 msgstr "Impossible de realiser des changements pour ce modele"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr ""
 

--- a/chirp/locale/hu.po
+++ b/chirp/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2015-01-28 13:47+0100\n"
 "Last-Translator: Attila Joubert <joubert.attila@gmail.com>\n"
 "Language-Team: English\n"
@@ -630,7 +630,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Mind"
 
@@ -643,7 +643,7 @@ msgstr "CSV fájlok"
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr ""
 
@@ -663,7 +663,7 @@ msgstr ""
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr ""
 
@@ -683,7 +683,7 @@ msgstr "Böngésző"
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Válasszon egy importálandót:"
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr ""
 
@@ -795,12 +795,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "Másolás"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr ""
 
@@ -868,6 +872,11 @@ msgstr "Memóriasorok összehasonlítása"
 msgid "Digital Code"
 msgstr "Digitális kód"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Digitális kód"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr ""
@@ -877,7 +886,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "Engedélyezve"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -908,6 +917,10 @@ msgstr "Letöltés a rádióról"
 #, fuzzy
 msgid "Download instructions"
 msgstr "{name} Utasítások"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -991,7 +1004,7 @@ msgstr "Export fájlba"
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1091,7 +1104,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1206,7 +1219,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1233,8 +1246,8 @@ msgstr ""
 msgid "Frequency"
 msgstr "Frekvencia"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr ""
 
@@ -1275,7 +1288,7 @@ msgid "Hide empty memories"
 msgstr "Felülírja?"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
@@ -1354,7 +1367,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
@@ -1363,7 +1376,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr ""
 
@@ -1371,11 +1384,11 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
@@ -1408,7 +1421,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1430,7 +1443,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 #, fuzzy
 msgid "Mode"
 msgstr "Mód"
@@ -1439,7 +1452,7 @@ msgstr "Mód"
 msgid "Model"
 msgstr "Modell"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Modes"
 msgstr "Mód"
@@ -1500,7 +1513,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr ""
 
@@ -1512,7 +1525,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Offszet"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr ""
 
@@ -1524,7 +1537,7 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr ""
 
@@ -1563,16 +1576,16 @@ msgstr ""
 msgid "Open stock config directory"
 msgstr "A(z) {name} konfigurációs készlet megnyitása"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Beállítások"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1727,7 +1740,7 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
@@ -1803,12 +1816,12 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 #, fuzzy
 msgid "Select Bands"
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Select Modes"
 msgstr "Oszlopok kiválasztása"
@@ -1877,7 +1890,7 @@ msgstr "Felülírja?"
 msgid "Sorting"
 msgstr "Beállítás"
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr ""
 
@@ -1943,16 +1956,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr ""
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 
@@ -2058,7 +2071,7 @@ msgstr "Ennél a modellnél nem változtatható"
 msgid "Unable to set %s on this memory"
 msgstr "Ennél a modellnél nem változtatható"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr ""
 

--- a/chirp/locale/it.po
+++ b/chirp/locale/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2014-11-08 17:58+0100\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -630,7 +630,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Tutto"
 
@@ -643,7 +643,7 @@ msgstr "Files CSV"
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr ""
 
@@ -663,7 +663,7 @@ msgstr ""
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr ""
 
@@ -683,7 +683,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Scegli da dove importare:"
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr ""
 
@@ -795,12 +795,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "Copia"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr ""
 
@@ -868,6 +872,11 @@ msgstr "Diff memorie Raw"
 msgid "Digital Code"
 msgstr "Digital Code"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Digital Code"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr ""
@@ -876,7 +885,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -907,6 +916,10 @@ msgstr "Leggi da Radio"
 #, fuzzy
 msgid "Download instructions"
 msgstr "Leggi da Radio"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -988,7 +1001,7 @@ msgstr "Esporta in File"
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1085,7 +1098,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1200,7 +1213,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1227,8 +1240,8 @@ msgstr ""
 msgid "Frequency"
 msgstr "Frequenza"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr ""
 
@@ -1267,7 +1280,7 @@ msgid "Hide empty memories"
 msgstr "Sovrascrivere?"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
@@ -1346,7 +1359,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
@@ -1355,7 +1368,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr ""
 
@@ -1363,11 +1376,11 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
@@ -1400,7 +1413,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1422,7 +1435,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 #, fuzzy
 msgid "Mode"
 msgstr "Modulazione"
@@ -1431,7 +1444,7 @@ msgstr "Modulazione"
 msgid "Model"
 msgstr "Modello"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Modes"
 msgstr "Modulazione"
@@ -1489,7 +1502,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr ""
 
@@ -1501,7 +1514,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr ""
 
@@ -1513,7 +1526,7 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr ""
 
@@ -1552,16 +1565,16 @@ msgstr ""
 msgid "Open stock config directory"
 msgstr "Apertura configurazione stock {name}"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Opzioni"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1714,7 +1727,7 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
@@ -1790,12 +1803,12 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "Seleziona colonne"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 #, fuzzy
 msgid "Select Bands"
 msgstr "Seleziona colonne"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Select Modes"
 msgstr "Seleziona colonne"
@@ -1862,7 +1875,7 @@ msgstr "Sovrascrivere?"
 msgid "Sorting"
 msgstr ""
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr ""
 
@@ -1928,16 +1941,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr ""
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 
@@ -2043,7 +2056,7 @@ msgstr "Impossibile effettuare modifiche su questo modello"
 msgid "Unable to set %s on this memory"
 msgstr "Impossibile effettuare modifiche su questo modello"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr ""
 

--- a/chirp/locale/nl.po
+++ b/chirp/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2012-03-18 12:01+0100\n"
 "Last-Translator: Michael Tel <m.tel@xs4all.nl>\n"
 "Language-Team: Dutch\n"
@@ -630,7 +630,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Alles"
 
@@ -643,7 +643,7 @@ msgstr "Komma gescheiden bestanden"
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr ""
 
@@ -663,7 +663,7 @@ msgstr ""
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr ""
 
@@ -683,7 +683,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr ""
 
@@ -731,7 +731,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Kies n om vanuit te importeren:"
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr ""
 
@@ -795,12 +795,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr ""
 
@@ -868,6 +872,11 @@ msgstr "Verschillen ruwe kanalen"
 msgid "Digital Code"
 msgstr "Digitale code"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Digitale code"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr ""
@@ -876,7 +885,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -907,6 +916,10 @@ msgstr "Download van radio"
 #, fuzzy
 msgid "Download instructions"
 msgstr "Download van radio"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -988,7 +1001,7 @@ msgstr "Exporteren naar bestand"
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1085,7 +1098,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1200,7 +1213,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1227,8 +1240,8 @@ msgstr ""
 msgid "Frequency"
 msgstr "Frequentie"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr ""
 
@@ -1267,7 +1280,7 @@ msgid "Hide empty memories"
 msgstr "Overschrijven?"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
@@ -1346,7 +1359,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
@@ -1355,7 +1368,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr ""
 
@@ -1363,11 +1376,11 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
@@ -1400,7 +1413,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1422,7 +1435,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1431,7 +1444,7 @@ msgstr "Mode"
 msgid "Model"
 msgstr "Model"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Modes"
 msgstr "Mode"
@@ -1489,7 +1502,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr ""
 
@@ -1501,7 +1514,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr ""
 
@@ -1513,7 +1526,7 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr ""
 
@@ -1552,16 +1565,16 @@ msgstr ""
 msgid "Open stock config directory"
 msgstr "Openen van aanwezige configuratie {name}"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Opties"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1714,7 +1727,7 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
@@ -1790,12 +1803,12 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "Kolommen selecteren"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 #, fuzzy
 msgid "Select Bands"
 msgstr "Kolommen selecteren"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Select Modes"
 msgstr "Kolommen selecteren"
@@ -1861,7 +1874,7 @@ msgstr "Overschrijven?"
 msgid "Sorting"
 msgstr ""
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr ""
 
@@ -1927,16 +1940,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr ""
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 
@@ -2042,7 +2055,7 @@ msgstr "Niet in staat om wijzigingen voor dit model te maken"
 msgid "Unable to set %s on this memory"
 msgstr "Niet in staat om wijzigingen voor dit model te maken"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr ""
 

--- a/chirp/locale/pl.po
+++ b/chirp/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2023-07-12 21:21+0200\n"
 "Last-Translator: szporwolik\n"
 "Language-Team: Polish\n"
@@ -645,7 +645,7 @@ msgstr "O programie"
 msgid "About CHIRP"
 msgstr "O programie CHIRP"
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Wszystkie"
 
@@ -657,7 +657,7 @@ msgstr "Wszystkie pliki"
 msgid "All supported formats|"
 msgstr "Wszystkie wspierane formaty|"
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr "Amatorska"
 
@@ -677,7 +677,7 @@ msgstr "Dostępne moduły"
 msgid "Bandplan"
 msgstr "Bandplan"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr "Pasma"
 
@@ -697,7 +697,7 @@ msgstr "Przeglądarka"
 msgid "Building Radio Browser"
 msgstr "Budowanie przeglądarki radiostacji"
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr "Kanada"
 
@@ -747,7 +747,7 @@ msgstr "Wybierz duplex"
 msgid "Choose the module to load from issue %i:"
 msgstr "Wybierz moduł do zaimportowania ze zgłoszenia %i:"
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr "Miasto"
 
@@ -808,12 +808,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr "Kraj"
 
@@ -881,6 +885,11 @@ msgstr "Porównaj surowe pamięci"
 msgid "Digital Code"
 msgstr "Kod cyfrowy"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Kod cyfrowy"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr "Wyłącz raportowanie"
@@ -889,7 +898,7 @@ msgstr "Wyłącz raportowanie"
 msgid "Disabled"
 msgstr "Wyłączony"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Dystans"
 
@@ -918,6 +927,10 @@ msgstr "Pobierz z radiostacji"
 #: ../wxui/clone.py:515
 msgid "Download instructions"
 msgstr "Instrukcje pobierania"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -996,7 +1009,7 @@ msgstr "Eksportuj do pliku CSV"
 msgid "Extra"
 msgstr "Dodatkowa"
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1096,7 +1109,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1211,7 +1224,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1238,8 +1251,8 @@ msgstr "Znaleziono pustą wartość listy dla %(name)s: %(value)r"
 msgid "Frequency"
 msgstr "Częstotliwość"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1277,7 +1290,7 @@ msgid "Hide empty memories"
 msgstr "Ukrywaj puste pamięci"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr "Jeśli ustawiono, sortuje wyniki po odległości od tych współrzędnych"
 
@@ -1353,7 +1366,7 @@ msgstr "Numer zgłoszenia:"
 msgid "LIVE"
 msgstr "Na żywo"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Szerokość geograficzna"
 
@@ -1362,7 +1375,7 @@ msgstr "Szerokość geograficzna"
 msgid "Length must be %i"
 msgstr "Długość musi wynosić %i"
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr "Ogranicz pasma"
 
@@ -1370,11 +1383,11 @@ msgstr "Ogranicz pasma"
 msgid "Limit Modes"
 msgstr "Ogranicz tryby"
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr "Ogranicz status"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Ogranicz wyniki do odległości (km) od współrzędnych"
 
@@ -1412,7 +1425,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr "Ładowanie ustawień"
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Długość geograficzna"
 
@@ -1434,7 +1447,7 @@ msgstr "Pamięć musi być w banku, aby można ją było edytować"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Pamięć {num} nie jest w banku {bank}"
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 msgid "Mode"
 msgstr "Tryb"
 
@@ -1442,7 +1455,7 @@ msgstr "Tryb"
 msgid "Model"
 msgstr "Model"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Modes"
 msgstr "Tryby"
 
@@ -1496,7 +1509,7 @@ msgstr "Nie znaleziono modułów w zgłoszeniu %i"
 msgid "No results"
 msgstr "Brak wyników"
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr "Brak wyników!"
 
@@ -1508,7 +1521,7 @@ msgstr "Numer"
 msgid "Offset"
 msgstr "Przesunięcie"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr "Tylko konkretne pasma"
 
@@ -1520,7 +1533,7 @@ msgstr "Tylko konkretne tryby"
 msgid "Only memory tabs may be exported"
 msgstr "Tylko zakładki pamięci mogą być wyeksportowane"
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr "Tylko czynne przemienniki"
 
@@ -1556,15 +1569,15 @@ msgstr "Otwórz w nowym oknie"
 msgid "Open stock config directory"
 msgstr "Otwórz katalog konfiguracji wstępnych"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr "Opcjonalnie: -122.0000"
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 msgid "Optional: 100"
 msgstr "Opcjonalnie: 100"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr "Opcjonalnie: 45.0000"
 
@@ -1721,7 +1734,7 @@ msgstr ""
 "jest ona przeznaczona na amerykański rynek, a wybrano model na inne regiony. "
 "Należy wybrać właściwy model i spróbować ponownie."
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr "RadioReference Canada wymaga logowania przed wysłaniem zapytań"
 
@@ -1798,11 +1811,11 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "Wybierz bandplan"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Select Bands"
 msgstr "Wybierz pasma"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Select Modes"
 msgstr "Wybierz tryby"
 
@@ -1865,7 +1878,7 @@ msgstr "Sortuj pamięci"
 msgid "Sorting"
 msgstr "Sortowanie"
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr "Stan"
 
@@ -1938,16 +1951,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr "To sterownik we wczesnej wersji beta\n"
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr "To sterownik we wczesnej wersji beta - wysyłasz na własne ryzyko\n"
 
@@ -2057,7 +2070,7 @@ msgstr "Nie można odkryć %s na tym systemie"
 msgid "Unable to set %s on this memory"
 msgstr "Nie można ustawić %s na tej pamięci"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr "Stany Zjednoczone"
 

--- a/chirp/locale/pt_BR.po
+++ b/chirp/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2013-03-30 22:04-0300\n"
 "Last-Translator: Crezivando <crezivando@gmail.com>\n"
 "Language-Team: Language pt-BR\n"
@@ -629,7 +629,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Tudo"
 
@@ -642,7 +642,7 @@ msgstr "Arquivos CSV"
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr ""
 
@@ -662,7 +662,7 @@ msgstr ""
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr ""
 
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Selecionar um para importar de:"
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr ""
 
@@ -794,12 +794,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr ""
 
@@ -867,6 +871,11 @@ msgstr "Diff Memórias Raw"
 msgid "Digital Code"
 msgstr "Código Digital"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Código Digital"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr ""
@@ -875,7 +884,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -906,6 +915,10 @@ msgstr "Descarregar a partir do Rádio"
 #, fuzzy
 msgid "Download instructions"
 msgstr "Descarregar a partir do Rádio"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -987,7 +1000,7 @@ msgstr "Exportar Para Arquivo"
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1084,7 +1097,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1199,7 +1212,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1226,8 +1239,8 @@ msgstr ""
 msgid "Frequency"
 msgstr "Frequência"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr ""
 
@@ -1266,7 +1279,7 @@ msgid "Hide empty memories"
 msgstr "Sobrescrever?"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
@@ -1345,7 +1358,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
@@ -1354,7 +1367,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr ""
 
@@ -1362,11 +1375,11 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
@@ -1399,7 +1412,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1421,7 +1434,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 #, fuzzy
 msgid "Mode"
 msgstr "Modo"
@@ -1430,7 +1443,7 @@ msgstr "Modo"
 msgid "Model"
 msgstr "Modelo"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Modes"
 msgstr "Modo"
@@ -1488,7 +1501,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr ""
 
@@ -1500,7 +1513,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr ""
 
@@ -1512,7 +1525,7 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr ""
 
@@ -1551,16 +1564,16 @@ msgstr ""
 msgid "Open stock config directory"
 msgstr "Abrir configuração de estoque {name}"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Opções"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1713,7 +1726,7 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
@@ -1789,12 +1802,12 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "Selecionar Colunas"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 #, fuzzy
 msgid "Select Bands"
 msgstr "Selecionar Colunas"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Select Modes"
 msgstr "Selecionar Colunas"
@@ -1860,7 +1873,7 @@ msgstr "Sobrescrever?"
 msgid "Sorting"
 msgstr ""
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr ""
 
@@ -1926,16 +1939,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr ""
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 
@@ -2041,7 +2054,7 @@ msgstr "Incapaz de efetuar alterações para este modelo"
 msgid "Unable to set %s on this memory"
 msgstr "Incapaz de efetuar alterações para este modelo"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr ""
 

--- a/chirp/locale/ru.po
+++ b/chirp/locale/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2023-10-11 16:47+0300\n"
 "Last-Translator: Olesya Gerasimenko <translation-team@basealt.ru>\n"
 "Language-Team: Basealt Translation Team\n"
@@ -973,7 +973,7 @@ msgstr "О программе"
 msgid "About CHIRP"
 msgstr "О программе CHIRP"
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Все"
 
@@ -985,7 +985,7 @@ msgstr "Все файлы"
 msgid "All supported formats|"
 msgstr "Все поддерживаемые форматы|"
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr "Любительская радиосвязь"
 
@@ -1005,7 +1005,7 @@ msgstr "Доступные модули"
 msgid "Bandplan"
 msgstr "Частотный план"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr "Полосы частот"
 
@@ -1025,7 +1025,7 @@ msgstr "Браузер"
 msgid "Building Radio Browser"
 msgstr "Браузер станций"
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr "Канада"
 
@@ -1074,7 +1074,7 @@ msgstr "Выберите дуплекс"
 msgid "Choose the module to load from issue %i:"
 msgstr "Выберите модуль для загрузки из задачи %i:"
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr "Город"
 
@@ -1143,12 +1143,16 @@ msgstr ""
 "Подключите ваш интерфейсный кабель к PC-порту на\n"
 "задней стороне модуля «TX/RX». НЕ к COM-порту на головке.\n"
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "Копировать"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr "Страна"
 
@@ -1215,6 +1219,11 @@ msgstr "Сравнить необработанные ячейки памяти"
 msgid "Digital Code"
 msgstr "Цифровой код"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Цифровой код"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr "Отключить отправку отчётов"
@@ -1223,7 +1232,7 @@ msgstr "Отключить отправку отчётов"
 msgid "Disabled"
 msgstr "Отключено"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Расстояние"
 
@@ -1251,6 +1260,10 @@ msgstr "Загрузить из станции..."
 #: ../wxui/clone.py:515
 msgid "Download instructions"
 msgstr "Инструкции по загрузке"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -1328,7 +1341,7 @@ msgstr "Экспорт в CSV..."
 msgid "Extra"
 msgstr "Дополнительно"
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1450,7 +1463,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1630,7 +1643,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1667,8 +1680,8 @@ msgstr "Найдено значение пустого списка для %(nam
 msgid "Frequency"
 msgstr "Частота"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1705,7 +1718,7 @@ msgid "Hide empty memories"
 msgstr "Скрыть пустые ячейки памяти"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Если установлено, упорядочить результаты по расстоянию от этих координат"
@@ -1781,7 +1794,7 @@ msgstr "Номер задачи:"
 msgid "LIVE"
 msgstr "В ЭФИРЕ"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Широта"
 
@@ -1790,7 +1803,7 @@ msgstr "Широта"
 msgid "Length must be %i"
 msgstr "Длина должна составлять %i"
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr "Ограничение полос частот"
 
@@ -1798,11 +1811,11 @@ msgstr "Ограничение полос частот"
 msgid "Limit Modes"
 msgstr "Ограничение режимов"
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr "Ограничение состояния"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Ограничить результаты этим расстоянием (км) от координат"
 
@@ -1838,7 +1851,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr "Загрузка параметров"
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Долгота"
 
@@ -1860,7 +1873,7 @@ msgstr "Чтобы редактировать ячейку памяти, нео�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Ячейка памяти {num} отсутствует в банке {bank}"
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 msgid "Mode"
 msgstr "Режим"
 
@@ -1868,7 +1881,7 @@ msgstr "Режим"
 msgid "Model"
 msgstr "Модель"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Modes"
 msgstr "Режимы"
 
@@ -1922,7 +1935,7 @@ msgstr "В задаче %i не найдены модули"
 msgid "No results"
 msgstr "Нет результатов"
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr "Нет результатов!"
 
@@ -1934,7 +1947,7 @@ msgstr "Число"
 msgid "Offset"
 msgstr "Смещение"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr "Только некоторые полосы частот"
 
@@ -1946,7 +1959,7 @@ msgstr "Только некоторые режимы"
 msgid "Only memory tabs may be exported"
 msgstr "Можно экспортировать только вкладки памяти"
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr "Только работающие репитеры"
 
@@ -1982,15 +1995,15 @@ msgstr "Открыть в новом окне"
 msgid "Open stock config directory"
 msgstr "Открыть каталог предустановленной конфигурации"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr "Опционально: -122.0000"
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 msgid "Optional: 100"
 msgstr "Опционально: 100"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr "Опционально: 45.0000"
 
@@ -2169,7 +2182,7 @@ msgstr ""
 "когда выбранная модель не является американской, а станция является. "
 "Выберите правильную модель и повторите попытку."
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr "RadioReference Canada запрашивает вход перед выполнением запроса"
 
@@ -2246,11 +2259,11 @@ msgstr "Угроза безопасности"
 msgid "Select Bandplan..."
 msgstr "Выбрать частотный план..."
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Select Bands"
 msgstr "Выбор полос частот"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Select Modes"
 msgstr "Выбор режимов"
 
@@ -2313,7 +2326,7 @@ msgstr "Упорядочить ячейки памяти"
 msgid "Sorting"
 msgstr "Сортировка"
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr "Область"
 
@@ -2405,16 +2418,16 @@ msgstr ""
 "полностью, создайте отчёт об ошибке и приложите к нему журнал отладки, чтобы "
 "мы могли добавить соответствующую поддержку для других версий."
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr "Это ранняя бета-версия драйвера\n"
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr "Это ранняя бета-версия драйвера — отправляйте на свой страх и риск\n"
 
@@ -2534,7 +2547,7 @@ msgstr "Невозможно обнаружить %s в этой системе"
 msgid "Unable to set %s on this memory"
 msgstr "Невозможно установить %s для этой ячейки памяти"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr "Соединённые Штаты"
 

--- a/chirp/locale/tr_TR.po
+++ b/chirp/locale/tr_TR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2023-11-22 22:39+0300\n"
 "Last-Translator: Abdullah YILMAZ (TA1AUB) <h.abdullahyilmaz@hotmail.com>\n"
 "Language-Team: TURKISH\n"
@@ -972,7 +972,7 @@ msgstr "Hakkında"
 msgid "About CHIRP"
 msgstr "CHIRP Hakkında"
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Tümü"
 
@@ -984,7 +984,7 @@ msgstr "Tüm Dosyalar"
 msgid "All supported formats|"
 msgstr "Desteklenen tüm biçimler|"
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr "Amatör"
 
@@ -1004,7 +1004,7 @@ msgstr "Mevcut modüller"
 msgid "Bandplan"
 msgstr "Bant planı"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr "Bantlar"
 
@@ -1024,7 +1024,7 @@ msgstr "Tarayıcı"
 msgid "Building Radio Browser"
 msgstr "Telsiz Tarayıcısı oluşturuluyor"
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr "Kanada"
 
@@ -1074,7 +1074,7 @@ msgstr "Dubleks seç"
 msgid "Choose the module to load from issue %i:"
 msgstr "Sorun %i'den yüklenecek modülü seçin:"
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr "Şehir"
 
@@ -1143,12 +1143,16 @@ msgstr ""
 "Arayüz kablonuzu 'TX/RX' ünitesinin arkasındaki\n"
 "PC Bağlantı Noktasına bağlayın. Kafadaki Com Portu DEĞİL.\n"
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "Kopyala"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr "Ülke"
 
@@ -1214,6 +1218,11 @@ msgstr "Farklı Ham Kayıtlar"
 msgid "Digital Code"
 msgstr "Dijital Kod"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Dijital Kod"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr "Raporlamayı devre dışı bırak"
@@ -1222,7 +1231,7 @@ msgstr "Raporlamayı devre dışı bırak"
 msgid "Disabled"
 msgstr "Devre dışı"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Mesafe"
 
@@ -1250,6 +1259,10 @@ msgstr "Telsizden indir..."
 #: ../wxui/clone.py:515
 msgid "Download instructions"
 msgstr "İndirme talimatları"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -1327,7 +1340,7 @@ msgstr "CSV'ye aktar..."
 msgid "Extra"
 msgstr "Ekstra"
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1445,7 +1458,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1620,7 +1633,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1657,8 +1670,8 @@ msgstr "%(name)s için boş liste değeri bulundu: %(value)r"
 msgid "Frequency"
 msgstr "Frekans"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1695,7 +1708,7 @@ msgid "Hide empty memories"
 msgstr "Boş kayıtları gizle"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr "Ayarlanırsa, sonuçları bu koordinatlardan uzaklığa göre sırala"
 
@@ -1770,7 +1783,7 @@ msgstr "Kayıt numarası:"
 msgid "LIVE"
 msgstr "CANLI"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Enlem"
 
@@ -1779,7 +1792,7 @@ msgstr "Enlem"
 msgid "Length must be %i"
 msgstr "Uzunluk %i olmalıdır"
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr "Bantları Sınırla"
 
@@ -1787,11 +1800,11 @@ msgstr "Bantları Sınırla"
 msgid "Limit Modes"
 msgstr "Modları Sınırla"
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr "Durum Sınırla"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Sonuçları koordinatlardan bu mesafeye (km) sınırla"
 
@@ -1828,7 +1841,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr "Ayarlar yükleniyor"
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Boylam"
 
@@ -1850,7 +1863,7 @@ msgstr "Hafızanın düzenlenebilmesi için bir bankada olması gerekir"
 msgid "Memory {num} not in bank {bank}"
 msgstr "{num} kaydı {bank} bankasında değil"
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 msgid "Mode"
 msgstr "Mod"
 
@@ -1858,7 +1871,7 @@ msgstr "Mod"
 msgid "Model"
 msgstr "Model"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Modes"
 msgstr "Modlar"
 
@@ -1912,7 +1925,7 @@ msgstr "%i kadında modül bulunamadı"
 msgid "No results"
 msgstr "Sonuç yok"
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr "Sonuç yok!"
 
@@ -1924,7 +1937,7 @@ msgstr "Numara"
 msgid "Offset"
 msgstr "Ofset"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr "Sadece belirli gruplar"
 
@@ -1936,7 +1949,7 @@ msgstr "Yalnızca belirli modlar"
 msgid "Only memory tabs may be exported"
 msgstr "Yalnızca kayıt sekmeleri dışa aktarılabilir"
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr "Yalnızca çalışan tekrarlayıcılar (röleler)"
 
@@ -1972,15 +1985,15 @@ msgstr "Yeni pencerede aç"
 msgid "Open stock config directory"
 msgstr "Hazır yapılandırma dizinini aç"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr "İsteğe bağlı: -122.0000"
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 msgid "Optional: 100"
 msgstr "İsteğe bağlı: 100"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr "İsteğe bağlı: 45.0000"
 
@@ -2159,7 +2172,7 @@ msgstr ""
 "dışındaysa gerçekleşir ama telsiz bir ABD telsizi. Lütfen doğru modeli seçin "
 "ve tekrar deneyin."
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 "RadioReference Kanada, sorgulayabilmeniz için önce oturum açmanız gerekir"
@@ -2237,11 +2250,11 @@ msgstr "Güvenlik Riski"
 msgid "Select Bandplan..."
 msgstr "Bant Planı Seç..."
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Select Bands"
 msgstr "Bantları Seç"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 msgid "Select Modes"
 msgstr "Modları Seç"
 
@@ -2304,7 +2317,7 @@ msgstr "Kayıtları sırala"
 msgid "Sorting"
 msgstr "Sıralama"
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr "Devlet"
 
@@ -2396,16 +2409,16 @@ msgstr ""
 "güncellenmemişse, lütfen hata ayıklama günlüğü içeren bir hata raporu açarak "
 "bize yardım edin, böylece diğer revizyonlar için destek verebilelim."
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr "Bu erken aşama beta sürücüsüdür\n"
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr "Bu, erken aşamadaki bir beta sürücüsüdür - yükleme riski size aittir\n"
 
@@ -2524,7 +2537,7 @@ msgstr "%s bu sistemde gösterilemiyor"
 msgid "Unable to set %s on this memory"
 msgstr "Bu kayıtta %s ayarlanamıyor"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr "Amerika Birleşik Devletleri"
 

--- a/chirp/locale/uk_UA.po
+++ b/chirp/locale/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2015-11-30 10:36+0200\n"
 "Last-Translator: laser <student.laser@gmail.com>\n"
 "Language-Team: laser <student.laser@gmail.com>\n"
@@ -629,7 +629,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "Все"
 
@@ -642,7 +642,7 @@ msgstr "CSV-файли"
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr ""
 
@@ -662,7 +662,7 @@ msgstr ""
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr ""
 
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Виберіть один для Імпорту з:"
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr ""
 
@@ -794,13 +794,17 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 #, fuzzy
 msgid "Copy"
 msgstr "Копіювати"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr ""
 
@@ -871,6 +875,11 @@ msgstr "Порівняти Raw пам'ять"
 msgid "Digital Code"
 msgstr "Цифровий код"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "Цифровий код"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr ""
@@ -879,7 +888,7 @@ msgstr ""
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -910,6 +919,10 @@ msgstr "Скопіювати з радіостанції"
 #, fuzzy
 msgid "Download instructions"
 msgstr "Скопіювати з радіостанції"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -991,7 +1004,7 @@ msgstr "Експорт до файлу"
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1088,7 +1101,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1203,7 +1216,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1230,8 +1243,8 @@ msgstr ""
 msgid "Frequency"
 msgstr "Частота"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr ""
 
@@ -1270,7 +1283,7 @@ msgid "Hide empty memories"
 msgstr "Перезаписати?"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
@@ -1349,7 +1362,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
@@ -1358,7 +1371,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr ""
 
@@ -1366,11 +1379,11 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
@@ -1403,7 +1416,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1426,7 +1439,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 #, fuzzy
 msgid "Mode"
 msgstr "Режим"
@@ -1435,7 +1448,7 @@ msgstr "Режим"
 msgid "Model"
 msgstr "Модель"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Modes"
 msgstr "Режим"
@@ -1493,7 +1506,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr ""
 
@@ -1505,7 +1518,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Зсув"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr ""
 
@@ -1517,7 +1530,7 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr ""
 
@@ -1556,16 +1569,16 @@ msgstr ""
 msgid "Open stock config directory"
 msgstr "Відкрите заводські конфігурації {name}"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Опції"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1720,7 +1733,7 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
@@ -1796,12 +1809,12 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 #, fuzzy
 msgid "Select Bands"
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Select Modes"
 msgstr "Виберіть Стовпці"
@@ -1868,7 +1881,7 @@ msgstr "Перезаписати?"
 msgid "Sorting"
 msgstr ""
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr ""
 
@@ -1934,16 +1947,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr ""
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 
@@ -2049,7 +2062,7 @@ msgstr "Не вдається внести зміни до цієї моделі
 msgid "Unable to set %s on this memory"
 msgstr "Не вдається внести зміни до цієї моделі"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr ""
 

--- a/chirp/locale/zh_CN.po
+++ b/chirp/locale/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-24 10:51-0800\n"
+"POT-Creation-Date: 2023-11-27 14:59-0800\n"
 "PO-Revision-Date: 2022-06-04 02:01+0800\n"
 "Last-Translator: DuckSoft, BH2UEP <realducksoft@gmail.com>\n"
 "Language: zh_CN\n"
@@ -628,7 +628,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:355
+#: ../wxui/query_sources.py:361
 msgid "All"
 msgstr "全选"
 
@@ -641,7 +641,7 @@ msgstr "全部文件"
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:347
+#: ../wxui/query_sources.py:283 ../wxui/query_sources.py:353
 msgid "Amateur"
 msgstr ""
 
@@ -661,7 +661,7 @@ msgstr ""
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 msgid "Bands"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr "浏览器"
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/query_sources.py:681
+#: ../wxui/query_sources.py:689
 msgid "Canada"
 msgstr ""
 
@@ -729,7 +729,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "选择一个来导入："
 
-#: ../wxui/query_sources.py:453
+#: ../wxui/query_sources.py:461
 msgid "City"
 msgstr ""
 
@@ -794,12 +794,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
+#: ../wxui/query_sources.py:331
+msgid "Convert to FM"
+msgstr ""
+
 #: ../wxui/memedit.py:1569
 msgid "Copy"
 msgstr "复制"
 
-#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:459
-#: ../wxui/query_sources.py:549
+#: ../wxui/query_sources.py:281 ../wxui/query_sources.py:467
+#: ../wxui/query_sources.py:557
 msgid "Country"
 msgstr ""
 
@@ -868,6 +872,11 @@ msgstr "对比原始存储"
 msgid "Digital Code"
 msgstr "数字代码"
 
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Digital Modes"
+msgstr "数字代码"
+
 #: ../wxui/main.py:1678
 msgid "Disable reporting"
 msgstr ""
@@ -877,7 +886,7 @@ msgstr ""
 msgid "Disabled"
 msgstr "已启用"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -908,6 +917,10 @@ msgstr "从电台下载"
 #, fuzzy
 msgid "Download instructions"
 msgstr "显示指引"
+
+#: ../wxui/query_sources.py:333
+msgid "Dual-mode digital repeaters that support analog will be shown as FM"
+msgstr ""
 
 #: ../wxui/memedit.py:394
 msgid "Duplex"
@@ -991,7 +1004,7 @@ msgstr "导出到文件"
 msgid "Extra"
 msgstr ""
 
-#: ../wxui/query_sources.py:604
+#: ../wxui/query_sources.py:612
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1091,7 +1104,7 @@ msgstr ""
 #: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:452 ../drivers/bf_t1.py:483
+#: ../drivers/baofeng_uv17Pro.py:445 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1206,7 +1219,7 @@ msgstr ""
 #: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
 #: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
 #: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:458
+#: ../drivers/baofeng_uv17Pro.py:451
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1233,8 +1246,8 @@ msgstr ""
 msgid "Frequency"
 msgstr "频率"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:338
-#: ../wxui/query_sources.py:429
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:344
+#: ../wxui/query_sources.py:436
 msgid "GMRS"
 msgstr ""
 
@@ -1276,7 +1289,7 @@ msgid "Hide empty memories"
 msgstr "要覆盖吗？"
 
 #: ../wxui/query_sources.py:295 ../wxui/query_sources.py:301
-#: ../wxui/query_sources.py:556 ../wxui/query_sources.py:562
+#: ../wxui/query_sources.py:564 ../wxui/query_sources.py:570
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
@@ -1355,7 +1368,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
@@ -1364,7 +1377,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:324 ../wxui/query_sources.py:532
 msgid "Limit Bands"
 msgstr ""
 
@@ -1372,11 +1385,11 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:539
+#: ../wxui/query_sources.py:547
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
@@ -1409,7 +1422,7 @@ msgstr ""
 msgid "Loading settings"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:565
+#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1431,7 +1444,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:516 ../wxui/memedit.py:510
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:510
 #, fuzzy
 msgid "Mode"
 msgstr "制式"
@@ -1440,7 +1453,7 @@ msgstr "制式"
 msgid "Model"
 msgstr "型号"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Modes"
 msgstr "制式"
@@ -1501,7 +1514,7 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:284
+#: ../sources/repeaterbook.py:290
 msgid "No results!"
 msgstr ""
 
@@ -1513,7 +1526,7 @@ msgstr ""
 msgid "Offset"
 msgstr "频差"
 
-#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:522
+#: ../wxui/query_sources.py:322 ../wxui/query_sources.py:530
 msgid "Only certain bands"
 msgstr ""
 
@@ -1525,7 +1538,7 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:541
 msgid "Only working repeaters"
 msgstr ""
 
@@ -1564,16 +1577,16 @@ msgstr ""
 msgid "Open stock config directory"
 msgstr "打开库存配置 {name}"
 
-#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:561
+#: ../wxui/query_sources.py:300 ../wxui/query_sources.py:569
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:569
+#: ../wxui/query_sources.py:309 ../wxui/query_sources.py:577
 #, fuzzy
 msgid "Optional: 100"
 msgstr "选项"
 
-#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:555
+#: ../wxui/query_sources.py:294 ../wxui/query_sources.py:563
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1728,7 +1741,7 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:828
+#: ../wxui/query_sources.py:836
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
@@ -1805,12 +1818,12 @@ msgstr ""
 msgid "Select Bandplan..."
 msgstr "全选"
 
-#: ../wxui/query_sources.py:377 ../wxui/query_sources.py:590
+#: ../wxui/query_sources.py:383 ../wxui/query_sources.py:598
 #, fuzzy
 msgid "Select Bands"
 msgstr "选择列"
 
-#: ../wxui/query_sources.py:398
+#: ../wxui/query_sources.py:404
 #, fuzzy
 msgid "Select Modes"
 msgstr "选择列"
@@ -1877,7 +1890,7 @@ msgstr "要覆盖吗？"
 msgid "Sorting"
 msgstr "设置"
 
-#: ../wxui/query_sources.py:456
+#: ../wxui/query_sources.py:464
 msgid "State"
 msgstr ""
 
@@ -1943,16 +1956,16 @@ msgid ""
 "add support for the other revisions."
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1317 ../drivers/radtel_rt490.py:1319
-#: ../drivers/radtel_rt490.py:1321
+#: ../drivers/radtel_rt490.py:1321 ../drivers/radtel_rt490.py:1323
+#: ../drivers/radtel_rt490.py:1325
 msgid "This driver is in development and should be considered as experimental."
 msgstr ""
 
-#: ../drivers/th_uv88.py:495
+#: ../drivers/th_uv88.py:553
 msgid "This is an early stage beta driver\n"
 msgstr ""
 
-#: ../drivers/th_uv88.py:497
+#: ../drivers/th_uv88.py:555
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr ""
 
@@ -2058,7 +2071,7 @@ msgstr "无法变更此型号电台"
 msgid "Unable to set %s on this memory"
 msgstr "无法变更此型号电台"
 
-#: ../wxui/query_sources.py:680
+#: ../wxui/query_sources.py:688
 msgid "United States"
 msgstr ""
 

--- a/chirp/sources/repeaterbook.py
+++ b/chirp/sources/repeaterbook.py
@@ -215,6 +215,7 @@ class RepeaterBook(base.NetworkResultRadio):
         search_filter = params.pop('filter', '')
         bands = params.pop('bands', [])
         modes = params.pop('modes', [])
+        fmconv = params.pop('fmconv', False)
         data_file = self.get_data(status,
                                   params.get('country'),
                                   params.pop('state'),
@@ -273,6 +274,11 @@ class RepeaterBook(base.NetworkResultRadio):
                 continue
             if not m:
                 continue
+            # Convert any non-FM repeater to FM if user requested it
+            if m.mode != 'FM' and fmconv and item.get('FM Analog') == 'Yes':
+                LOG.debug('Converting repeater %r from %r to FM: %s',
+                          item['Rptr ID'], m.mode, m.comment)
+                m.mode = 'FM'
             if modes and m.mode not in modes:
                 continue
             self._memories.append(m)

--- a/chirp/wxui/query_sources.py
+++ b/chirp/wxui/query_sources.py
@@ -328,6 +328,12 @@ class RepeaterBookQueryDialog(QuerySourceDialog):
         self.Bind(wx.EVT_CHECKBOX, self._select_modes, self._modefilter)
         self._add_grid(grid, _('Limit Modes'), self._modefilter)
 
+        self._fmconv = wx.CheckBox(panel, label=_('Convert to FM'))
+        self._fmconv.SetValue(CONF.get_bool('fmconv', 'repeaterbook'))
+        self._fmconv.SetToolTip(_('Dual-mode digital repeaters that support '
+                                  'analog will be shown as FM'))
+        self._add_grid(grid, _('Digital Modes'), self._fmconv)
+
         self._state_selected(None)
         self._service_selected(None)
 
@@ -412,6 +418,7 @@ class RepeaterBookQueryDialog(QuerySourceDialog):
         CONF.set('state', self._state.GetStringSelection(), 'repeaterbook')
         CONF.set('country', self._country.GetStringSelection(), 'repeaterbook')
         CONF.set('service', self._service.GetStringSelection(), 'repeaterbook')
+        CONF.set_bool('fmconv', self._fmconv.IsChecked(), 'repeaterbook')
         self.result_radio = repeaterbook.RepeaterBook()
         super().do_query()
 
@@ -428,6 +435,7 @@ class RepeaterBookQueryDialog(QuerySourceDialog):
             'modes': self._limit_modes,
             'service': 'gmrs' if service == _('GMRS') else '',
             'service_display': self._service.GetStringSelection(),
+            'fmconv': self._fmconv.IsChecked(),
         }
 
 


### PR DESCRIPTION
This makes repeaterbook allow the query to convert multi-mode repeaters
that support FM to be represented as such in the result set, thus
making it easier to add those repeaters to an analog-only radio.

Fixes #10962
