### PR TITLE
Remove unused imports

### DIFF
--- a/chirp/drivers/ga510.py
+++ b/chirp/drivers/ga510.py
@@ -18,7 +18,6 @@
 import logging
 import struct
 
-from chirp import bandplan_na
 from chirp import bitwise
 from chirp import chirp_common
 from chirp import directory

--- a/chirp/drivers/ic2730.py
+++ b/chirp/drivers/ic2730.py
@@ -27,14 +27,6 @@ from chirp.settings import RadioSettingGroup, RadioSetting, \
 
 LOG = logging.getLogger(__name__)
 
-HAS_FUTURE = True
-try:                         # PY3 compliance
-    from builtins import bytes
-except ImportError:
-    HAS_FUTURE = False
-    LOG.debug('python-future package is not '
-              'available; %s requires it' % __name__)
-
 MEM_FORMAT = """
 struct {
   u24  freq_flags:6,

--- a/chirp/drivers/retevis_rb15.py
+++ b/chirp/drivers/retevis_rb15.py
@@ -18,7 +18,6 @@ import logging
 
 from chirp import chirp_common, directory, memmap
 from chirp import bitwise, errors, util
-from chirp import bandplan_na
 from chirp.settings import RadioSetting, RadioSettingGroup, \
     RadioSettingValueInteger, RadioSettingValueList, \
     RadioSettingValueBoolean, RadioSettings

--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -24,7 +24,7 @@ from chirp import bitwise
 from chirp.settings import RadioSetting, RadioSettingGroup, \
     RadioSettingValueInteger, RadioSettingValueList, \
     RadioSettingValueBoolean, RadioSettingValueString, \
-    RadioSettingValueFloat, InvalidValueError, RadioSettings
+    InvalidValueError, RadioSettings
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
Fixes the following pylint warnings:
```
chirp/drivers/ga510.py:21:0: W0611: Unused bandplan_na imported from chirp (unused-import) 
chirp/drivers/retevis_rb15.py:21:0: W0611: Unused bandplan_na imported from chirp (unused-import) 
chirp/drivers/uv5r.py:24:0: W0611: Unused RadioSettingValueFloat imported from chirp.settings (unused-import) 
chirp/drivers/ic2730.py:32:4: W0611: Unused bytes imported from builtins (unused-import)
```
---
For the first 3 files above, code that used bandplan_na and RadioSettingValueFloat was removed some time ago but the import remained.
For chirp/drivers/ic2730.py `git log` doesn't show that `bytes` and `HAS_FUTURE` have been used in that file.
