### PR TITLE
Fix decoding module during SHA calculation

### DIFF
--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1587,10 +1587,10 @@ class ChirpMain(wx.Frame):
 
         self.SetBackgroundColour((0xEA, 0x62, 0x62, 0xFF))
 
-        with open(filename) as module:
+        with open(filename, 'rb') as module:
             code = module.read()
         sha = hashlib.sha256()
-        sha.update(code.encode())
+        sha.update(code)
         LOG.info('Loading module %s SHA256 %s' % (filename, sha.hexdigest()))
 
         import importlib.util


### PR DESCRIPTION
When we load a module, we read it in to calculate the SHA for logging.
The current code reads it as text and decodes it, which defaults to
cp1252 on windows instead of UTF-8 as it should be (and as other
platforms do). However, we have to convert that back to bytes to do
the hash, so we should just read it as bytes in the first place to
avoid the issue altogether.
