### PR TITLE
mml_jc8810.py: Add HI-8811 firmware v2.00 support - fixes #10975

### DIFF
--- a/chirp/drivers/mml_jc8810.py
+++ b/chirp/drivers/mml_jc8810.py
@@ -1330,9 +1330,22 @@ class HI8811Radio(RT470LRadio):
 
     # ==========
     # Notice to developers:
-    # The HI-8811 support in this driver is currently based upon v1.17
-    # firmware.
+    # The HI-8811 support in this driver is currently based upon...
+    # - v1.17 firmware (original pcb)
+    # - v2.00 firmware (pcb2)
     # ==========
+
+    # original pcb
+    _fingerprint_pcb1 = [b"\x00\x00\x00\xfe\x00\x20\xAC\x04",
+                         b"\x00\x00\x00\x20\x00\x20\xCC\x04",  # fw v1.17
+                         b"\x00\x00\x00\x20\x00\x20\x07\x00",
+                         ]
+
+    # pcb 2
+    _fingerprint_pcb2 = [b"\x00\x00\x00\x28\x00\x20\xD4\x04",  # fw v2.00
+                         ]
+
+    _fingerprint = _fingerprint_pcb1 + _fingerprint_pcb2
 
 
 @directory.register


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
