### PR TITLE
mml_jc8810.py: Support Radtel RT-470X Firmware 2.13A - fixes #11027

### DIFF
--- a/chirp/drivers/mml_jc8810.py
+++ b/chirp/drivers/mml_jc8810.py
@@ -466,7 +466,7 @@ class JC8810base(chirp_common.CloneModeRadio):
         rf.valid_modes = ["FM", "NFM"]  # 25 kHz, 12.5 kHz.
         rf.valid_dtcs_codes = DTCS
         rf.memory_bounds = (1, self._upper)
-        rf.valid_tuning_steps = [2.5, 5., 6.25, 10., 12.5, 20., 25., 50.]
+        rf.valid_tuning_steps = [2.5, 5., 6.25, 8.33, 10., 12.5, 20., 25., 50.]
         rf.valid_bands = self.VALID_BANDS
         return rf
 
@@ -1294,7 +1294,7 @@ class RT470XRadio(RT470LRadio):
     # Notice to developers:
     # The RT-470X support in this driver is currently based upon...
     # - v1.18a firmware (original pcb)
-    # - v2.10a firmware (pcb2)
+    # - v2.13a firmware (pcb2)
     # ==========
 
     # original pcb
@@ -1303,6 +1303,7 @@ class RT470XRadio(RT470LRadio):
 
     # pcb 2
     _fingerprint_pcb2 = [b"\x00\x00\x00\x2C\x00\x20\xD8\x04",  # fw v2.10A
+                         b"\x00\x00\x00\x36\x00\x20\xDC\x04",  # fw v2.13A
                          ]
 
     _fingerprint = _fingerprint_pcb1 + _fingerprint_pcb2


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues).
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
