### PR TITLE
Reflect settings modifications of RadioSettingValue._validate_callbac…

### DIFF
--- a/chirp/wxui/settingsedit.py
+++ b/chirp/wxui/settingsedit.py
@@ -125,7 +125,15 @@ class ChirpSettingsEdit(common.ChirpEditor):
                                                             val))
                         realname, index = name.split(common.INDEX_CHAR)
                         if int(index) == j:
-                            setting[j] = val
+                            try:
+                                setting[j] = val
+                            finally:
+                                if setting[j].get_value() != val:
+                                    # setting value modified or not accepted in
+                                    # validate callback, propagate back to GUI
+                                    prop = self._propgrid.propgrid.GetProperty(
+                                        name)
+                                    prop.SetValue(setting[j].get_value())
             return True
         except Exception as e:
             LOG.exception('Failed to apply settings')


### PR DESCRIPTION
…k onto a GUI

When a validate callback is defined and it modifies a value, or rises an exception it is not reflected onto the user interface. The value in internal settings will be different from what a user is presented with. Moreover if the validation rises an exception the value in the interface is preserved, subsequent changes to any other settings will again read the value from GUI and rise the exception each and every time. This PR fixes it.