### PR TITLE
Fix/vulture

### DIFF
--- a/chirp/drivers/ic9x_ll.py
+++ b/chirp/drivers/ic9x_ll.py
@@ -145,7 +145,7 @@ class IC92Frame:
 
     def send(self, pipe, verbose=False):
         """Send the frame to the radio via @pipe"""
-        if verbose or True:
+        if verbose:
             LOG.debug("Sending:\n%s" % util.hexprint(self.get_raw()))
 
         response = ic9x_send(pipe, self.get_raw())

--- a/chirp/drivers/th_uvf8d.py
+++ b/chirp/drivers/th_uvf8d.py
@@ -621,12 +621,6 @@ class TYTUVF8DRadio(chirp_common.CloneModeRadio):
 
         return top
 
-        group.append(RadioSetting(
-                "disnm", "Display Name",
-                RadioSettingValueBoolean(_settings.disnm)))
-
-        return group
-
     def set_settings(self, settings):
         _settings = self._memobj.settings
 

--- a/chirp/drivers/uv6r.py
+++ b/chirp/drivers/uv6r.py
@@ -853,7 +853,7 @@ class UV6R(baofeng_common.BaofengCommonHT):
         match_model = False
 
         # testing the file data size
-        if len(filedata) == 0x2008 or 0x2010:
+        if len(filedata) in (0x2008, 0x2010):
             match_size = True
 
         # testing the firmware model fingerprint

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -266,9 +266,6 @@ class ChirpFrequencyColumn(ChirpMemoryColumn):
 
 
 class ChirpVariablePowerColumn(ChirpMemoryColumn):
-    def __init__(self, name, radio, power_levels):
-        super().__init__(name, radio)
-
     @property
     def level(self):
         return _('Power')
@@ -872,12 +869,13 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
         valid_modes = filter_unknowns(self._features.valid_modes)
         valid_skips = filter_unknowns(self._features.valid_skips)
         valid_duplexes = filter_unknowns(self._features.valid_duplexes)
-        valid_power_levels = self._features.valid_power_levels
         valid_tuning_steps = self._features.valid_tuning_steps
         if self._features.has_variable_power:
-            power_col_cls = ChirpVariablePowerColumn
+            power_column = ChirpVariablePowerColumn('power', self._radio)
         else:
-            power_col_cls = ChirpChoiceColumn
+            valid_power_levels = self._features.valid_power_levels
+            power_column = ChirpChoiceColumn('power', self._radio,
+                                             valid_power_levels)
         defs = [
             ChirpFrequencyColumn('freq', self._radio),
             ChirpMemoryColumn('name', self._radio),
@@ -900,8 +898,7 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
                               label=_('Tuning Step')),
             ChirpChoiceColumn('skip', self._radio,
                               valid_skips),
-            power_col_cls('power', self._radio,
-                          valid_power_levels),
+            power_column,
             ChirpCommentColumn('comment', self._radio),
         ]
         return defs


### PR DESCRIPTION
This PR fixes some issues found with `vulture --min-confidence 100 chirp`; other issues with confidence 100 and below remain.

The first commit modifies what looks like a constant added to debug code.

The second commit removes what looks like a copy and paste error from `huv1f.py` because that's the only driver that handles the `"disnm"` setting.

The third commit does some refactoring so in both cases and object with only the mandatory arguments gets created.

The fourth commit fixes a check for an integer number.