### PR TITLE
Implement 'Open stock config directory' for Linux

### DIFF
--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -615,6 +615,8 @@ def reveal_location(path):
         wx.Execute('explorer %s' % path)
     elif system == 'Darwin':
         wx.Execute('open -R %s' % path)
+    elif system == 'Linux':
+        wx.Execute('open %s' % path)
     else:
         raise Exception(_('Unable to reveal %s on this system') % path)
 

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -604,7 +604,7 @@ class ChirpMain(wx.Frame):
         if user_stock_confs:
             stock.Append(wx.MenuItem(stock, wx.ID_SEPARATOR))
 
-        if sys.platform in ('darwin', 'win32'):
+        if sys.platform in ('darwin', 'linux', 'win32'):
             reveal = stock.Append(REVEAL_STOCK_DIR,
                                   _('Open stock config directory'))
             self.Bind(wx.EVT_MENU, self._menu_open_stock_config, reveal)


### PR DESCRIPTION
This PR enable the menu item 'Open stock config directory' for Linux. Tested on a Debian system.