### PR TITLE
Fix/gui

### DIFF
--- a/chirp/wxui/developer.py
+++ b/chirp/wxui/developer.py
@@ -83,8 +83,10 @@ class MemoryDialog(wx.Dialog):
         if isinstance(mem, tuple):
             mem_a, mem_b = mem
             self._diff_memories(mem_a, mem_b)
+            self.SetTitle(_('Diff Raw Memories'))
         else:
             self._raw_memory(mem)
+            self.SetTitle(_('Show Raw Memory'))
 
         self.SetSize(640, 480)
         self.Centre()

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -601,14 +601,14 @@ class ChirpMain(wx.Frame):
             add_stock(fn)
             found.append(os.path.basename(fn))
 
-        stock.Append(wx.MenuItem(stock, wx.ID_SEPARATOR))
+        if user_stock_confs:
+            stock.Append(wx.MenuItem(stock, wx.ID_SEPARATOR))
 
         if sys.platform in ('darwin', 'win32'):
             reveal = stock.Append(REVEAL_STOCK_DIR,
                                   _('Open stock config directory'))
             self.Bind(wx.EVT_MENU, self._menu_open_stock_config, reveal)
-
-        stock.Append(wx.MenuItem(stock, wx.ID_SEPARATOR))
+            stock.Append(wx.MenuItem(stock, wx.ID_SEPARATOR))
 
         for fn, hash in dist_stock_confs:
             if os.path.basename(fn) in found:

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -1670,13 +1670,13 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
                       raw_item)
             menu.Append(raw_item)
 
-            if len(selected_rows) == 2:
-                diff_item = wx.MenuItem(menu, wx.NewId(),
-                                        _('Diff Raw Memories'))
-                self.Bind(wx.EVT_MENU,
-                          functools.partial(self._mem_diff, selected_rows),
-                          diff_item)
-                menu.Append(diff_item)
+            diff_item = wx.MenuItem(menu, wx.NewId(),
+                                    _('Diff Raw Memories'))
+            self.Bind(wx.EVT_MENU,
+                      functools.partial(self._mem_diff, selected_rows),
+                      diff_item)
+            menu.Append(diff_item)
+            menu.Enable(diff_item.GetId(), len(selected_rows) == 2)
 
         self.PopupMenu(menu)
         menu.Destroy()


### PR DESCRIPTION
This PR makes small changes to make the GUI nicer:

- disable the developer's menu item "Diff Raw Memories" instead of hiding it (makes it more discoverable)
- add a title for the popup window that shows raw memories
- show the menu separators only when needed in the "Open Stock Config" submenu