### PR TITLE
Added ability to open/import .csv files with # comments in them (no use of temp files).

### DIFF
--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -204,6 +204,9 @@ class CSVRadio(chirp_common.FileBackedRadio):
         good = 0
         lineno = 0
         for line in reader:
+            # Skipping comment lines that start with #
+            if line and line[0].startswith('#'):
+                continue
             lineno += 1
             if lineno == 1:
                 header = line
@@ -311,7 +314,13 @@ class CSVRadio(chirp_common.FileBackedRadio):
             # CSV files are text
             return False
         return filename.lower().endswith("." + cls.FILE_EXTENSION) and \
-            (filedata.startswith("Location,") or filedata == "")
+            (find_csv_header(filedata) or filedata == "")
+
+
+def find_csv_header(filedata):
+    while filedata.startswith('#'):
+        filedata = filedata[filedata.find('\n') + 1:]
+    return filedata.startswith('Location,')
 
 
 @directory.register

--- a/tests/unit/test_csv.py
+++ b/tests/unit/test_csv.py
@@ -72,6 +72,20 @@ class TestCSV(unittest.TestCase):
         self.assertEqual('5.0W', str(mem.power))
         self.assertIn('UHF calling', mem.comment)
 
+    def test_csv_with_comments(self):
+        lines = list(CHIRP_CSV_MODERN.split('\n'))
+        lines.insert(0, '# This is a comment')
+        lines.insert(0, '# Test file with comments')
+        lines.insert(4, '# Test comment in the middle')
+        lines.append('# Comment at the end')
+        with open(self.testfn, 'w') as f:
+            f.write('\n'.join(lines))
+        csv = generic_csv.CSVRadio(self.testfn)
+        mem = csv.get_memory(0)
+        self.assertEqual(146520000, mem.freq)
+        mem = csv.get_memory(1)
+        self.assertEqual(446000000, mem.freq)
+
     def test_parse_modern_bom(self):
         self.test_parse_modern(output_encoding='utf-8-sig')
 

--- a/tests/unit/test_csv.py
+++ b/tests/unit/test_csv.py
@@ -73,18 +73,22 @@ class TestCSV(unittest.TestCase):
         self.assertIn('UHF calling', mem.comment)
 
     def test_csv_with_comments(self):
-        lines = list(CHIRP_CSV_MODERN.split('\n'))
+        lines = list(CHIRP_CSV_MODERN.strip().split('\n'))
         lines.insert(0, '# This is a comment')
         lines.insert(0, '# Test file with comments')
         lines.insert(4, '# Test comment in the middle')
         lines.append('# Comment at the end')
         with open(self.testfn, 'w') as f:
-            f.write('\n'.join(lines))
+            f.write('\r\n'.join(lines))
         csv = generic_csv.CSVRadio(self.testfn)
         mem = csv.get_memory(0)
         self.assertEqual(146520000, mem.freq)
         mem = csv.get_memory(1)
         self.assertEqual(446000000, mem.freq)
+        csv.save(self.testfn)
+        with open(self.testfn, 'r') as f:
+            read_lines = [x.strip() for x in f.readlines()]
+        self.assertEqual(lines, read_lines)
 
     def test_parse_modern_bom(self):
         self.test_parse_modern(output_encoding='utf-8-sig')


### PR DESCRIPTION
This is a new pull request to replace PR 870, because I couldn't figure out how to get rid of the "Please do not include merge commits in your PR" (tried rebasing, etc)

Here's there original discussion regarding PR 870, for reference:
[Please do not include merge commits in your PR](https://github.com/kk7ds/chirp/pull/870)

This is related to feature request 11081:
https://chirp.danplanet.com/issues/11081

Anyway...

* Rewrote to NOT use a temp file to strip out # comment lines from opened/imported .csv files.

Now, comments are stripped in two places:

-chirp/directory.py:  where lines starting with "#" are stripped out from filedata variable after a binary read.  If the file read in is a .csv file, then filedata is split into lines and then rejoined, skipping lines that start with "#", if it's not a .csv file, but nothing is modified from the usual code path.

-chirp/drivers/generic_csv.py:  Where lines are read in to "line" by csv.reader and lines who's first element starts with "#" are skipped (i.e. jump to next iteration of the loops without being processed)

You can open and import .csv files that have comment lines that start with "#" anywhere in the file.
