### PR TITLE
[UV-K5] warn the user of the radio being in firmware flash mode

### DIFF
--- a/chirp/drivers/uvk5.py
+++ b/chirp/drivers/uvk5.py
@@ -495,6 +495,13 @@ def _sayhello(serport):
         LOG.debug("Sending hello packet")
         _send_command(serport, hellopacket)
         o = _receive_reply(serport)
+
+        if o[0] == 0x18 and o[1] == 0x05:
+            LOG.warning("Radio is in firmware flash mode")
+            raise errors.RadioError(
+                    "This radio is in firmware flash mode (PTT + turn on). "
+                    "Please do this according to the vendor documentation")
+
         if (o):
             break
         tries -= 1


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
