### PR TITLE
Add a GUI option to set restore tabs on start

### DIFF
--- a/chirp/locale/de.po
+++ b/chirp/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2012-10-02 22:11+0100\n"
 "Last-Translator: Benjamin, HB9EUK <hb9euk@hb9d.org>\n"
 "Language-Team: German\n"
@@ -35,28 +35,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Löschen (und nach oben verschieben)"
 msgstr[1] "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Speicher"
 msgstr[1] "Speicher"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Löschen (und nach oben verschieben)"
 msgstr[1] "Löschen (und nach oben verschieben)"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Datei wurde geändert, speichern Sie die Änderungen vor dem Schliessen?"
@@ -65,7 +65,7 @@ msgstr "Datei wurde geändert, speichern Sie die Änderungen vor dem Schliessen?
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -623,17 +623,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr ""
 
@@ -641,12 +641,12 @@ msgstr ""
 msgid "All"
 msgstr "Alle"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "CSV Datei"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
@@ -662,11 +662,11 @@ msgstr "Ein Fehler ist aufgetreten"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr ""
 
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Banks"
 msgstr "Bank"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr ""
 
@@ -686,7 +686,7 @@ msgstr ""
 msgid "Browser"
 msgstr ""
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr ""
 
@@ -700,40 +700,40 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross Mode"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, fuzzy, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Importieren von:"
@@ -770,22 +770,22 @@ msgstr "Download vom Gerät"
 msgid "Cloning to radio"
 msgstr "Upload zum Gerät"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -817,7 +817,7 @@ msgstr "Kopieren"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr "Cross Mode"
 
@@ -829,16 +829,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -849,38 +849,38 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr ""
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 #, fuzzy
 msgid "Dec"
 msgstr "Erkennung"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Entwickler"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr "Digital Code"
 
@@ -889,16 +889,17 @@ msgstr "Digital Code"
 msgid "Digital Modes"
 msgstr "Digital Code"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 #, fuzzy
 msgid "Disabled"
 msgstr "Aktiviert"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -911,16 +912,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download vom Gerät"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download vom Gerät"
@@ -938,25 +939,25 @@ msgstr ""
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 #, fuzzy
 msgid "Enabled"
 msgstr "Aktiviert"
@@ -966,11 +967,11 @@ msgstr "Aktiviert"
 msgid "Enter Frequency"
 msgstr "Frequenz"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1002,11 +1003,11 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Weiter mit dem experimentellen Treiber?"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 #, fuzzy
 msgid "Export to CSV"
 msgstr "In Datei exportieren"
@@ -1016,7 +1017,7 @@ msgstr "In Datei exportieren"
 msgid "Export to CSV..."
 msgstr "In Datei exportieren"
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr ""
 
@@ -1031,7 +1032,7 @@ msgid ""
 "required."
 msgstr ""
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr ""
 
@@ -1048,8 +1049,8 @@ msgstr ""
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 #, fuzzy
 msgid "Files"
 msgstr "_Datei"
@@ -1062,7 +1063,7 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
@@ -1275,20 +1276,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Zeige RAW Speicher"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Hilfe"
 
@@ -1296,11 +1297,11 @@ msgstr "Hilfe"
 msgid "Help Me..."
 msgstr ""
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Überschreiben?"
@@ -1310,7 +1311,7 @@ msgstr "Überschreiben?"
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Importieren"
 
@@ -1319,7 +1320,7 @@ msgstr "Importieren"
 msgid "Import from file..."
 msgstr "Importieren von Datei"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr ""
 
@@ -1331,11 +1332,11 @@ msgstr "Index"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Zeile oben einfügen"
@@ -1344,7 +1345,7 @@ msgstr "Zeile oben einfügen"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1353,7 +1354,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ungültiger Wert. Muss eine ganze Zahl sein."
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ungültiger Wert für dieses Feld"
@@ -1362,12 +1363,12 @@ msgstr "Ungültiger Wert für dieses Feld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1376,7 +1377,7 @@ msgstr ""
 msgid "Invalid value: %r"
 msgstr "Ungültiger Wert für dieses Feld"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr ""
 
@@ -1384,11 +1385,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr ""
@@ -1414,17 +1416,17 @@ msgstr ""
 msgid "Load Module..."
 msgstr "Module laden"
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 #, fuzzy
 msgid "Load module from issue"
 msgstr "Module laden"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Module laden"
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1446,7 +1448,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1454,7 +1457,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Speicher"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1468,7 +1471,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1482,17 +1485,17 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Mode"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 #, fuzzy
 msgid "Module"
 msgstr "Module laden"
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Module laden"
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1501,12 +1504,12 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 #, fuzzy
 msgid "Move Down"
 msgstr "Nach _Unten"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 #, fuzzy
 msgid "Move Up"
 msgstr "Nach _Oben"
@@ -1515,21 +1518,21 @@ msgstr "Nach _Oben"
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 #, fuzzy
 msgid "New version available"
 msgstr "Eine neue Version von CHIRP ist verfügbar:"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Zeile unten einfügen"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr ""
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr ""
@@ -1542,7 +1545,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr ""
 
@@ -1566,7 +1569,7 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
@@ -1580,15 +1583,15 @@ msgstr "_Aktuell"
 msgid "Open Stock Config"
 msgstr "Speichervorgaben öffnen"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
@@ -1596,7 +1599,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Vorgaben öffnen {name}"
@@ -1618,7 +1621,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Überschreiben?"
@@ -1634,31 +1637,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1688,7 +1691,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1708,11 +1711,11 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Leistung"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 #, fuzzy
 msgid "Press enter to set this in memory"
 msgstr "Fehler beim Setzen der Speicher"
@@ -1725,25 +1728,25 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 #, fuzzy
 msgid "Query Source"
 msgstr "Datenquelle abfragen"
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Gerät"
 
@@ -1784,11 +1787,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1803,19 +1806,19 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Report ist deaktiviert"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr ""
 
@@ -1826,19 +1829,23 @@ msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../wxui/main.py:815
+msgid "Restore tabs on start"
+msgstr ""
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1855,11 +1862,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Spalten auswählen"
@@ -1874,7 +1881,7 @@ msgstr "Spalten auswählen"
 msgid "Select Modes"
 msgstr "Spalten auswählen"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1886,54 +1893,54 @@ msgstr ""
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "Zeige RAW Speicher"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "Eingefügter Speicher {number} ist nicht mit diesem Gerät kompatibel weil:"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 #, fuzzy
 msgid "Sort memories"
 msgstr "Überschreiben?"
@@ -1951,7 +1958,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr ""
 
@@ -1984,14 +1991,14 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2001,7 +2008,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 #, fuzzy
 msgid "This Memory"
 msgstr "Zeige RAW Speicher"
@@ -2046,12 +2053,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Löschen (und nach oben verschieben)"
@@ -2073,24 +2080,24 @@ msgid ""
 "own risk!"
 msgstr ""
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "Tone"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Tone Mode"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Abstimmungsschritt"
@@ -2105,11 +2112,11 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Speichervorgaben öffnen"
@@ -2130,7 +2137,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Keine Änderungen bei diesem Modell möglich"
@@ -2152,12 +2159,12 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Upload zum Gerät"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Upload zum Gerät"
@@ -2175,7 +2182,7 @@ msgstr ""
 msgid "Use larger font"
 msgstr ""
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr ""
@@ -2190,16 +2197,16 @@ msgstr ""
 msgid "Value must be at most %.4f"
 msgstr ""
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr ""
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr ""
 
@@ -2207,7 +2214,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Hersteller"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 #, fuzzy
 msgid "View"
 msgstr "_Ansicht"
@@ -2216,11 +2223,11 @@ msgstr "_Ansicht"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2237,24 +2244,24 @@ msgstr ""
 msgid "Your cable appears to be on port:"
 msgstr ""
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr ""
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr ""
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 #, fuzzy
 msgid "disabled"
 msgstr "Aktiviert"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 #, fuzzy
 msgid "enabled"
 msgstr "Aktiviert"

--- a/chirp/locale/el.po
+++ b/chirp/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2023-02-11 15:12+0200\n"
 "Last-Translator: Sokratis Alichanidis <sv2hzs@posteo.net>\n"
 "Language-Team: Greek\n"
@@ -37,28 +37,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 msgstr[1] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Μνήμες"
 msgstr[1] "Μνήμες"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
 msgstr[1] "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr ""
@@ -67,7 +67,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(καμία)"
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -625,7 +625,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -633,11 +633,11 @@ msgstr ""
 "Μία νέα έκδοση του CHIRP είναι διαθέσιμη. Παρακαλούμε επισκεφθείτε την "
 "ιστοσελίδα το συντομότερο δυνατό για να την κατεβάσετε!"
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "Σχετικά"
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr "Σχετικά με το CHIRP"
 
@@ -645,11 +645,11 @@ msgstr "Σχετικά με το CHIRP"
 msgid "All"
 msgstr "Όλες"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Όλα τα αρχεία"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Όλοι οι τύποι αρχείων|"
 
@@ -665,11 +665,11 @@ msgstr "Παρουσιάστηκε ένα σφάλμα"
 msgid "Applying settings"
 msgstr "Εφαρμογή ρυθμίσεων"
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr "Χάρτης συχνοτήτων"
 
@@ -681,7 +681,7 @@ msgstr "Μπάντες"
 msgid "Banks"
 msgstr "Ομάδες μνημών"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr "Bin"
 
@@ -689,7 +689,7 @@ msgstr "Bin"
 msgid "Browser"
 msgstr "Περιηγητής"
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr "Δημιουργία Περιηγητή Πομποδεκτών"
 
@@ -703,40 +703,40 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Αρχεία ειδώλου CHIRP"
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr "Απαιτείται επιλογή"
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Επιλέξτε κωδικό DTCS %s"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Επιλέξτε τόνο %s"
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 #, fuzzy
 msgid "Choose duplex"
 msgstr "Επιλογή duplex"
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr ""
@@ -771,22 +771,22 @@ msgstr "Λήψη από πομποδέκτη"
 msgid "Cloning to radio"
 msgstr "Αποστολή σε πομποδέκτη"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr "Κλείσιμο"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr "Κλείσιμο αρχείου"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Σχόλιο"
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr ""
 
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Country"
 msgstr "Χώρα"
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr ""
 
@@ -830,16 +830,16 @@ msgstr "Εισάγετε προσαρμοσμένη θύρα:"
 msgid "Custom..."
 msgstr "Προσαρμοσμένη..."
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 #, fuzzy
 msgid "Cut"
 msgstr "Χώρα"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -851,36 +851,36 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr "Μνήμη DV"
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr ""
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Λειτουργία προγραμματιστή"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 #, fuzzy
 msgid "Digital Code"
 msgstr "Ψηφιακός Κωδικός"
@@ -890,16 +890,17 @@ msgstr "Ψηφιακός Κωδικός"
 msgid "Digital Modes"
 msgstr "Ψηφιακός Κωδικός"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 #, fuzzy
 msgid "Disable reporting"
 msgstr "Αναφορές απενεργοποιημένες"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Απόσταση"
 
@@ -912,15 +913,15 @@ msgstr "Να μην ερωτηθώ ξανά για %s"
 msgid "Double-click to change bank name"
 msgstr "Κάντε διπλό κλικ για μετονομασία της ομάδας μνημών"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr "Λήψη"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 msgid "Download from radio"
 msgstr "Λήψη Από Πομποδέκτη"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Λήψη Από Πομποδέκτη"
@@ -937,26 +938,26 @@ msgstr ""
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Επεξεργασία λεπτομερειών για %i μνήμες"
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Επεξεργασία λεπτομερειών για τη μνήμη %i"
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 #, fuzzy
 msgid "Enable Automatic Edits"
 msgstr "Ενεργοποίηση αυτόματης επεξεργασίας"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr ""
 
@@ -964,11 +965,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Εισάγετε συχνότητα"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr "Εισάγετε συχνότητα εκπομπής (MHz)"
 
@@ -998,11 +999,11 @@ msgstr "Σφάλμα επικοινωνίας με τον πομποδέκτη"
 msgid "Experimental driver"
 msgstr "Πειραματικός οδηγός"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr "Η εξαγωγή είναι δυνατή μόνο σε αρχεία CSV"
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 msgid "Export to CSV"
 msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 
@@ -1011,7 +1012,7 @@ msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 msgid "Export to CSV..."
 msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr "Περισσότερα"
 
@@ -1026,7 +1027,7 @@ msgid ""
 "required."
 msgstr ""
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr "Αδυναμία φόρτωσης περιηγητή πομποδεκτών"
 
@@ -1044,8 +1045,8 @@ msgstr "Δυνατότητες"
 msgid "File does not exist: %s"
 msgstr "Το αρχείο δεν υπάρχει: %s"
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 msgid "Files"
 msgstr "Αρχεία"
 
@@ -1057,7 +1058,7 @@ msgstr "Φίλτρο"
 msgid "Filter results with location matching this string"
 msgstr "Φιλτράρισμα αποτελεσμάτων με τοποθεσία σύμφωνη με αυτό το λεκτικό"
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr "Εύρεση"
 
@@ -1268,20 +1269,20 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Λήψη ρυθμίσεων"
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 msgid "Goto Memory"
 msgstr "Μετάβαση σε Μνήμη"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr "Μετάβαση σε Μνήμη:"
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 #, fuzzy
 msgid "Goto..."
 msgstr "Μετάβαση σε"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr ""
 
@@ -1289,11 +1290,11 @@ msgstr ""
 msgid "Help Me..."
 msgstr "Βοήθεια..."
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Αντικατάσταση μνημών;"
@@ -1303,7 +1304,7 @@ msgstr "Αντικατάσταση μνημών;"
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr ""
 
@@ -1311,7 +1312,7 @@ msgstr ""
 msgid "Import from file..."
 msgstr ""
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr ""
 
@@ -1323,11 +1324,11 @@ msgstr ""
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 msgid "Insert Row Above"
 msgstr "Εισαγωγή γραμμής επάνω"
 
@@ -1335,7 +1336,7 @@ msgstr "Εισαγωγή γραμμής επάνω"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 #, fuzzy
 msgid "Interact with driver"
 msgstr "Αλληλεπίδραση με οδηγό"
@@ -1345,7 +1346,7 @@ msgstr "Αλληλεπίδραση με οδηγό"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Μη έγκυρη τιμή: %s"
@@ -1354,12 +1355,12 @@ msgstr "Μη έγκυρη τιμή: %s"
 msgid "Invalid ZIP code"
 msgstr "Μη έγκυρος ΤΚ"
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Μη έγκυρη τιμή: %s"
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1368,7 +1369,7 @@ msgstr ""
 msgid "Invalid value: %r"
 msgstr "Μη έγκυρη τιμή: %r"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr ""
 
@@ -1377,11 +1378,12 @@ msgstr ""
 msgid "LIVE"
 msgstr "LIVE"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Γεωγραφικό πλάτος"
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr "Το μήκος πρέπει να είναι %i"
@@ -1408,17 +1410,17 @@ msgstr ""
 msgid "Load Module..."
 msgstr "Φόρτωση Module"
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 #, fuzzy
 msgid "Load module from issue"
 msgstr "Φόρτωση Module"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Φόρτωση Module"
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1440,7 +1442,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Γεωγραφικό μήκος"
 
@@ -1448,7 +1451,7 @@ msgstr "Γεωγραφικό μήκος"
 msgid "Memories"
 msgstr "Μνήμες"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Η μνήμη %i δεν μπορεί να διαγραφεί"
@@ -1462,7 +1465,7 @@ msgstr "Η μνήμη πρέπει να βρίσκεται σε ομάδα γι�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Η μνήμη {num} δεν βρίσκεται στην ομάδα μνημών {bank}"
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 #, fuzzy
 msgid "Mode"
 msgstr "Λειτουργία"
@@ -1475,16 +1478,16 @@ msgstr "Μοντέλο"
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr "Module"
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Module"
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1493,11 +1496,11 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr "Βρέθηκαν περισσότερες από μία θύρες: %s"
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 msgid "Move Down"
 msgstr ""
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 msgid "Move Up"
 msgstr ""
 
@@ -1505,19 +1508,19 @@ msgstr ""
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr "Διαθέσιμη νέα έκδοση"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 msgid "No empty rows below!"
 msgstr "Καμία κενή σειρά από κάτω!"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr ""
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr ""
@@ -1531,7 +1534,7 @@ msgstr "Κανένα αποτέλεσμα!"
 msgid "No results!"
 msgstr "Κανένα αποτέλεσμα!"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr "Αριθμός"
 
@@ -1555,7 +1558,7 @@ msgstr "Μόνο οι καρτέλες μνημών μπορούν να εξαχ
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Άνοιγμα"
 
@@ -1567,15 +1570,15 @@ msgstr "Άνοιγμα πρόσφατου"
 msgid "Open Stock Config"
 msgstr "Άνοιγμα προεπιλεγμένων ρυθμίσεων"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Άνοιγμα αρχείου"
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr "Άνοιγμα αρθρώματος"
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Άνοιγμα αρχείου καταγραφής αποσφαλμάτωσης"
 
@@ -1583,7 +1586,7 @@ msgstr "Άνοιγμα αρχείου καταγραφής αποσφαλμάτ�
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Άνοιγμα προεπιλεγμένων ρυθμίσεων"
@@ -1605,7 +1608,7 @@ msgstr "Προαιρετικό: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Προαιρετικό: Επαρχία, Νοσοκομείο κλπ"
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 msgid "Overwrite memories?"
 msgstr "Αντικατάσταση μνημών;"
 
@@ -1620,31 +1623,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
-msgstr ""
-
-#: ../wxui/memedit.py:1850
-#, python-format
-msgid "Pasted memories will overwrite %s existing memories"
-msgstr ""
-
-#: ../wxui/memedit.py:1853
-#, python-format
-msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
 #: ../wxui/memedit.py:1847
 #, python-format
-msgid "Pasted memories will overwrite memory %s"
+msgid "Pasted memories will overwrite %s existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:1850
+#, python-format
+msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
 #: ../wxui/memedit.py:1844
 #, python-format
+msgid "Pasted memories will overwrite memory %s"
+msgstr ""
+
+#: ../wxui/memedit.py:1841
+#, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 "Παρακαλούμε βεβαιωθείτε ότι έχετε κλείσει το CHIRP πριν εγκαταστήσετε την "
@@ -1676,7 +1679,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1696,11 +1699,11 @@ msgstr "Συνδέστε το καλώδιο σας και πατήστε OK"
 msgid "Port"
 msgstr "Θύρα"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Ισχύς"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 msgid "Press enter to set this in memory"
 msgstr "Πατήστε enter για καταχώρηση στη μνήμη"
 
@@ -1712,24 +1715,24 @@ msgstr "Προεπισκόπηση εκτύπωσης"
 msgid "Printing"
 msgstr "Εκτύπωση"
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr "Ιδιότητες"
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr "Ερώτημα %s"
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Ερώτημα Πηγής"
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr "DTCS Λήψης"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Πομποδέκτης"
 
@@ -1770,11 +1773,11 @@ msgstr "Απαιτείται επανεκκίνηση"
 msgid "Refreshed memory %s"
 msgstr "Ανανεώθηκε η μνήμη %s"
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Επαναφόρτωση Οδηγού"
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Επαναφόρτωση Οδηγού και Αρχείου"
 
@@ -1788,19 +1791,19 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Αναφορές ενεργοποιημένες"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr "Απαιτείται επανεκκίνηση"
 
@@ -1811,19 +1814,24 @@ msgid_plural "Restore %i tabs"
 msgstr[0] "Επαναφορά %i καρτελών"
 msgstr[1] "Επαναφορά %i καρτελών"
 
+#: ../wxui/main.py:815
+#, fuzzy
+msgid "Restore tabs on start"
+msgstr "Επαναφορά %i καρτελών"
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr "Ρυθμίσεις ανακτήθηκαν"
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr "Αποθήκευση πριν το κλείσιμο;"
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Αποθήκευση αρχείου"
 
@@ -1839,11 +1847,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Επιλογή χάρτη συχνοτήτων"
@@ -1856,7 +1864,7 @@ msgstr "Επιλογή Μπαντών"
 msgid "Select Modes"
 msgstr ""
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr "Επιλογή χάρτη συνοτήτων"
 
@@ -1868,52 +1876,52 @@ msgstr "Υπηρεσία"
 msgid "Settings"
 msgstr "Ρυθμίσεις"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr ""
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Εμφάνιση τοποθεσίας αρχείου καταγραφής αποσφαλμάτωσης"
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 msgid "Some memories are incompatible with this radio"
 msgstr "Κάποιες μνήμες δεν είναι συμβατές με αυτόν τον πομποδέκτη"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr "Κάποιες μνήμες δεν είναι δυνατόν να διαγραφούν"
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 #, fuzzy
 msgid "Sort memories"
 msgstr "Αντικατάσταση μνημών;"
@@ -1931,7 +1939,7 @@ msgstr "Πολιτεία"
 msgid "State/Province"
 msgstr "Πολιτεία / Επαρχία"
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr ""
 
@@ -1964,14 +1972,14 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -1981,7 +1989,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 #, fuzzy
 msgid "This Memory"
 msgstr "Μνήμη DV"
@@ -2033,12 +2041,12 @@ msgstr ""
 "δυνατοτήτων!\n"
 "Σας προειδοποιήσαμε. Προχωράτε με δική σας ευθύνη!"
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
@@ -2060,23 +2068,23 @@ msgid ""
 "own risk!"
 msgstr ""
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "Τόνος"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Τύπος τόνου"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 msgid "Tone Squelch"
 msgstr "Τόνος Φίμωσης"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 msgid "Tuning Step"
 msgstr "Βήμα συντονισμού"
 
@@ -2090,11 +2098,11 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
@@ -2114,7 +2122,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
@@ -2136,11 +2144,11 @@ msgstr "Αποσυνδέστε το καλώδιο σας (αν χρειάζετ
 msgid "Upload instructions"
 msgstr "Οδηγίες αποστολής"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 msgid "Upload to radio"
 msgstr "Αποστολή Σε Πομποδέκτη"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Αποστολή Σε Πομποδέκτη"
@@ -2158,7 +2166,7 @@ msgstr "Χρήση γραμματοσειράς σταθερού πλάτους"
 msgid "Use larger font"
 msgstr "Χρήση μεγαλύτερης γραμματοσειράς"
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr "Η τιμή δεν χωράει σε %i bits"
@@ -2173,16 +2181,16 @@ msgstr "Η τιμή πρέπει να είναι τουλάχιστον %.4f"
 msgid "Value must be at most %.4f"
 msgstr "Η τιμή πρέπει να είναι το πολύ  %.4f"
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr "Η τιμή πρέπει να έιναι ακριβώς %i δεκαδικά ψηφία"
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr "Η τιμή πρέπει να είναι μηδέν ή μεγαλύτερη"
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr ""
 
@@ -2190,7 +2198,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Προμηθευτής"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 msgid "View"
 msgstr "Εμφάνιση"
 
@@ -2198,11 +2206,11 @@ msgstr "Εμφάνιση"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr "Προειδοποίηση"
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr "Προειδοποίηση: %s"
@@ -2219,23 +2227,23 @@ msgstr ""
 msgid "Your cable appears to be on port:"
 msgstr "Το καλώδιο σας φαίνεται να είανι στη θύρα:"
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr "bits"
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr "bytes"
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr "bytes το καθένα"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/en_US.po
+++ b/chirp/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2011-11-29 16:07-0800\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "_Delete"
 msgstr[1] "_Delete"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "_Delete"
 msgstr[1] "_Delete"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "File is modified, save changes before closing?"
@@ -63,7 +63,7 @@ msgstr "File is modified, save changes before closing?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -621,17 +621,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr ""
 
@@ -639,12 +639,12 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "CSV Files"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
@@ -660,11 +660,11 @@ msgstr ""
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr ""
 
@@ -676,7 +676,7 @@ msgstr ""
 msgid "Banks"
 msgstr ""
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Browser"
 msgstr ""
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr ""
 
@@ -698,39 +698,39 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
-msgstr ""
-
-#: ../wxui/memedit.py:1246
-#, python-format
-msgid "Choose %s DTCS Code"
 msgstr ""
 
 #: ../wxui/memedit.py:1243
 #, python-format
+msgid "Choose %s DTCS Code"
+msgstr ""
+
+#: ../wxui/memedit.py:1240
+#, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr ""
@@ -767,22 +767,22 @@ msgstr "Download From Radio"
 msgid "Cloning to radio"
 msgstr "Upload To Radio"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 #, fuzzy
 msgid "Copy"
 msgstr "_Copy"
@@ -814,7 +814,7 @@ msgstr "_Copy"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr ""
 
@@ -826,16 +826,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 #, fuzzy
 msgid "Cut"
 msgstr "_Cut"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 msgid "DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -845,39 +845,39 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr ""
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 #, fuzzy
 msgid "Delete"
 msgstr "_Delete"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Developer"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr ""
 
@@ -885,15 +885,16 @@ msgstr ""
 msgid "Digital Modes"
 msgstr ""
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -906,16 +907,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download From Radio"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download From Radio"
@@ -933,25 +934,25 @@ msgstr ""
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr ""
 
@@ -959,11 +960,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr ""
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -993,11 +994,11 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Import from RFinder"
@@ -1007,7 +1008,7 @@ msgstr "Import from RFinder"
 msgid "Export to CSV..."
 msgstr "Import from RFinder"
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr ""
 
@@ -1022,7 +1023,7 @@ msgid ""
 "required."
 msgstr ""
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr ""
 
@@ -1039,8 +1040,8 @@ msgstr ""
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 #, fuzzy
 msgid "Files"
 msgstr "_File"
@@ -1053,7 +1054,7 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr ""
 
@@ -1263,20 +1264,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Show raw memory"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Help"
 
@@ -1284,11 +1285,11 @@ msgstr "Help"
 msgid "Help Me..."
 msgstr ""
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Diff raw memories"
@@ -1298,7 +1299,7 @@ msgstr "Diff raw memories"
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Import"
 
@@ -1307,7 +1308,7 @@ msgstr "Import"
 msgid "Import from file..."
 msgstr "Import from RFinder"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Import from RFinder"
@@ -1320,11 +1321,11 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 msgid "Insert Row Above"
 msgstr ""
 
@@ -1332,7 +1333,7 @@ msgstr ""
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1341,7 +1342,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1349,12 +1350,12 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1363,7 +1364,7 @@ msgstr ""
 msgid "Invalid value: %r"
 msgstr ""
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr ""
 
@@ -1371,11 +1372,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr ""
@@ -1400,15 +1402,15 @@ msgstr ""
 msgid "Load Module..."
 msgstr ""
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 msgid "Load module from issue"
 msgstr ""
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1430,7 +1432,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1439,7 +1442,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1453,7 +1456,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 msgid "Mode"
 msgstr ""
 
@@ -1465,15 +1468,15 @@ msgstr ""
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1482,12 +1485,12 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 #, fuzzy
 msgid "Move Down"
 msgstr "Move D_n"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 #, fuzzy
 msgid "Move Up"
 msgstr "Move _Up"
@@ -1496,19 +1499,19 @@ msgstr "Move _Up"
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 msgid "No empty rows below!"
 msgstr ""
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr ""
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr ""
@@ -1521,7 +1524,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr ""
 
@@ -1545,7 +1548,7 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
@@ -1558,15 +1561,15 @@ msgstr "_Recent"
 msgid "Open Stock Config"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
@@ -1574,7 +1577,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 msgid "Open stock config directory"
 msgstr ""
 
@@ -1594,7 +1597,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Diff raw memories"
@@ -1610,32 +1613,32 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 #, fuzzy
 msgid "Paste"
 msgstr "_Paste"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1665,7 +1668,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1685,11 +1688,11 @@ msgstr ""
 msgid "Port"
 msgstr ""
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr ""
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 msgid "Press enter to set this in memory"
 msgstr ""
 
@@ -1701,24 +1704,24 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr ""
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 #, fuzzy
 msgid "Radio"
 msgstr "_Radio"
@@ -1759,11 +1762,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1777,19 +1780,19 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Reporting is disabled"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr ""
 
@@ -1800,19 +1803,23 @@ msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../wxui/main.py:815
+msgid "Restore tabs on start"
+msgstr ""
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1828,11 +1835,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Select Columns"
@@ -1847,7 +1854,7 @@ msgstr "Select Columns"
 msgid "Select Modes"
 msgstr "Select Columns"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1859,53 +1866,53 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Show raw memory"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 #, fuzzy
 msgid "Sort memories"
 msgstr "Diff raw memories"
@@ -1922,7 +1929,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr ""
 
@@ -1955,14 +1962,14 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -1972,7 +1979,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 #, fuzzy
 msgid "This Memory"
 msgstr "Show raw memory"
@@ -2017,12 +2024,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "_Delete"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "_Delete"
@@ -2044,23 +2051,23 @@ msgid ""
 "own risk!"
 msgstr ""
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 msgid "Tone Squelch"
 msgstr ""
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 msgid "Tuning Step"
 msgstr ""
 
@@ -2074,11 +2081,11 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
@@ -2098,7 +2105,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
@@ -2120,12 +2127,12 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Upload To Radio"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Upload To Radio"
@@ -2143,7 +2150,7 @@ msgstr ""
 msgid "Use larger font"
 msgstr ""
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr ""
@@ -2158,16 +2165,16 @@ msgstr ""
 msgid "Value must be at most %.4f"
 msgstr ""
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr ""
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr ""
 
@@ -2175,7 +2182,7 @@ msgstr ""
 msgid "Vendor"
 msgstr ""
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 #, fuzzy
 msgid "View"
 msgstr "_View"
@@ -2184,11 +2191,11 @@ msgstr "_View"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2205,23 +2212,23 @@ msgstr ""
 msgid "Your cable appears to be on port:"
 msgstr ""
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr ""
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr ""
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/es.po
+++ b/chirp/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2023-12-14 17:16-0300\n"
 "Last-Translator: MELERIX\n"
 "Language-Team: \n"
@@ -43,28 +43,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s debe estar entre %(min)i y %(max)i"
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Memorias y desplazar todo hacia arriba"
 msgstr[1] "%i Memorias y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Memorias"
 msgstr[1] "%i Memorias"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Memorias y desplazar bloque hacia arriba"
 msgstr[1] "%i Memorias y desplazar bloque hacia arriba"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s no ha sido guardado. ¿Guardar antes de cerrar?"
@@ -73,7 +73,7 @@ msgstr "%s no ha sido guardado. ¿Guardar antes de cerrar?"
 msgid "(none)"
 msgstr "(nada)"
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr "...y %i más"
@@ -995,7 +995,7 @@ msgstr ""
 "\n"
 "Esto podría no funcionar si enciendes la radio con el cable ya conectado"
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -1003,11 +1003,11 @@ msgstr ""
 "Una nueva versión de CHIRP está disponible, ¡Por favor visita el sitio web "
 "tan pronto como sea posible para descargarla!"
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "Acerca de"
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr "Acerca de CHIRP"
 
@@ -1015,11 +1015,11 @@ msgstr "Acerca de CHIRP"
 msgid "All"
 msgstr "Todo"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Todos los archivos"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Todos los formatos soportados|"
 
@@ -1035,11 +1035,11 @@ msgstr "Ha ocurrido un error"
 msgid "Applying settings"
 msgstr "Aplicando ajustes"
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr "Módulos disponibles"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr "Plan de banda"
 
@@ -1051,7 +1051,7 @@ msgstr "Bandas"
 msgid "Banks"
 msgstr "Bancos"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr "Binario"
 
@@ -1059,7 +1059,7 @@ msgstr "Binario"
 msgid "Browser"
 msgstr "Navegador"
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr "Construyendo navegador de radio"
 
@@ -1075,7 +1075,7 @@ msgstr ""
 "Cambiar este ajuste requiere actualizar los ajustes desde la imagen, lo cual "
 "ocurrirá ahora."
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
@@ -1083,33 +1083,33 @@ msgstr ""
 "Canales con TX y RX equivalentes %s son representados por modo de tono de "
 "\"%s\""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Archivos de imagen Chirp"
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr "Elección requerida"
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Elegir %s código DTCS"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Elegir %s tono"
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 msgid "Choose Cross Mode"
 msgstr "Elegir modo cruzado"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr "Elegir Dúplex"
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Elige el módulo para cargar desde problema %i:"
@@ -1151,22 +1151,22 @@ msgstr "Clonando desde radio"
 msgid "Cloning to radio"
 msgstr "Clonando a radio"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr "Cerrar"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr "Cerrar archivo"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Agrupar %i memorias"
 msgstr[1] "Agrupar %i memorias"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Comentario"
 
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Convertir a FM"
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "Copiar"
 
@@ -1199,7 +1199,7 @@ msgstr "Copiar"
 msgid "Country"
 msgstr "País"
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr "Modo cruzado"
 
@@ -1211,15 +1211,15 @@ msgstr "Puerto personalizado"
 msgid "Custom..."
 msgstr "Personalizado..."
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -1231,38 +1231,38 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Decodificación DTMF"
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr "Memoria DV"
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr "Peligro adelante"
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 msgid "Dec"
 msgstr "Decimal"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Modo desarrollador"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Estado de desarrollador ahora está %s. CHIRP debe ser reiniciado para que "
 "tome efecto"
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "Diferenciar memorias en bruto"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr "Código digital"
 
@@ -1270,15 +1270,16 @@ msgstr "Código digital"
 msgid "Digital Modes"
 msgstr "Modos digitales"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr "Deshabilitar reportes"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr "Desahbilitado"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Distancia"
 
@@ -1291,15 +1292,15 @@ msgstr "No preguntar de nuevo para %s"
 msgid "Double-click to change bank name"
 msgstr "Doble clic para cambiar nombre de banco"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr "Descargar"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 msgid "Download from radio"
 msgstr "Descargar desde radio"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "Descargar desde radio..."
 
@@ -1317,25 +1318,25 @@ msgstr ""
 "Los repetidores digitales de modo dual que soportan análogo se mostrarán "
 "como FM"
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Dúplex"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Editar detalles para %i memorias"
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editar detalles para memoria %i"
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Habilitar ediciones automáticas"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr "Habilitado"
 
@@ -1343,11 +1344,11 @@ msgstr "Habilitado"
 msgid "Enter Frequency"
 msgstr "Ingresar frecuencia"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr "Ingresar desplazamiento (MHz)"
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr "Ingresar frecuencia TX (MHz)"
 
@@ -1377,11 +1378,11 @@ msgstr "Error comunicándose con la radio"
 msgid "Experimental driver"
 msgstr "Controlador experimental"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr "Exportar solo puede escribir archivos CSV"
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 msgid "Export to CSV"
 msgstr "Exportar a CSV"
 
@@ -1389,7 +1390,7 @@ msgstr "Exportar a CSV"
 msgid "Export to CSV..."
 msgstr "Exportar a CSV..."
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr "Extra"
 
@@ -1407,7 +1408,7 @@ msgstr ""
 "información más actualizada sobre de repetidores en Europa. No requiere\n"
 "cuenta."
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr "Fallo al cargar navegador de radio"
 
@@ -1424,8 +1425,8 @@ msgstr "Caracteristicas"
 msgid "File does not exist: %s"
 msgstr "El archivo no existe: %s"
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 msgid "Files"
 msgstr "Archivos"
 
@@ -1437,7 +1438,7 @@ msgstr "Filtrar"
 msgid "Filter results with location matching this string"
 msgstr "Filtrar resultados con ubicación coincidiendo esta cadena"
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr "Buscar"
 
@@ -1742,19 +1743,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Obteniendo ajustes"
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 msgid "Goto Memory"
 msgstr "Ir a memoria"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr "Ir a memoria:"
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr "Ir a..."
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Ayuda"
 
@@ -1762,11 +1763,11 @@ msgstr "Ayuda"
 msgid "Help Me..."
 msgstr "Ayúdame..."
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr "Hexadecimal"
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 msgid "Hide empty memories"
 msgstr "Ocultar memorias vacías"
 
@@ -1776,7 +1777,7 @@ msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Si se establece, ordenar los resultados por distancia desde estas coordenadas"
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Importar"
 
@@ -1784,7 +1785,7 @@ msgstr "Importar"
 msgid "Import from file..."
 msgstr "Importar desde archivo..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr "Importación no recomendada"
 
@@ -1796,11 +1797,11 @@ msgstr "Índice"
 msgid "Info"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 msgid "Insert Row Above"
 msgstr "Insertar fila arriba"
 
@@ -1808,7 +1809,7 @@ msgstr "Insertar fila arriba"
 msgid "Install desktop icon?"
 msgstr "¿Instalar icono de escritorio?"
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr "Interactuar con controlador"
 
@@ -1817,7 +1818,7 @@ msgstr "Interactuar con controlador"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s inválido (usa grados decimales)"
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 msgid "Invalid Entry"
 msgstr "Entrada inválida"
 
@@ -1825,12 +1826,12 @@ msgstr "Entrada inválida"
 msgid "Invalid ZIP code"
 msgstr "Código postal inválido"
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Edición inválida: %s"
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr "Archivo de módulo inválido o no soportado"
 
@@ -1839,7 +1840,7 @@ msgstr "Archivo de módulo inválido o no soportado"
 msgid "Invalid value: %r"
 msgstr "Valor inválido: %r"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr "Número de problema:"
 
@@ -1847,11 +1848,12 @@ msgstr "Número de problema:"
 msgid "LIVE"
 msgstr "EN VIVO"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Latitud"
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr "Largo debe ser %i"
@@ -1876,15 +1878,15 @@ msgstr "Limitar resultados a esta distancia (km) desde coordenadas"
 msgid "Load Module..."
 msgstr "Cargar modulo..."
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 msgid "Load module from issue"
 msgstr "Cargar módulo desde problema"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 msgid "Load module from issue..."
 msgstr "Cargar módulo desde problema..."
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1912,7 +1914,8 @@ msgstr "Cadena del logotipo 1 (12 caracteres)"
 msgid "Logo string 2 (12 characters)"
 msgstr "Cadena del logotipo 2 (12 caracteres)"
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Longitud"
 
@@ -1920,7 +1923,7 @@ msgstr "Longitud"
 msgid "Memories"
 msgstr "Memorias"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoria %i no es borrable"
@@ -1934,7 +1937,7 @@ msgstr "La memoria debe estar en un banco para ser editada"
 msgid "Memory {num} not in bank {bank}"
 msgstr "La memoria {num} no está en banco {bank}"
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 msgid "Mode"
 msgstr "Modo"
 
@@ -1946,15 +1949,15 @@ msgstr "Modelo"
 msgid "Modes"
 msgstr "Modos"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr "Modulo"
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr "Módulo cargado"
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr "Módulo cargado exitosamente"
 
@@ -1963,11 +1966,11 @@ msgstr "Módulo cargado exitosamente"
 msgid "More than one port found: %s"
 msgstr "Más de un puerto encontrado: %s"
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 msgid "Move Down"
 msgstr "Mover abajo"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 msgid "Move Up"
 msgstr "Mover arriba"
 
@@ -1975,19 +1978,19 @@ msgstr "Mover arriba"
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr "Nueva versión disponible"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 msgid "No empty rows below!"
 msgstr "¡No hay filas vacías debajo!"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr "No se encontraron módulos"
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr "No se encontraron módulos en problema %i"
@@ -2000,7 +2003,7 @@ msgstr "No hay resultados"
 msgid "No results!"
 msgstr "¡No hay resultados!"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr "Numero"
 
@@ -2024,7 +2027,7 @@ msgstr "Solo pestañas de memorias pueden ser exportadas"
 msgid "Only working repeaters"
 msgstr "Sólo repetidores funcionando"
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Abrir"
 
@@ -2036,15 +2039,15 @@ msgstr "Abrir reciente"
 msgid "Open Stock Config"
 msgstr "Abrir configuración original"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Abrir un archivo"
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr "Abrir un modulo"
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Abrir registro de depuración"
 
@@ -2052,7 +2055,7 @@ msgstr "Abrir registro de depuración"
 msgid "Open in new window"
 msgstr "Abrir en nueva ventana"
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 msgid "Open stock config directory"
 msgstr "Abrir directorio de configuración original"
 
@@ -2072,7 +2075,7 @@ msgstr "Opcional: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcional: Condado, Hospital, etc."
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 msgid "Overwrite memories?"
 msgstr "¿Sobrescribir memorias?"
 
@@ -2090,31 +2093,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Analizando"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Las memorias pegadas sobrescribirán %s memorias existentes"
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Las memorias pegadas sobrescribirán memorias %s"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Las memorias pegadas sobrescribirán la memoria %s"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria pegada sobrescribirá la memoria %s"
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 "¡Por favor asegúrate de salir de CHIRP antes de instalar la nueva versión!"
@@ -2163,7 +2166,7 @@ msgstr ""
 "4 - Entonces presiona el botón \"A\" en tu radio para iniciar la clonación.\n"
 "    (Al final la radio emitirá un pitido)\n"
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2188,11 +2191,11 @@ msgstr "Conecta tu cable y luego haz clic en ACEPTAR"
 msgid "Port"
 msgstr "Puerto"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Poder"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 msgid "Press enter to set this in memory"
 msgstr "Presiona enter para configurar esto en memoria"
 
@@ -2204,24 +2207,24 @@ msgstr "Previsualización de impresión"
 msgid "Printing"
 msgstr "Imprimiendo"
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr "Consulta %s"
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Consultar fuente"
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Radio"
 
@@ -2266,11 +2269,11 @@ msgstr "Actualización requerida"
 msgid "Refreshed memory %s"
 msgstr "Memoria actualizada %s"
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Recargar controlador"
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Recargar controlador y archivo"
 
@@ -2284,11 +2287,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Reportes habilitados"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2298,7 +2301,7 @@ msgstr ""
 "plataformas de SO gastar nuestros limitados esfuerzos. Apreciamos mucho si "
 "lo dejas habilitado. ¿Realmente deshabilitar reportes?"
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr "Reinicio requerido"
 
@@ -2309,19 +2312,24 @@ msgid_plural "Restore %i tabs"
 msgstr[0] "Restaurar %i pestañas"
 msgstr[1] "Restaurar %i pestañas"
 
+#: ../wxui/main.py:815
+#, fuzzy
+msgid "Restore tabs on start"
+msgstr "Restaurar %i pestañas"
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr "Ajustes recuperados"
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr "Guardar"
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr "¿Guardar antes de cerrar?"
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Guardar archivo"
 
@@ -2337,11 +2345,11 @@ msgstr "Listas de escaneo"
 msgid "Scrambler"
 msgstr "Codificador"
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr "Riesgo de seguridad"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "Seleccionar plan de banda..."
 
@@ -2353,7 +2361,7 @@ msgstr "Seleccionar bandas"
 msgid "Select Modes"
 msgstr "Seleccionar modos"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr "Seleccionar plan de banda"
 
@@ -2365,52 +2373,52 @@ msgstr "Servicio"
 msgid "Settings"
 msgstr "Ajustes"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "Mostrar memoria en bruto"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Mostrar ubicación del registro de depuración"
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr "Mostrar campos adicionales"
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 msgid "Some memories are incompatible with this radio"
 msgstr "Algunas memorias son incompatibles con esta radio"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr "Algunas memorias no son borrables"
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Ordenar %i memorias"
 msgstr[1] "Ordenar %i memorias"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Ordenar %i memorias de forma ascendente"
 msgstr[1] "Ordenar %i memorias de forma ascendente"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Ordenar %i memorias de forma descendente"
 msgstr[1] "Ordenar %i memorias de forma descendente"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr "Ordenar por columna:"
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 msgid "Sort memories"
 msgstr "Ordenar memorias"
 
@@ -2426,7 +2434,7 @@ msgstr "Estado"
 msgid "State/Province"
 msgstr "Estado/Provincia"
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr "Éxito"
 
@@ -2478,7 +2486,7 @@ msgstr ""
 "Por favor guarda una copia sin editar de tu primera descarga\n"
 "exitosa a un archivo de imagen de Radio de CHIRP (*.img).\n"
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
@@ -2488,7 +2496,7 @@ msgstr ""
 "recomienda que no cargues este modulo ya que podría poner un riesgo de "
 "seguridad. ¿Proceder de todos modos?"
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2504,7 +2512,7 @@ msgstr ""
 "abrir este archivo para copiar/pegar memorias a través de este, o proceder "
 "con la importación?"
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 msgid "This Memory"
 msgstr "Esta memoria"
 
@@ -2567,11 +2575,11 @@ msgstr ""
 "¡También por favor envía en solicitudes de errores y mejoras!\n"
 "Has sido advertido. ¡Procede bajo tu propio riesgo!"
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 msgid "This memory and shift all up"
 msgstr "Esta memoria y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 msgid "This memory and shift block up"
 msgstr "Esta memoria y desplazar bloque hacia arriba"
 
@@ -2602,23 +2610,23 @@ msgstr ""
 "aplique las restricciones del OEM y puede conducir a un comportamiento "
 "indefinido o no regulado. ¡Úsalo bajo tu propio riesgo!"
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr "Esto va a cargar un módulo desde un problema del sitio web"
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "Tono"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Modo de tono"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 msgid "Tone Squelch"
 msgstr "Silenciador de tono"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 msgid "Tuning Step"
 msgstr "Paso de sintonización"
 
@@ -2634,11 +2642,11 @@ msgstr ""
 "No se puede determinar puerto para tu cable. Comprueba tus controladores y "
 "conexiones."
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr "No se puede editar memoria antes de que la radio este cargada"
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "No se puede buscar la configuración original %r"
@@ -2661,7 +2669,7 @@ msgstr ""
 "seleccionado es de EE.UU pero la radio no es una de EE.UU (o de banda "
 "ancha). Por favor elije el modelo correcto e intenta de nuevo."
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "No se puede revelar %s en este sistema"
@@ -2683,11 +2691,11 @@ msgstr "Desconecta tu cable (si es necesario) y entonces haz clic en ACEPTAR"
 msgid "Upload instructions"
 msgstr "Cargar instrucciones"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 msgid "Upload to radio"
 msgstr "Cargar a radio"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "Cargar a radio..."
 
@@ -2704,7 +2712,7 @@ msgstr "Usar fuente de ancho fijo"
 msgid "Use larger font"
 msgstr "Usar fuente más grande"
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr "Valor no cabe en %i bits"
@@ -2719,16 +2727,16 @@ msgstr "Valor debe ser al menos %.4f"
 msgid "Value must be at most %.4f"
 msgstr "Valor debe ser como máximo %.4f"
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr "Valor debe ser exactamente %i dígitos decimales"
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr "Valor debe ser cero o superior"
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr "Valores"
 
@@ -2736,7 +2744,7 @@ msgstr "Valores"
 msgid "Vendor"
 msgstr "Vendedor"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 msgid "View"
 msgstr "Ver"
 
@@ -2744,11 +2752,11 @@ msgstr "Ver"
 msgid "WARNING!"
 msgstr "¡ADVERTENCIA!"
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr "Advertencia: %s"
@@ -2765,23 +2773,23 @@ msgstr "¿Quieres que CHIRP instale un icono en el escritorio para ti?"
 msgid "Your cable appears to be on port:"
 msgstr "Tu cable parece estar en puerto:"
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr "bits"
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr "bytes"
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr "bytes cada"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr "habilitado"
 

--- a/chirp/locale/fr.po
+++ b/chirp/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2023-12-13 00:03+0100\n"
 "Last-Translator: Matthieu Lapadu-Hargues <mlhpub@free.fr>\n"
 "Language-Team: French\n"
@@ -41,28 +41,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s doit etre entre %(min)i et %(max)i"
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Memoires et tout changer"
 msgstr[1] "%i Memoires et tout changer"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Memoires"
 msgstr[1] "%i Memoires"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Memoires et tout decaler vers le haut"
 msgstr[1] "%i Memoires et tout decaler vers le haut"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s n'a pas ete enregistre. Enregistrer avant de fermer?"
@@ -71,7 +71,7 @@ msgstr "%s n'a pas ete enregistre. Enregistrer avant de fermer?"
 msgid "(none)"
 msgstr "(vide)"
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr "...et %i plus"
@@ -629,7 +629,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -637,11 +637,11 @@ msgstr ""
 "Une nouvelle version de CHIRP est disponible. Visitez le site internet des "
 "que possible pour la telecharger!"
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "A propos"
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr "A propos de CHIRP"
 
@@ -649,11 +649,11 @@ msgstr "A propos de CHIRP"
 msgid "All"
 msgstr "Tout"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Tous fichiers"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Tours formats supportes|"
 
@@ -669,11 +669,11 @@ msgstr "Une erreur s'est produite"
 msgid "Applying settings"
 msgstr "Application des preferences"
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr "Modules disponibles"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr "Plan de frequences"
 
@@ -685,7 +685,7 @@ msgstr "Bandes"
 msgid "Banks"
 msgstr "Banques"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr "Corbeille"
 
@@ -693,7 +693,7 @@ msgstr "Corbeille"
 msgid "Browser"
 msgstr "Navigateur"
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr "Etablissement navigateur radio"
 
@@ -709,7 +709,7 @@ msgstr ""
 "Modifier ce parametre necessite de refraichir tous les parametres depuis "
 "l'image, ce qui va etre fait maintenant."
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
@@ -717,33 +717,33 @@ msgstr ""
 "Les canaux avec TX et RX equivalents %s sont representes par le mode de "
 "tonalite de \"%s\""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Fichiers image Chirp"
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr "Choix necessaire"
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Choisir %s DTCS Code"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Choisir %s Tone"
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 msgid "Choose Cross Mode"
 msgstr "Choisir cross mode"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr "Choisir duplex"
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Choisir le module a charger depuis le probleme %i:"
@@ -784,22 +784,22 @@ msgstr "Telechargement depuis la radio - Lire"
 msgid "Cloning to radio"
 msgstr "Telechargement vers la radio - Ecrire"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr "Fermer"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr "Fermer fichier"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Groupement %i memoires"
 msgstr[1] "Groupement %i memoires"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -823,7 +823,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Convertir en FM"
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "Copier"
 
@@ -832,7 +832,7 @@ msgstr "Copier"
 msgid "Country"
 msgstr "Pays"
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr "Cross mode"
 
@@ -844,15 +844,15 @@ msgstr "Personnalisation du port"
 msgid "Custom..."
 msgstr "Personnalisation..."
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "Couper"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -864,38 +864,38 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr "Memoire DV"
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr "Danger devant"
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Mode developpeur"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Le mode developpement est maintenant %s. CHIRP doit etre redemarre pour que "
 "ceci prenne effet"
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "Comparaison memoires brutes"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr "Digital Code"
 
@@ -903,15 +903,16 @@ msgstr "Digital Code"
 msgid "Digital Modes"
 msgstr "Modes numeriques"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr "Desactiver le rapport d'utilisation"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr "Descative"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Distance"
 
@@ -924,15 +925,15 @@ msgstr "Ne plus demander pendant %s"
 msgid "Double-click to change bank name"
 msgstr "Double-cliquer pour modifier le nom de la banque"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr "Telecharger"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 msgid "Download from radio"
 msgstr "Telecharger depuis la radio - Lire"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "Telecharger depuis la radio - Lire..."
 
@@ -951,25 +952,25 @@ msgstr ""
 "Les repeteurs numeriques bimodes supportant l'analogique seront presentes "
 "comme FM"
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Editer les details pour %i memoires"
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editer les details pour la memoire %i"
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Aciter l'edition automatique"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr "Active"
 
@@ -977,11 +978,11 @@ msgstr "Active"
 msgid "Enter Frequency"
 msgstr "Entrer la frequence"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr "Saisir le decalage (MHz)"
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr "Saisir la frequence d'emission (MHz)"
 
@@ -1011,11 +1012,11 @@ msgstr "Erreur de communication avec la radio"
 msgid "Experimental driver"
 msgstr "Pilote experimental"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr "L'exportation ne peut ecrire que des fichiers CSV"
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 msgid "Export to CSV"
 msgstr "Exporter vers un fichier CSV"
 
@@ -1023,7 +1024,7 @@ msgstr "Exporter vers un fichier CSV"
 msgid "Export to CSV..."
 msgstr "Exporter vers un fichier CSV..."
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr "Extra"
 
@@ -1042,7 +1043,7 @@ msgstr ""
 "les plus a jour sur les relais Europeens. Un compte utiliseteur\n"
 "n'est pas requis."
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr "Echec du chargement du navigateur de la radio"
 
@@ -1059,8 +1060,8 @@ msgstr "Caracteristiques"
 msgid "File does not exist: %s"
 msgstr "Fichier inexistant: %s"
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 msgid "Files"
 msgstr "Fichiers"
 
@@ -1074,7 +1075,7 @@ msgstr ""
 "Filtrer les resultats avec emplacement correspondant a cette chaine de "
 "caracteres"
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr "Rechercher"
 
@@ -1284,19 +1285,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Acquisition des preferences"
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 msgid "Goto Memory"
 msgstr "Aller a la memoire"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr "Aller a la memoire:"
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr "Aller..."
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Aide"
 
@@ -1304,11 +1305,11 @@ msgstr "Aide"
 msgid "Help Me..."
 msgstr "Aidez moi..."
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 msgid "Hide empty memories"
 msgstr "Cacher les memoires vides"
 
@@ -1318,7 +1319,7 @@ msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Si selectionne, trier les resultats selon la distance depuis ces coordonnees"
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Importer"
 
@@ -1326,7 +1327,7 @@ msgstr "Importer"
 msgid "Import from file..."
 msgstr "Importer depuis un fichier..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr "Import non recommande"
 
@@ -1338,11 +1339,11 @@ msgstr "Index"
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr "Information"
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 msgid "Insert Row Above"
 msgstr "Inserer une ligne avant"
 
@@ -1350,7 +1351,7 @@ msgstr "Inserer une ligne avant"
 msgid "Install desktop icon?"
 msgstr "Installer une icone sur le bureau?"
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr "Interaction avec le pilote"
 
@@ -1359,7 +1360,7 @@ msgstr "Interaction avec le pilote"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Invalide %(value)s (utiliser degres decimaux)"
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 msgid "Invalid Entry"
 msgstr "Entree invalide"
 
@@ -1367,12 +1368,12 @@ msgstr "Entree invalide"
 msgid "Invalid ZIP code"
 msgstr "Code postal invalide"
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Edition invalide: %s"
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr "Fichier module invalide ou pas supporte"
 
@@ -1381,7 +1382,7 @@ msgstr "Fichier module invalide ou pas supporte"
 msgid "Invalid value: %r"
 msgstr "Valeur invalide: %r"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr "Probleme numero:"
 
@@ -1389,11 +1390,12 @@ msgstr "Probleme numero:"
 msgid "LIVE"
 msgstr "LIVE"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Latitude"
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr "La longueur doit etre %i"
@@ -1418,15 +1420,15 @@ msgstr "Limite les resultats a cette distance (km) depuis les coordonnees"
 msgid "Load Module..."
 msgstr "Chargement module..."
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 msgid "Load module from issue"
 msgstr "Chargement module depuis un probleme"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 msgid "Load module from issue..."
 msgstr "Chargement module depuis un probleme..."
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1454,7 +1456,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Longitude"
 
@@ -1462,7 +1465,7 @@ msgstr "Longitude"
 msgid "Memories"
 msgstr "Memoires"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoire %i n'est pas supprimable"
@@ -1476,7 +1479,7 @@ msgstr "La memoire doit entre dans une banque pour etre editee"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Memoire {num} pas dans la banque {bank}"
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 msgid "Mode"
 msgstr "Mode"
 
@@ -1488,15 +1491,15 @@ msgstr "Modele"
 msgid "Modes"
 msgstr "Modes"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr "Module"
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr "Module charge"
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr "Module charge avec succes"
 
@@ -1505,11 +1508,11 @@ msgstr "Module charge avec succes"
 msgid "More than one port found: %s"
 msgstr "Plus d'un port trouve: %s"
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 msgid "Move Down"
 msgstr "Descendre"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 msgid "Move Up"
 msgstr "Monter"
 
@@ -1517,19 +1520,19 @@ msgstr "Monter"
 msgid "New Window"
 msgstr "Nouvelle fenetre"
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr "Nouvelle version disponible"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 msgid "No empty rows below!"
 msgstr "Pas de ligne vide dessous!"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr "Aucun module trouve"
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr "Aucun module trouve pour le probleme %i"
@@ -1542,7 +1545,7 @@ msgstr "Aucun resultat"
 msgid "No results!"
 msgstr "Aucun resultat!"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr "Nombre"
 
@@ -1566,7 +1569,7 @@ msgstr "Seuls les onglets des memoires peuvent etre exportes"
 msgid "Only working repeaters"
 msgstr "Uniquement les repeteurs en fonctionnement"
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Ouvrir"
 
@@ -1578,15 +1581,15 @@ msgstr "Ouvrir recent"
 msgid "Open Stock Config"
 msgstr "Ouvrir base de donnees"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Ouvrir un fichier"
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr "Ouvrir un module"
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Ouvrir le fichier de debogage"
 
@@ -1594,7 +1597,7 @@ msgstr "Ouvrir le fichier de debogage"
 msgid "Open in new window"
 msgstr "Ouvrir dans une nouvelle fenetre"
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 msgid "Open stock config directory"
 msgstr "Ouvrir le repertoire de base de donnees"
 
@@ -1614,7 +1617,7 @@ msgstr "Optionnel: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Optionnel: County, Hospital, etc."
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 msgid "Overwrite memories?"
 msgstr "Ecraser les memoires?"
 
@@ -1632,31 +1635,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Analyse"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "Coller"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Les memoires collees vont ecraser %s memoires existantes"
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Les memoires collees vont ecraser les memoires %s"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Les memoires collees vont ecraser la memoire %s"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoire collee va ecraser la memoire %s"
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Soyez certain de quitter CHIRP avant d'installer la nouvelle version!"
 
@@ -1705,7 +1708,7 @@ msgstr ""
 "clonage\n"
 "    (A la fin la radio va sonner)\n"
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1730,11 +1733,11 @@ msgstr "Branchez votre cable et cliquez sur OK"
 msgid "Port"
 msgstr "Port"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Puissance"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 msgid "Press enter to set this in memory"
 msgstr "Appuyez sur entree pour inscrire ceci en memoire"
 
@@ -1746,24 +1749,24 @@ msgstr "Apercu avant impression"
 msgid "Printing"
 msgstr "Impression"
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr "Proprietes"
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr "Interroger %s"
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Interroger Source"
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Radio"
 
@@ -1806,11 +1809,11 @@ msgstr "Rafraichissement necessaire"
 msgid "Refreshed memory %s"
 msgstr "Rafraichir la memoire %s"
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Recharger pilote"
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Recharger pilote et fichier"
 
@@ -1824,11 +1827,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Rapport d'utilisation active"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -1839,7 +1842,7 @@ msgstr ""
 "la. Nous apprecierions vraiment que vous le laissiez actif. Etes-vous "
 "certain de vouloir desactiver le rapport d'utilisation?"
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr "Redemarrage necessaire"
 
@@ -1850,19 +1853,24 @@ msgid_plural "Restore %i tabs"
 msgstr[0] "Restaurer %i onglets"
 msgstr[1] "Restaurer %i onglets"
 
+#: ../wxui/main.py:815
+#, fuzzy
+msgid "Restore tabs on start"
+msgstr "Restaurer %i onglets"
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr "Preferences recuperees"
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr "Enregistrer"
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr "Enregistrer avant de fermer?"
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Enregistrer fichier"
 
@@ -1878,11 +1886,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr "Risque de securite"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "Choix d'un plan de frequences..."
 
@@ -1894,7 +1902,7 @@ msgstr "Choix des bandes"
 msgid "Select Modes"
 msgstr "Choix des modes"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr "Choix d'un plan de frequences"
 
@@ -1906,52 +1914,52 @@ msgstr "Service"
 msgid "Settings"
 msgstr "Preferences"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "Afficher les donnees de memoires brutes"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Montrer l'emplacement du fichier de debogage"
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr "Montrer les champs supplementaires"
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 msgid "Some memories are incompatible with this radio"
 msgstr "Des memoires sont incompatibles avec cette radio"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr "Des memoires ne sont pas supprimables"
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Tri %i memoires"
 msgstr[1] "Tri %i memoires"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Tri  croissant %i memoires"
 msgstr[1] "Tri  croissant %i memoires"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Tri  decroissant %i memoires"
 msgstr[1] "Tri  decroissant %i memoires"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr "Tri par colonne:"
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 msgid "Sort memories"
 msgstr "Tri des memoires"
 
@@ -1967,7 +1975,7 @@ msgstr "Etat"
 msgid "State/Province"
 msgstr "Etat/Province"
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr "Reussi"
 
@@ -2021,7 +2029,7 @@ msgstr ""
 "Sauvegardez une copie non editee de votre premier\n"
 "telechargement dans un fichier image radio CHIRP (*.img).\n"
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
@@ -2031,7 +2039,7 @@ msgstr ""
 "comporter un risque de securite, il est recommande de ne pas importer ce "
 "module. Importer tout de meme?"
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2047,7 +2055,7 @@ msgstr ""
 "%(file)s. Souhaitez-vous ouvrir ce fichier pour copier/coller entre eux ou "
 "l'importer?"
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 msgid "This Memory"
 msgstr "Cette memoire"
 
@@ -2104,11 +2112,11 @@ msgstr ""
 "Envoyez aussi vos demandes d'ameliorations ou rapports de bogues!\n"
 "Vous avez ete prevenu. Procedez a vos risques et perils!"
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 msgid "This memory and shift all up"
 msgstr "Remonter ces memoires et decalage"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 msgid "This memory and shift block up"
 msgstr "Bloquer cette memoire et le decalage"
 
@@ -2141,24 +2149,24 @@ msgstr ""
 "un comportement indefini ou non reglementaire. A utiliser a vos risques et "
 "perils!"
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 #, fuzzy
 msgid "This will load a module from a website issue"
 msgstr "Ceci chargera un module a partir d'un site web"
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "Tone"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Tone Mode"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 msgid "Tone Squelch"
 msgstr "Tone Squelch"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 msgid "Tuning Step"
 msgstr "Pas de reglage"
 
@@ -2174,11 +2182,11 @@ msgstr ""
 "Impossible de determiner le port de votre cable. Verifiez les pilotes et "
 "connexions."
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Impossible d'editer une memoire avant telechargement de la radio"
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Impossible de trouver la configuration de base %r"
@@ -2201,7 +2209,7 @@ msgstr ""
 "modele selectionne est US mais que la radio n'est pas US (ou large-bande). "
 "Selectionnez le bon modele et reessayez."
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Impossible de montrer %s dans ce systeme"
@@ -2223,11 +2231,11 @@ msgstr "Debranchez votre cable (si necessaire) et cliquez sur OK"
 msgid "Upload instructions"
 msgstr "Instruction de telechargement"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 msgid "Upload to radio"
 msgstr "Telecharger vers la radio"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "Telecharger vers la radio..."
 
@@ -2244,7 +2252,7 @@ msgstr "Utiliser une police a chasse fixe"
 msgid "Use larger font"
 msgstr "Utiliser une plus grande police"
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr "La valeur ne correspond pas a %i bits"
@@ -2259,16 +2267,16 @@ msgstr "La valeur doit etre d'au moins %.4f"
 msgid "Value must be at most %.4f"
 msgstr "La valeur ne doit pas depasser %.4f"
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr "La valeur doit comporter exactement %i decimales"
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr "Les valeur doivent etre zero ou positives"
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr "Valeurs"
 
@@ -2276,7 +2284,7 @@ msgstr "Valeurs"
 msgid "Vendor"
 msgstr "Fabricant"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 msgid "View"
 msgstr "Voir"
 
@@ -2284,11 +2292,11 @@ msgstr "Voir"
 msgid "WARNING!"
 msgstr "ATTENTION!"
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr "Attention"
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr "Attention: %s"
@@ -2307,23 +2315,23 @@ msgstr ""
 "Votre cable apparai\n"
 "t sur le port:"
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr "bits"
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr "octets"
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr "octets chacun"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr "desactive"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr "active"
 

--- a/chirp/locale/hu.po
+++ b/chirp/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2015-01-28 13:47+0100\n"
 "Last-Translator: Attila Joubert <joubert.attila@gmail.com>\n"
 "Language-Team: English\n"
@@ -34,28 +34,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "... és a tömböt felfelé lépteti"
 msgstr[1] "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memória"
 msgstr[1] "Memória"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "... és a tömböt felfelé lépteti"
 msgstr[1] "... és a tömböt felfelé lépteti"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "A fájl megváltozott! Menti bezárás előtt?"
@@ -64,7 +64,7 @@ msgstr "A fájl megváltozott! Menti bezárás előtt?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, fuzzy, python-format
 msgid "...and %i more"
 msgstr "...és minden memória felfelé lép"
@@ -622,17 +622,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr ""
 
@@ -640,12 +640,12 @@ msgstr ""
 msgid "All"
 msgstr "Mind"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "CSV fájlok"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
@@ -661,11 +661,11 @@ msgstr "Hiba történt"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr ""
 
@@ -677,7 +677,7 @@ msgstr ""
 msgid "Banks"
 msgstr ""
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Browser"
 msgstr "Böngésző"
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr ""
 
@@ -699,40 +699,40 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "RX DTCS kód"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Kereszt-üzem"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, fuzzy, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Válasszon egy importálandót:"
@@ -769,22 +769,22 @@ msgstr "Letöltés a rádióról"
 msgid "Cloning to radio"
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Megjegyzés"
 
@@ -807,7 +807,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "Másolás"
 
@@ -816,7 +816,7 @@ msgstr "Másolás"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr "Kereszt-üzem"
 
@@ -828,16 +828,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "Kivágás"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS pol."
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -848,39 +848,39 @@ msgstr "DTCS pol."
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 #, fuzzy
 msgid "DV Memory"
 msgstr "ez a memória"
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr ""
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 #, fuzzy
 msgid "Dec"
 msgstr "Érzékelés"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Fejlesztői"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr "Digitális kód"
 
@@ -889,16 +889,17 @@ msgstr "Digitális kód"
 msgid "Digital Modes"
 msgstr "Digitális kód"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 #, fuzzy
 msgid "Disabled"
 msgstr "Engedélyezve"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -911,16 +912,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 #, fuzzy
 msgid "Download from radio"
 msgstr "Letöltés a rádióról"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Letöltés a rádióról"
@@ -938,25 +939,25 @@ msgstr ""
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, fuzzy, python-format
 msgid "Edit details for %i memories"
 msgstr "Több memória szerkesztése"
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 #, fuzzy
 msgid "Enabled"
 msgstr "Engedélyezve"
@@ -966,11 +967,11 @@ msgstr "Engedélyezve"
 msgid "Enter Frequency"
 msgstr "Frekvencia"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1002,11 +1003,11 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Folytassam kísérleti driver-rel?"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Export fájlba"
@@ -1016,7 +1017,7 @@ msgstr "Export fájlba"
 msgid "Export to CSV..."
 msgstr "Export fájlba"
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr ""
 
@@ -1031,7 +1032,7 @@ msgid ""
 "required."
 msgstr ""
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr ""
 
@@ -1048,8 +1049,8 @@ msgstr ""
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 #, fuzzy
 msgid "Files"
 msgstr "_Fájl"
@@ -1062,7 +1063,7 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
@@ -1276,21 +1277,21 @@ msgstr ""
 msgid "Getting settings"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 #, fuzzy
 msgid "Goto Memory"
 msgstr "ez a memória"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 #, fuzzy
 msgid "Goto Memory:"
 msgstr "ez a memória"
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Súgó"
 
@@ -1298,11 +1299,11 @@ msgstr "Súgó"
 msgid "Help Me..."
 msgstr ""
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Felülírja?"
@@ -1312,7 +1313,7 @@ msgstr "Felülírja?"
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Importálás"
 
@@ -1321,7 +1322,7 @@ msgstr "Importálás"
 msgid "Import from file..."
 msgstr "Importálás fájlból"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr ""
 
@@ -1333,12 +1334,12 @@ msgstr "Sorszám"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 #, fuzzy
 msgid "Information"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Memória beszúrása fölé"
@@ -1347,7 +1348,7 @@ msgstr "Memória beszúrása fölé"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1356,7 +1357,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Érvénytelen érték! Egész szám kell legyen."
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Érvénytelen érték %s"
@@ -1365,12 +1366,12 @@ msgstr "Érvénytelen érték %s"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "Érvénytelen érték %s"
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1379,7 +1380,7 @@ msgstr ""
 msgid "Invalid value: %r"
 msgstr "Érvénytelen %s mezőérték"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr ""
 
@@ -1387,11 +1388,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr ""
@@ -1417,17 +1419,17 @@ msgstr ""
 msgid "Load Module..."
 msgstr "Modul betöltése"
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 #, fuzzy
 msgid "Load module from issue"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1449,7 +1451,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1457,7 +1460,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Memória"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1471,7 +1474,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 #, fuzzy
 msgid "Mode"
 msgstr "Mód"
@@ -1485,17 +1488,17 @@ msgstr "Modell"
 msgid "Modes"
 msgstr "Mód"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 #, fuzzy
 msgid "Module"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1504,12 +1507,12 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 #, fuzzy
 msgid "Move Down"
 msgstr "Lefel_é"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 #, fuzzy
 msgid "Move Up"
 msgstr "Fe_lfelé"
@@ -1518,21 +1521,21 @@ msgstr "Fe_lfelé"
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 #, fuzzy
 msgid "New version available"
 msgstr "A CHIRP egy új verziója érhető el:"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Memória beszúrása alá"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr ""
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr ""
@@ -1545,7 +1548,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr ""
 
@@ -1569,7 +1572,7 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
@@ -1583,15 +1586,15 @@ msgstr "Leg_utóbbi"
 msgid "Open Stock Config"
 msgstr "A csoportos beállítás megnyitása"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
@@ -1599,7 +1602,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "A(z) {name} konfigurációs készlet megnyitása"
@@ -1621,7 +1624,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Felülírja?"
@@ -1637,31 +1640,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1691,7 +1694,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1711,11 +1714,11 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Teljesítmény"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 #, fuzzy
 msgid "Press enter to set this in memory"
 msgstr "Memória beállítási hiba"
@@ -1728,26 +1731,26 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, fuzzy, python-format
 msgid "Query %s"
 msgstr "Lekérdezés hiba"
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 #, fuzzy
 msgid "Query Source"
 msgstr "Lekérd. adatforrása"
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 #, fuzzy
 msgid "RX DTCS"
 msgstr "RX DTCS kód"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Rádió"
 
@@ -1788,11 +1791,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr "ezek a memóriák"
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1806,19 +1809,19 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Listázás letiltva"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr ""
 
@@ -1829,19 +1832,23 @@ msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../wxui/main.py:815
+msgid "Restore tabs on start"
+msgstr ""
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1858,11 +1865,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Oszlopok kiválasztása"
@@ -1877,7 +1884,7 @@ msgstr "Oszlopok kiválasztása"
 msgid "Select Modes"
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1889,55 +1896,55 @@ msgstr ""
 msgid "Settings"
 msgstr "Beállítás"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "Memóriasor mutatása"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "A beillesztett {number}. számú memória nem kompatibilis ezzel a rádióval, "
 "mert:"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 #, fuzzy
 msgid "Sort memories"
 msgstr "Felülírja?"
@@ -1955,7 +1962,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr ""
 
@@ -1988,14 +1995,14 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2005,7 +2012,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 #, fuzzy
 msgid "This Memory"
 msgstr "ez a memória"
@@ -2050,12 +2057,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "... és a tömböt felfelé lépteti"
@@ -2077,24 +2084,24 @@ msgid ""
 "own risk!"
 msgstr ""
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "CTCSS"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Hang (CTCSS) mód"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Lépésköz"
@@ -2109,11 +2116,11 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "A csoportos beállítás megnyitása"
@@ -2134,7 +2141,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Ennél a modellnél nem változtatható"
@@ -2157,12 +2164,12 @@ msgstr ""
 msgid "Upload instructions"
 msgstr "{instructions}"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Feltöltés a rádióra"
@@ -2180,7 +2187,7 @@ msgstr ""
 msgid "Use larger font"
 msgstr ""
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr ""
@@ -2195,16 +2202,16 @@ msgstr ""
 msgid "Value must be at most %.4f"
 msgstr ""
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr ""
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr ""
 
@@ -2212,7 +2219,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Gyártó"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 #, fuzzy
 msgid "View"
 msgstr "Né_zet"
@@ -2221,11 +2228,11 @@ msgstr "Né_zet"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2242,24 +2249,24 @@ msgstr ""
 msgid "Your cable appears to be on port:"
 msgstr ""
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr ""
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr ""
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 #, fuzzy
 msgid "disabled"
 msgstr "Engedélyezve"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 #, fuzzy
 msgid "enabled"
 msgstr "Engedélyezve"

--- a/chirp/locale/it.po
+++ b/chirp/locale/it.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
-"PO-Revision-Date: 2024-01-16 21:20+0100\n"
+"POT-Creation-Date: 2024-01-20 12:22+0100\n"
+"PO-Revision-Date: 2024-01-20 12:24+0100\n"
 "Last-Translator: Daniele Forsi <iu5hkx@gmail.com>\n"
 "Language-Team: \n"
 "Language: it\n"
@@ -35,28 +35,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s deve essere tra %(min)i e %(max)i"
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i memoria e sposta tutto su"
 msgstr[1] "%i memorie e sposta tutto su"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i memoria"
 msgstr[1] "%i memorie"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i memoria e sposta il blocco su"
 msgstr[1] "%i memoria e sposta il blocco su"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s non è stato salvato. Salvarlo prima di chiudere?"
@@ -65,7 +65,7 @@ msgstr "%s non è stato salvato. Salvarlo prima di chiudere?"
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr "...e altri %i"
@@ -623,7 +623,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -631,11 +631,11 @@ msgstr ""
 "È disponibile una nuova versione di CHIRP. Visitare il sito web prima "
 "possibile per scaricarla!"
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "Informazioni"
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr "Informazioni su CHIRP"
 
@@ -643,11 +643,11 @@ msgstr "Informazioni su CHIRP"
 msgid "All"
 msgstr "Tutto"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Tutti i file"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Tutti i formati supportati|"
 
@@ -663,11 +663,11 @@ msgstr "Si è verificato un errore"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr "Moduli disponibili"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr ""
 
@@ -679,7 +679,7 @@ msgstr "Bande"
 msgid "Banks"
 msgstr "Banchi"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr "Bin"
 
@@ -687,7 +687,7 @@ msgstr "Bin"
 msgid "Browser"
 msgstr "Browser"
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr ""
 
@@ -701,39 +701,39 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "File immagine di Chirp"
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr "Scelta richiesta"
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Scegliere il codice DTCS %s"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Scegliere il Tono %s"
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 msgid "Choose Cross Mode"
 msgstr "Scegliere il modo Cross"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr "Scegliere il duplex"
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr ""
@@ -768,22 +768,22 @@ msgstr "Clonazione dalla radio"
 msgid "Cloning to radio"
 msgstr "Clonazione verso la radio"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr "Chiudi"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr "Chiude il file"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Raggruppa %i memoria"
 msgstr[1] "Raggruppa %i memorie"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Commento"
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Converti in FM"
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "Copia"
 
@@ -814,7 +814,7 @@ msgstr "Copia"
 msgid "Country"
 msgstr "Nazione"
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr "Modo cross"
 
@@ -826,15 +826,15 @@ msgstr "Porta personalizzata"
 msgid "Custom..."
 msgstr "Personalizza..."
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "Taglia"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -846,36 +846,36 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr "Memoria DV"
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr ""
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Elimina"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Modalità sviluppatore"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "Diff memorie grezze"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr ""
 
@@ -883,15 +883,16 @@ msgstr ""
 msgid "Digital Modes"
 msgstr "Modi digitali"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr "Disabilitata"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Distanza"
 
@@ -904,15 +905,15 @@ msgstr "Non mostrarlo più per %s"
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr "Scarica"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 msgid "Download from radio"
 msgstr "Scarica dalla radio"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "Scarica dalla radio..."
 
@@ -930,25 +931,25 @@ msgstr ""
 "I ripetitori digitali dual-mode che supportano l'analogico saranno mostrati "
 "come FM"
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Modifica dettagli per %i memorie"
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Modifica dettagli per la memoria %i"
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Abilita modifiche automatiche"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr "Abilitata"
 
@@ -956,11 +957,11 @@ msgstr "Abilitata"
 msgid "Enter Frequency"
 msgstr "Inserire la frequenza"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr "Inserire l'offset (MHz)"
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr "Inserire la frequenza TX (MHz)"
 
@@ -991,11 +992,11 @@ msgstr "Errore durante la comunicazione con la radio"
 msgid "Experimental driver"
 msgstr "Driver sperimentale"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr "L'esportazione può scrivere solo file CSV"
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 msgid "Export to CSV"
 msgstr "Esporta in CSV"
 
@@ -1003,7 +1004,7 @@ msgstr "Esporta in CSV"
 msgid "Export to CSV..."
 msgstr "Esporta in CSV..."
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr ""
 
@@ -1021,7 +1022,7 @@ msgstr ""
 "informazioni più aggiornate sui ripetitori in Europa.\n"
 "Non è necessario un account."
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr ""
 
@@ -1038,8 +1039,8 @@ msgstr ""
 msgid "File does not exist: %s"
 msgstr "Il file non esiste: %s"
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 msgid "Files"
 msgstr "File"
 
@@ -1051,7 +1052,7 @@ msgstr "Filtro"
 msgid "Filter results with location matching this string"
 msgstr "Filtra i risultati con i luoghi che corrispondono a questa stringa"
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr "Trova"
 
@@ -1261,19 +1262,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 msgid "Goto Memory"
 msgstr "Vai alla memoria"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr "Vai alla memoria:"
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr "Vai..."
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Aiuto"
 
@@ -1281,11 +1282,11 @@ msgstr "Aiuto"
 msgid "Help Me..."
 msgstr "Aiutami..."
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 msgid "Hide empty memories"
 msgstr "Nascondi memorie vuote"
 
@@ -1295,7 +1296,7 @@ msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Se impostata, ordina i risultati secondo la distanza da tali coordinate"
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Importa"
 
@@ -1303,7 +1304,7 @@ msgstr "Importa"
 msgid "Import from file..."
 msgstr "Importa da file..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr "Importazione non raccomandata"
 
@@ -1315,11 +1316,11 @@ msgstr "Indice"
 msgid "Info"
 msgstr "Informazioni"
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr "Informazioni"
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 msgid "Insert Row Above"
 msgstr "Inserisci riga sopra"
 
@@ -1327,7 +1328,7 @@ msgstr "Inserisci riga sopra"
 msgid "Install desktop icon?"
 msgstr "Installare l'icona per il desktop?"
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1336,7 +1337,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Valore %(value)s non valido (usare gradi decimali)"
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 msgid "Invalid Entry"
 msgstr "Valore non valido"
 
@@ -1344,12 +1345,12 @@ msgstr "Valore non valido"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Modifica non valida: %s"
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1358,7 +1359,7 @@ msgstr ""
 msgid "Invalid value: %r"
 msgstr "Valore non valido: %r"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr ""
 
@@ -1366,11 +1367,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Latitudine"
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr "La lunghezza deve essere %i"
@@ -1395,15 +1397,15 @@ msgstr "Limita i risultati a questa distanza (km) dalle coordinate"
 msgid "Load Module..."
 msgstr "Carica modulo..."
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 msgid "Load module from issue"
 msgstr ""
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1425,7 +1427,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Longitudine"
 
@@ -1433,7 +1436,7 @@ msgstr "Longitudine"
 msgid "Memories"
 msgstr "Memorie"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoria %i non è eliminabile"
@@ -1447,7 +1450,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 msgid "Mode"
 msgstr "Modo"
 
@@ -1459,15 +1462,15 @@ msgstr "Modello"
 msgid "Modes"
 msgstr "Modi"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr "Modulo"
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr "Modulo caricato"
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr "Modulo caricato con successo"
 
@@ -1476,11 +1479,11 @@ msgstr "Modulo caricato con successo"
 msgid "More than one port found: %s"
 msgstr "Trovata più di una porta: %s"
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 msgid "Move Down"
 msgstr "Sposta giù"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 msgid "Move Up"
 msgstr "Sposta su"
 
@@ -1488,19 +1491,19 @@ msgstr "Sposta su"
 msgid "New Window"
 msgstr "Nuova finestra"
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr "Nuova versione disponibile"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 msgid "No empty rows below!"
 msgstr ""
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr "Nessun modulo trovato"
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr ""
@@ -1513,7 +1516,7 @@ msgstr "Nessun risultato"
 msgid "No results!"
 msgstr "Nessun risultato!"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr "Numero"
 
@@ -1537,7 +1540,7 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr "Solo ripetitori funzionanti"
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Apri"
 
@@ -1549,15 +1552,15 @@ msgstr "Apri recente"
 msgid "Open Stock Config"
 msgstr "Apri configurazione standard"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Apri file"
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr "Apri modulo"
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Apri registro di debug"
 
@@ -1565,7 +1568,7 @@ msgstr "Apri registro di debug"
 msgid "Open in new window"
 msgstr "Apri in nuova finestra"
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 msgid "Open stock config directory"
 msgstr "Apri directory configurazioni standard"
 
@@ -1585,7 +1588,7 @@ msgstr "Opzionale: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opzionale: contea, ospedale, ecc."
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 msgid "Overwrite memories?"
 msgstr "Sovrascrivere le memorie?"
 
@@ -1600,31 +1603,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "Incolla"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Le memorie incollate sovrascriveranno %s memorie esistenti"
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Le memorie incollate sovrascriveranno le memorie %s"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Le memorie incollate sovrascriveranno la memoria %s"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria incollata sovrascrivera la memoria %s"
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Assicurarsi di uscire da CHIRP prima di installare la nuova versione!"
 
@@ -1654,7 +1657,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1674,11 +1677,11 @@ msgstr "Collegare il cavo e premere OK"
 msgid "Port"
 msgstr "Porta"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Potenza"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 msgid "Press enter to set this in memory"
 msgstr "Premere Invio per impostarlo in memoria"
 
@@ -1690,24 +1693,24 @@ msgstr "Anteprima di stampa"
 msgid "Printing"
 msgstr "Stampa in corso"
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr "Proprietà"
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr "Interroga %s"
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Interroga fonte"
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Radio"
 
@@ -1747,11 +1750,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1767,18 +1770,18 @@ msgstr ""
 "RepeaterBook è l'elenco mondiale e GRATUITO\n"
 "più completo di ripetitori per radioamatori."
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Reporting abilitato"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr "Riavvio richiesto"
 
@@ -1789,19 +1792,23 @@ msgid_plural "Restore %i tabs"
 msgstr[0] "Ripristina %i scheda"
 msgstr[1] "Ripristina %i schede"
 
+#: ../wxui/main.py:815
+msgid "Restore tabs on start"
+msgstr "Ripristina schede all'avvio"
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr "Impostazioni recuperate"
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr "Salva"
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr "Salvare prima di chiudere?"
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Salva file"
 
@@ -1817,11 +1824,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr "Rischio di sicurezza"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "Seleziona bandplan..."
 
@@ -1833,7 +1840,7 @@ msgstr "Selezionare le bande"
 msgid "Select Modes"
 msgstr "Selezionare i modi"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr "Selezionare un bandplan"
 
@@ -1845,52 +1852,52 @@ msgstr "Servizio"
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "Mostra memoria grezza"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Mostra posizione di debug"
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr "Mostra campi aggiuntivi"
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 msgid "Some memories are incompatible with this radio"
 msgstr "Alcune memorie sono incompatibili con questa radio"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr "Alcune memorie non sono cancellabili"
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Ordina %i memoria"
 msgstr[1] "Ordina %i memorie"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "%i memoria in ordine decrescente"
 msgstr[1] "%i memorie in ordine decrescente"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "%i memoria in ordine decrescente"
 msgstr[1] "%i memorie in ordine decrescente"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr "Colonna per l'ordinamento:"
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 msgid "Sort memories"
 msgstr "Ordina memorie"
 
@@ -1906,7 +1913,7 @@ msgstr "Stato"
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr "Successo"
 
@@ -1939,14 +1946,14 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -1956,7 +1963,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 msgid "This Memory"
 msgstr "Questa memoria"
 
@@ -2000,11 +2007,11 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 msgid "This memory and shift all up"
 msgstr "Questa memoria e sposta tutto in alto"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 msgid "This memory and shift block up"
 msgstr "Questa memoria e sposta il blocco in alto"
 
@@ -2025,23 +2032,23 @@ msgid ""
 "own risk!"
 msgstr ""
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "Tono"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Modalità tono"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 msgid "Tone Squelch"
 msgstr "Tone squelch"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 msgid "Tuning Step"
 msgstr "Step sintonia"
 
@@ -2057,11 +2064,11 @@ msgstr ""
 "Impossibile determinare la porta per il cavo. Controllare i driver e i "
 "collegamenti."
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Impossibile modificare la memoria prima di averla caricata dalla radio"
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Impossibile trovare la configurazione standard %r"
@@ -2081,7 +2088,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Impossibile rivelare %s su questo sistema"
@@ -2103,11 +2110,11 @@ msgstr "Scollegare il cavo (se necessario) e poi premere OK"
 msgid "Upload instructions"
 msgstr "Istruzioni per il caricamento"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 msgid "Upload to radio"
 msgstr "Carica sulla radio"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "Carica sulla radio..."
 
@@ -2124,7 +2131,7 @@ msgstr "Usa carattere a larghezza fissa"
 msgid "Use larger font"
 msgstr "Usa carattere più grande"
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr "Il valore non entra in %i bit"
@@ -2139,16 +2146,16 @@ msgstr "Il valore deve essere almeno %.4f"
 msgid "Value must be at most %.4f"
 msgstr "Il valore deve essere al massimo %.4f"
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr "Il valore deve essere di esattamente %i cifre decimali"
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr "Il valore deve essere maggiore o uguale a zero"
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr "Valori"
 
@@ -2156,7 +2163,7 @@ msgstr "Valori"
 msgid "Vendor"
 msgstr "Produttore"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 msgid "View"
 msgstr "Visualizza"
 
@@ -2164,11 +2171,11 @@ msgstr "Visualizza"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2185,23 +2192,23 @@ msgstr "Installare un'icona sul desktop?"
 msgid "Your cable appears to be on port:"
 msgstr "Il cavo sembra sulla porta:"
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr "bit"
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr "byte"
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr "byte ciascuno"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/ja_JP.po
+++ b/chirp/locale/ja_JP.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2023-12-03 11:04+0900\n"
 "Last-Translator: weboo <weboo@users.noreply.github.com>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
@@ -33,25 +33,25 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i 件削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i 件の内容を削除"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i 件削除してグループを上方向にシフト"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s は保存されていません。保存しますか？"
@@ -60,7 +60,7 @@ msgstr "%s は保存されていません。保存しますか？"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -630,7 +630,7 @@ msgstr ""
 "\n"
 "ケーブルを接続した状態で電源オンにするとうまく動かない場合があります。"
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -638,11 +638,11 @@ msgstr ""
 "新しいバージョンのCHIRPが利用可能です。できるだけ早く更新されることをお勧めし"
 "ます。今すぐ更新しますか？"
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "このアプリについて"
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr "CHIRP について"
 
@@ -650,11 +650,11 @@ msgstr "CHIRP について"
 msgid "All"
 msgstr "すべて"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr ""
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
@@ -670,11 +670,11 @@ msgstr ""
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr "バンドプラン"
 
@@ -686,7 +686,7 @@ msgstr "バンド"
 msgid "Banks"
 msgstr "バンク"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Browser"
 msgstr ""
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr ""
 
@@ -708,39 +708,39 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
-msgstr ""
-
-#: ../wxui/memedit.py:1246
-#, python-format
-msgid "Choose %s DTCS Code"
 msgstr ""
 
 #: ../wxui/memedit.py:1243
 #, python-format
+msgid "Choose %s DTCS Code"
+msgstr ""
+
+#: ../wxui/memedit.py:1240
+#, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr ""
@@ -775,21 +775,21 @@ msgstr ""
 msgid "Cloning to radio"
 msgstr ""
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr "閉じる"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr "ファイルを閉じる"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "%i 件を同一グループにまとめる"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "コメント"
 
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "コピー"
 
@@ -820,7 +820,7 @@ msgstr "コピー"
 msgid "Country"
 msgstr "国"
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr ""
 
@@ -832,15 +832,15 @@ msgstr "ポートを手動で設定"
 msgid "Custom..."
 msgstr "カスタム..."
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "切り取り"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 msgid "DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -850,36 +850,36 @@ msgstr "DTCS極性"
 msgid "DTMF decode"
 msgstr "DTMF デコード"
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr ""
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "削除"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "開発者モード"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr ""
 
@@ -887,15 +887,16 @@ msgstr ""
 msgid "Digital Modes"
 msgstr ""
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr "診断レポート送信を停止"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -908,15 +909,15 @@ msgstr "次回から %s に接続する際にプロンプトを表示しない"
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr "ダウンロード"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 msgid "Download from radio"
 msgstr "無線機からダウンロード"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "無線機からダウンロード..."
 
@@ -932,25 +933,25 @@ msgstr "ドライバー情報"
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "値を自動設定"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr ""
 
@@ -958,11 +959,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "周波数を入力"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -992,11 +993,11 @@ msgstr "無線機との通信エラー"
 msgid "Experimental driver"
 msgstr "実験的ドライバー"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 msgid "Export to CSV"
 msgstr "CSVにエクスポート"
 
@@ -1004,7 +1005,7 @@ msgstr "CSVにエクスポート"
 msgid "Export to CSV..."
 msgstr "CSVにエクスポート..."
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr ""
 
@@ -1019,7 +1020,7 @@ msgid ""
 "required."
 msgstr ""
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr ""
 
@@ -1036,8 +1037,8 @@ msgstr ""
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 msgid "Files"
 msgstr ""
 
@@ -1049,7 +1050,7 @@ msgstr "フィルター"
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr "検索"
 
@@ -1259,19 +1260,19 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 msgid "Goto Memory"
 msgstr "行移動"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr "指定した行に移動:"
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr "行移動..."
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "ヘルプ"
 
@@ -1279,11 +1280,11 @@ msgstr "ヘルプ"
 msgid "Help Me..."
 msgstr "ポートが不明の場合..."
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 msgid "Hide empty memories"
 msgstr "空のメモリーを非表示"
 
@@ -1292,7 +1293,7 @@ msgstr "空のメモリーを非表示"
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "インポート"
 
@@ -1300,7 +1301,7 @@ msgstr "インポート"
 msgid "Import from file..."
 msgstr "ファイルからインポート..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr "インポートは推奨されません"
 
@@ -1312,11 +1313,11 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 msgid "Insert Row Above"
 msgstr "上に1行追加"
 
@@ -1324,7 +1325,7 @@ msgstr "上に1行追加"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1333,7 +1334,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1341,12 +1342,12 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1355,7 +1356,7 @@ msgstr ""
 msgid "Invalid value: %r"
 msgstr ""
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr ""
 
@@ -1363,11 +1364,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "緯度"
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr ""
@@ -1392,15 +1394,15 @@ msgstr ""
 msgid "Load Module..."
 msgstr ""
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 msgid "Load module from issue"
 msgstr ""
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1422,7 +1424,8 @@ msgstr "起動メッセージ１（半角12文字）"
 msgid "Logo string 2 (12 characters)"
 msgstr "起動メッセージ２（半角12文字）"
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "軽度"
 
@@ -1430,7 +1433,7 @@ msgstr "軽度"
 msgid "Memories"
 msgstr "メモリー"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1444,7 +1447,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 msgid "Mode"
 msgstr "受信モード"
 
@@ -1456,15 +1459,15 @@ msgstr "モデル"
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1473,11 +1476,11 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 msgid "Move Down"
 msgstr "下に移動"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 msgid "Move Up"
 msgstr "上に移動"
 
@@ -1485,19 +1488,19 @@ msgstr "上に移動"
 msgid "New Window"
 msgstr "新規ウィンドウ"
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr "新しいバージョンが利用可能です"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 msgid "No empty rows below!"
 msgstr ""
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr ""
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr ""
@@ -1510,7 +1513,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr "行"
 
@@ -1534,7 +1537,7 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr "開く"
 
@@ -1546,15 +1549,15 @@ msgstr "最近使ったファイル"
 msgid "Open Stock Config"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "ファイルを開く"
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
@@ -1562,7 +1565,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr "新しいウィンドウで開く"
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 msgid "Open stock config directory"
 msgstr ""
 
@@ -1582,7 +1585,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 msgid "Overwrite memories?"
 msgstr "メモリーを上書きしますか？"
 
@@ -1597,31 +1600,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "ペースト"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "新しいバージョンをインストールする前に必ずCHIRPを終了してください。"
 
@@ -1651,7 +1654,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1671,11 +1674,11 @@ msgstr "ケーブルを接続してOKをクリックしてください。"
 msgid "Port"
 msgstr "ポート"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "出力"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 msgid "Press enter to set this in memory"
 msgstr ""
 
@@ -1687,24 +1690,24 @@ msgstr "印刷プレビュー"
 msgid "Printing"
 msgstr "印刷"
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr "プロパティ"
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr ""
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "無線機"
 
@@ -1744,11 +1747,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr "%s 件のメモリーを取得しました"
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1762,11 +1765,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "診断レポート送信"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -1776,7 +1779,7 @@ msgstr ""
 "かを判断するのに役立ちます。このまま有効にしておいていただけると有り難いで"
 "す。本当に無効にしますか？"
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr "再起動が必要です"
 
@@ -1786,19 +1789,24 @@ msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "最近閉じた%i個のタブを開く"
 
+#: ../wxui/main.py:815
+#, fuzzy
+msgid "Restore tabs on start"
+msgstr "最近閉じた%i個のタブを開く"
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr "設定を取得しました"
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr "保存"
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr "保存しますか？"
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "ファイルに保存"
 
@@ -1814,11 +1822,11 @@ msgstr "スキャンリスト"
 msgid "Scrambler"
 msgstr "スクランブル"
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr "セキュリティリスク"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "バンドプランを選択..."
 
@@ -1830,7 +1838,7 @@ msgstr ""
 msgid "Select Modes"
 msgstr ""
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr "バンドプラン選択"
 
@@ -1842,49 +1850,49 @@ msgstr "サービス"
 msgid "Settings"
 msgstr "設定"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr ""
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr "追加フィールドを表示"
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "昇順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "降順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr "カラムを選択"
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 msgid "Sort memories"
 msgstr "並び替え"
 
@@ -1900,7 +1908,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr "成功"
 
@@ -1933,14 +1941,14 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -1955,7 +1963,7 @@ msgstr ""
 "に置き換えます。このファイルを開いて「メモリ」をコピー＆ペーストしますか？そ"
 "れともインポートを続けますか？"
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 msgid "This Memory"
 msgstr "この行の内容を削除"
 
@@ -2007,11 +2015,11 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 msgid "This memory and shift all up"
 msgstr "この行を削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 msgid "This memory and shift block up"
 msgstr "この行を削除してグループを上方向にシフト"
 
@@ -2032,23 +2040,23 @@ msgid ""
 "own risk!"
 msgstr ""
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "トーン(Hz)"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "トーンモード"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 msgid "Tone Squelch"
 msgstr "トーンスケルチ"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 msgid "Tuning Step"
 msgstr "ステップ(kHz)"
 
@@ -2064,11 +2072,11 @@ msgstr ""
 "ポートを検出できませんでした。ドライバーがインストールされているかと接続状態"
 "をもう一度確認してください。"
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
@@ -2088,7 +2096,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
@@ -2110,11 +2118,11 @@ msgstr "ケーブルを抜いてからOKをクリックしてください。"
 msgid "Upload instructions"
 msgstr "アップロード手順"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 msgid "Upload to radio"
 msgstr "無線機にアップロード"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "無線機にアップロード..."
 
@@ -2131,7 +2139,7 @@ msgstr "固定幅フォントを使用"
 msgid "Use larger font"
 msgstr "大きいフォントを使用"
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr "値は %i bitにしてください"
@@ -2146,16 +2154,16 @@ msgstr "値は %.4f 以上にしてください"
 msgid "Value must be at most %.4f"
 msgstr "値は %.4f 以下にしてください"
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr "値は %i 桁にしてください"
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr "値は 0 以上にしてください"
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr "値"
 
@@ -2163,7 +2171,7 @@ msgstr "値"
 msgid "Vendor"
 msgstr "メーカー"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 msgid "View"
 msgstr "表示"
 
@@ -2171,11 +2179,11 @@ msgstr "表示"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2192,23 +2200,23 @@ msgstr "デスクトップにCHIRPのアイコンを設定しますか？"
 msgid "Your cable appears to be on port:"
 msgstr "あなたのケーブルが使用しているポート:"
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr ""
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr ""
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr "無効"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr "有効"
 

--- a/chirp/locale/nl.po
+++ b/chirp/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2012-03-18 12:01+0100\n"
 "Last-Translator: Michael Tel <m.tel@xs4all.nl>\n"
 "Language-Team: Dutch\n"
@@ -34,28 +34,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Verwijderen (en naar boven verplaatsen)"
 msgstr[1] "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Kanalen"
 msgstr[1] "Kanalen"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Verwijderen (en naar boven verplaatsen)"
 msgstr[1] "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Het bestand is aangepast. Wilt u de wijzigingen opslaan?"
@@ -64,7 +64,7 @@ msgstr "Het bestand is aangepast. Wilt u de wijzigingen opslaan?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -622,17 +622,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr ""
 
@@ -640,12 +640,12 @@ msgstr ""
 msgid "All"
 msgstr "Alles"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "Komma gescheiden bestanden"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
@@ -661,11 +661,11 @@ msgstr "Er is een fout opgetreden"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr ""
 
@@ -677,7 +677,7 @@ msgstr ""
 msgid "Banks"
 msgstr "Banken"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Browser"
 msgstr ""
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr ""
 
@@ -699,40 +699,40 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS code"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross-mode"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, fuzzy, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Kies n om vanuit te importeren:"
@@ -769,22 +769,22 @@ msgstr "Download van radio"
 msgid "Cloning to radio"
 msgstr "Naar radio uploaden"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Opmerking"
 
@@ -807,7 +807,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "Kopiëren"
 
@@ -816,7 +816,7 @@ msgstr "Kopiëren"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 #, fuzzy
 msgid "Cross mode"
 msgstr "Cross-mode"
@@ -829,16 +829,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "Knippen"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -849,38 +849,38 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr ""
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 #, fuzzy
 msgid "Dec"
 msgstr "Detecteren"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Ontwerper"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr "Digitale code"
 
@@ -889,15 +889,16 @@ msgstr "Digitale code"
 msgid "Digital Modes"
 msgstr "Digitale code"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -910,16 +911,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download van radio"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download van radio"
@@ -937,25 +938,25 @@ msgstr ""
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr ""
 
@@ -964,11 +965,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Frequentie"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -999,11 +1000,11 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Exporteren naar bestand"
@@ -1013,7 +1014,7 @@ msgstr "Exporteren naar bestand"
 msgid "Export to CSV..."
 msgstr "Exporteren naar bestand"
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr ""
 
@@ -1028,7 +1029,7 @@ msgid ""
 "required."
 msgstr ""
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr ""
 
@@ -1045,8 +1046,8 @@ msgstr ""
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 #, fuzzy
 msgid "Files"
 msgstr "_Bestanden"
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr ""
 
@@ -1269,20 +1270,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Toon ruw kanaal"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Help"
 
@@ -1290,11 +1291,11 @@ msgstr "Help"
 msgid "Help Me..."
 msgstr ""
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Overschrijven?"
@@ -1304,7 +1305,7 @@ msgstr "Overschrijven?"
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Importeren"
 
@@ -1313,7 +1314,7 @@ msgstr "Importeren"
 msgid "Import from file..."
 msgstr "Importeren van bestand"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Importeren uit RFinder"
@@ -1326,11 +1327,11 @@ msgstr "Index"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Regel hierboven invoegen"
@@ -1339,7 +1340,7 @@ msgstr "Regel hierboven invoegen"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1348,7 +1349,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ongeldige waarde. Het moet een integer zijn."
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ongeldige waarde voor dit veld"
@@ -1357,12 +1358,12 @@ msgstr "Ongeldige waarde voor dit veld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1371,7 +1372,7 @@ msgstr ""
 msgid "Invalid value: %r"
 msgstr "Ongeldige waarde voor dit veld"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr ""
 
@@ -1379,11 +1380,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr ""
@@ -1409,17 +1411,17 @@ msgstr ""
 msgid "Load Module..."
 msgstr "Toonmodus"
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 #, fuzzy
 msgid "Load module from issue"
 msgstr "Toonmodus"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Toonmodus"
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1441,7 +1443,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1449,7 +1452,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Kanalen"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1463,7 +1466,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1477,15 +1480,15 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Mode"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1494,12 +1497,12 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 #, fuzzy
 msgid "Move Down"
 msgstr "Verplaats omlaa_g"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 #, fuzzy
 msgid "Move Up"
 msgstr "Verplaats om_hoog"
@@ -1508,20 +1511,20 @@ msgstr "Verplaats om_hoog"
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Regel hieronder invoegen"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr ""
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr ""
@@ -1534,7 +1537,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr ""
 
@@ -1558,7 +1561,7 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
@@ -1572,15 +1575,15 @@ msgstr "_Recent"
 msgid "Open Stock Config"
 msgstr "Openen aanwezige configuratie"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
@@ -1588,7 +1591,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Openen van aanwezige configuratie {name}"
@@ -1610,7 +1613,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Overschrijven?"
@@ -1626,31 +1629,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "Plakken"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1680,7 +1683,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1700,11 +1703,11 @@ msgstr ""
 msgid "Port"
 msgstr "Poort"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Vermogen"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 #, fuzzy
 msgid "Press enter to set this in memory"
 msgstr "Fout bij het instellen van het geheugen"
@@ -1717,24 +1720,24 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr ""
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Radio"
 
@@ -1775,11 +1778,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1794,19 +1797,19 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Rapportering is uitgeschakeld"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr ""
 
@@ -1817,19 +1820,23 @@ msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../wxui/main.py:815
+msgid "Restore tabs on start"
+msgstr ""
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1845,11 +1852,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Kolommen selecteren"
@@ -1864,7 +1871,7 @@ msgstr "Kolommen selecteren"
 msgid "Select Modes"
 msgstr "Kolommen selecteren"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1876,53 +1883,53 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "Toon ruw kanaal"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Geplakt kanaal {number} is niet compatibel met deze radio omdat:"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 #, fuzzy
 msgid "Sort memories"
 msgstr "Overschrijven?"
@@ -1939,7 +1946,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr ""
 
@@ -1972,14 +1979,14 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -1989,7 +1996,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 #, fuzzy
 msgid "This Memory"
 msgstr "Toon ruw kanaal"
@@ -2034,12 +2041,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
@@ -2061,24 +2068,24 @@ msgid ""
 "own risk!"
 msgstr ""
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "Toon"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Toonmodus"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "Toon squelch"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Kanaal-afstand"
@@ -2093,11 +2100,11 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Openen aanwezige configuratie"
@@ -2118,7 +2125,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Niet in staat om wijzigingen voor dit model te maken"
@@ -2140,12 +2147,12 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Naar radio uploaden"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Naar radio uploaden"
@@ -2163,7 +2170,7 @@ msgstr ""
 msgid "Use larger font"
 msgstr ""
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr ""
@@ -2178,16 +2185,16 @@ msgstr ""
 msgid "Value must be at most %.4f"
 msgstr ""
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr ""
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr ""
 
@@ -2195,7 +2202,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Merk"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 #, fuzzy
 msgid "View"
 msgstr "Bee_ld"
@@ -2204,11 +2211,11 @@ msgstr "Bee_ld"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2225,23 +2232,23 @@ msgstr ""
 msgid "Your cable appears to be on port:"
 msgstr ""
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr ""
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr ""
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/pl.po
+++ b/chirp/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2023-07-12 21:21+0200\n"
 "Last-Translator: szporwolik\n"
 "Language-Team: Polish\n"
@@ -35,7 +35,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s muszą być pomiędzy %(min)i oraz %(max)i"
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -43,7 +43,7 @@ msgstr[0] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[1] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[2] "%i pamięci oraz przesuń wszystkie do góry"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -51,7 +51,7 @@ msgstr[0] "%i pamięci"
 msgstr[1] "%i pamięci"
 msgstr[2] "%i pamięci"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -59,7 +59,7 @@ msgstr[0] "%i pamięci oraz przesuń blok do góry"
 msgstr[1] "%i pamięci oraz przesuń blok do góry"
 msgstr[2] "%i pamięci oraz przesuń blok do góry"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s nie został zapisany. Zapisać przed zamknięciem?"
@@ -68,7 +68,7 @@ msgstr "%s nie został zapisany. Zapisać przed zamknięciem?"
 msgid "(none)"
 msgstr "(brak)"
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr "...oraz %i więcej"
@@ -638,7 +638,7 @@ msgstr ""
 "\n"
 "Obraz może nie działać, jeśli radio zostanie włączone z podłączonym kablem"
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -646,11 +646,11 @@ msgstr ""
 "Nowa wersja programu CHIRP jest dostępna. Odwiedź stronę internetową "
 "projektu i pobierz ją!"
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "O programie"
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr "O programie CHIRP"
 
@@ -658,11 +658,11 @@ msgstr "O programie CHIRP"
 msgid "All"
 msgstr "Wszystkie"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Wszystkie pliki"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Wszystkie wspierane formaty|"
 
@@ -678,11 +678,11 @@ msgstr "Wystąpił błąd"
 msgid "Applying settings"
 msgstr "Stosowanie ustawień"
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr "Dostępne moduły"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr "Bandplan"
 
@@ -694,7 +694,7 @@ msgstr "Pasma"
 msgid "Banks"
 msgstr "Banki"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr "Bin"
 
@@ -702,7 +702,7 @@ msgstr "Bin"
 msgid "Browser"
 msgstr "Przeglądarka"
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr "Budowanie przeglądarki radiostacji"
 
@@ -718,40 +718,40 @@ msgstr ""
 "Zmiana tego ustawienia wymaga odświeżenia z obrazu, co zostanie teraz "
 "wykonane."
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 "Kanały z takim samym TX oraz RX %s są reprezentowane trybem tonu \"%s\""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Pliki obrazu CHIRP"
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr "Wymagany wybór"
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Wybierz %s kod DTCS "
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Wybierz %s ton"
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 msgid "Choose Cross Mode"
 msgstr "Wybierz tryb krzyżowy"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr "Wybierz duplex"
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Wybierz moduł do zaimportowania ze zgłoszenia %i:"
@@ -786,15 +786,15 @@ msgstr "Pobieranie z radiostacji"
 msgid "Cloning to radio"
 msgstr "Wysyłanie do radiostacji"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr "Zamknij"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr "Zamknij plik"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -802,7 +802,7 @@ msgstr[0] "Grupuj %i pamięci"
 msgstr[1] "Grupuj %i pamięci"
 msgstr[2] "Grupuj %i pamięci"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -824,7 +824,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "Kopiuj"
 
@@ -833,7 +833,7 @@ msgstr "Kopiuj"
 msgid "Country"
 msgstr "Kraj"
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr "Tryb krzyżowy"
 
@@ -846,15 +846,15 @@ msgstr "Wprowadź port:"
 msgid "Custom..."
 msgstr "Nietypowy..."
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "Wytnij"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 msgid "DTCS"
 msgstr "DTCS TX"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -866,38 +866,38 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr "Pamięć DV"
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr "Niebezpieczeństwo"
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Tryb dewelopera"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Tryb developera jest teraz %s. CHIRP musi zostać ponowie uruchomiony, aby "
 "zmiany przyniosły efekt"
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "Porównaj surowe pamięci"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr "Kod cyfrowy"
 
@@ -906,15 +906,16 @@ msgstr "Kod cyfrowy"
 msgid "Digital Modes"
 msgstr "Kod cyfrowy"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr "Wyłącz raportowanie"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr "Wyłączony"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Dystans"
 
@@ -927,15 +928,15 @@ msgstr "Nie pytaj ponownie dla %s"
 msgid "Double-click to change bank name"
 msgstr "Kliknij podwójnie w celu zmiany nazwy banku"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr "Pobierz"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 msgid "Download from radio"
 msgstr "Pobierz z radiostacji"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Pobierz z radiostacji"
@@ -952,25 +953,25 @@ msgstr ""
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Dupleks"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Zmień szczegóły dla %i pamięci"
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Zmień szczególy dla pamięci %i"
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Zezwól na automatyczną edycję"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr "Włączony"
 
@@ -978,11 +979,11 @@ msgstr "Włączony"
 msgid "Enter Frequency"
 msgstr "Wprowadź częstotliwość"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr "Wprowadź przesunięcie (MHz)"
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr "Wprowadź częstotliwość nadawania (MHz)"
 
@@ -1012,11 +1013,11 @@ msgstr "Błąd komunikacji z radiostacją"
 msgid "Experimental driver"
 msgstr "Sterownik eksperymentalny"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr "Eksport może tylko zapisywać pliki CSV"
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 msgid "Export to CSV"
 msgstr "Eksportuj do pliku CSV"
 
@@ -1025,7 +1026,7 @@ msgstr "Eksportuj do pliku CSV"
 msgid "Export to CSV..."
 msgstr "Eksportuj do pliku CSV"
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr "Dodatkowa"
 
@@ -1043,7 +1044,7 @@ msgstr ""
 "informacji o przemiennikach w Europie.\n"
 "Nie jest wymagane konto użytkownika."
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr "Nie udało się załadować przeglądarki radiostacji"
 
@@ -1060,8 +1061,8 @@ msgstr "Funkcje"
 msgid "File does not exist: %s"
 msgstr "Plik nie istnieje: %s"
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 msgid "Files"
 msgstr "Pliki"
 
@@ -1073,7 +1074,7 @@ msgstr "Filtr"
 msgid "Filter results with location matching this string"
 msgstr "Filtruj wyniki z lokalizacją pasująco do tej wartości tekstowej"
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr "Wyszukaj"
 
@@ -1284,20 +1285,20 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Pobieranie ustawień"
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 msgid "Goto Memory"
 msgstr "Idź do pamięci"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr "Idź do pamięci:"
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 #, fuzzy
 msgid "Goto..."
 msgstr "Idź do"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Pomoc"
 
@@ -1305,11 +1306,11 @@ msgstr "Pomoc"
 msgid "Help Me..."
 msgstr "Pomocy..."
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 msgid "Hide empty memories"
 msgstr "Ukrywaj puste pamięci"
 
@@ -1318,7 +1319,7 @@ msgstr "Ukrywaj puste pamięci"
 msgid "If set, sort results by distance from these coordinates"
 msgstr "Jeśli ustawiono, sortuje wyniki po odległości od tych współrzędnych"
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Importuj"
 
@@ -1327,7 +1328,7 @@ msgstr "Importuj"
 msgid "Import from file..."
 msgstr "Importuj z pliku"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr "Importuj nie jest zalecany"
 
@@ -1339,11 +1340,11 @@ msgstr "Indeks"
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr "Informacja"
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 msgid "Insert Row Above"
 msgstr "Umieść wiersz wyżej"
 
@@ -1351,7 +1352,7 @@ msgstr "Umieść wiersz wyżej"
 msgid "Install desktop icon?"
 msgstr "Utworzyć skrót pulpitu?"
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr "Interakcja ze sterownikiem"
 
@@ -1360,7 +1361,7 @@ msgstr "Interakcja ze sterownikiem"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Niewłaściwe %(value)s (używaj stopni dziesiętnych)"
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 msgid "Invalid Entry"
 msgstr "Niewłaściwy wpis: %s"
 
@@ -1368,12 +1369,12 @@ msgstr "Niewłaściwy wpis: %s"
 msgid "Invalid ZIP code"
 msgstr "Niewłaściwy kod pocztowy"
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Niewłaściwa edycja: %s"
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr "Niewłaściwy lub niespierany plik modułu"
 
@@ -1382,7 +1383,7 @@ msgstr "Niewłaściwy lub niespierany plik modułu"
 msgid "Invalid value: %r"
 msgstr "Niewłaściwa wartość: %r"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr "Numer zgłoszenia:"
 
@@ -1390,11 +1391,12 @@ msgstr "Numer zgłoszenia:"
 msgid "LIVE"
 msgstr "Na żywo"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Szerokość geograficzna"
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr "Długość musi wynosić %i"
@@ -1420,16 +1422,16 @@ msgstr "Ogranicz wyniki do odległości (km) od współrzędnych"
 msgid "Load Module..."
 msgstr "Załaduj moduł"
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 msgid "Load module from issue"
 msgstr "Załaduj moduł ze zgłoszenia"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Załaduj moduł ze zgłoszenia"
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1457,7 +1459,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Długość geograficzna"
 
@@ -1465,7 +1468,7 @@ msgstr "Długość geograficzna"
 msgid "Memories"
 msgstr "Pamięci"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Pamięć %i jest nieusuwalna"
@@ -1479,7 +1482,7 @@ msgstr "Pamięć musi być w banku, aby można ją było edytować"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Pamięć {num} nie jest w banku {bank}"
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 msgid "Mode"
 msgstr "Tryb"
 
@@ -1491,15 +1494,15 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Tryby"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr "Moduł"
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr "Załadowano moduł"
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr "Pomyślnie załadowano moduł"
 
@@ -1508,11 +1511,11 @@ msgstr "Pomyślnie załadowano moduł"
 msgid "More than one port found: %s"
 msgstr "Znaleziono więcej niż jeden port: %s"
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 msgid "Move Down"
 msgstr "Przesuń w dół"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 msgid "Move Up"
 msgstr "Przesuń w górę"
 
@@ -1520,19 +1523,19 @@ msgstr "Przesuń w górę"
 msgid "New Window"
 msgstr "Nowe okno"
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr "Nowa wersja jest dostępna"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 msgid "No empty rows below!"
 msgstr "Brak pustych wierszy poniżej!"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr "Nie znaleziono modułów"
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr "Nie znaleziono modułów w zgłoszeniu %i"
@@ -1545,7 +1548,7 @@ msgstr "Brak wyników"
 msgid "No results!"
 msgstr "Brak wyników!"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr "Numer"
 
@@ -1569,7 +1572,7 @@ msgstr "Tylko zakładki pamięci mogą być wyeksportowane"
 msgid "Only working repeaters"
 msgstr "Tylko czynne przemienniki"
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Otwórz"
 
@@ -1581,15 +1584,15 @@ msgstr "Otwórz ostatnio używany"
 msgid "Open Stock Config"
 msgstr "Otwórz konfigurację wstępną"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Otwórz plik"
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr "Otwórz moduł"
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Otwórz log debugowy"
 
@@ -1597,7 +1600,7 @@ msgstr "Otwórz log debugowy"
 msgid "Open in new window"
 msgstr "Otwórz w nowym oknie"
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 msgid "Open stock config directory"
 msgstr "Otwórz katalog konfiguracji wstępnych"
 
@@ -1617,7 +1620,7 @@ msgstr "Opcjonalnie: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcjonalnie: Szpital, Hrabstwo itp."
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 msgid "Overwrite memories?"
 msgstr "Nadpisać pamięci?"
 
@@ -1632,31 +1635,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Parsowanie"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "Wklej"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Wklejone pamięci nadpisze %s istniejących pamięci"
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Wklejone pamięci nadpisze pamięci %s"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Wklejone pamięci nadpiszą pamięć %s"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Wklejona pamięć nadpisze pamięć %s"
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Proszę wyjdź z programu CHIRP przed instalacją nowej wersji!"
 
@@ -1686,7 +1689,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1710,11 +1713,11 @@ msgstr "Podłącz kabel i naciśnij przycisk OK"
 msgid "Port"
 msgstr "Port"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Moc"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 msgid "Press enter to set this in memory"
 msgstr "Naciśnij przycisk enter, aby ustawić to w pamięci"
 
@@ -1726,24 +1729,24 @@ msgstr "Podgląd wydruku"
 msgid "Printing"
 msgstr "Drukowanie"
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr "Właściwości"
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr "Odpytywanie %s"
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Źródło zapytań"
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Radiostacja"
 
@@ -1786,11 +1789,11 @@ msgstr "Wymagane jest odświeżenie"
 msgid "Refreshed memory %s"
 msgstr "Odświeżono pamięć %s"
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Przeładuj sterownik"
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Przeładuj sterownik oraz plik"
 
@@ -1804,11 +1807,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Raportowanie jest włączone"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -1818,7 +1821,7 @@ msgstr ""
 "oraz systemów operacyjnych należy traktować priorytetowo. Naprawdę doceniamy "
 "zostawienie tej opcji włączonej. Naprawdę wyłączyć raportowanie?"
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr "Wymagany jest restart"
 
@@ -1830,19 +1833,24 @@ msgstr[0] "Przywrócono %i zakładek"
 msgstr[1] "Przywrócono %i zakładek"
 msgstr[2] "Przywrócono %i zakładek"
 
+#: ../wxui/main.py:815
+#, fuzzy
+msgid "Restore tabs on start"
+msgstr "Przywrócono %i zakładek"
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr "Pobrano ustawienia"
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr "Zapisać przed zamknięciem?"
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Zapisz plik"
 
@@ -1858,11 +1866,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Wybierz bandplan"
@@ -1875,7 +1883,7 @@ msgstr "Wybierz pasma"
 msgid "Select Modes"
 msgstr "Wybierz tryby"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr "Wybierz bandplan"
 
@@ -1887,27 +1895,27 @@ msgstr "Usługa"
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "Pokaż surową pamięć"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Pokaż lokalizację pliku debug"
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr "Pokazuj dodatkowe pola"
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 msgid "Some memories are incompatible with this radio"
 msgstr "Niektóre pamięci są niekompatybilne z tą radiostacją"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr "Niektóre pamięci są nieusuwalne"
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -1915,7 +1923,7 @@ msgstr[0] "Sortuj %i pamięci"
 msgstr[1] "Sortuj %i pamięci"
 msgstr[2] "Sortuj %i pamięci"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -1923,7 +1931,7 @@ msgstr[0] "Sortuj %i pamięci rosnąco"
 msgstr[1] "Sortuj %i pamięci rosnąco"
 msgstr[2] "Sortuj %i pamięci rosnąco"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -1931,11 +1939,11 @@ msgstr[0] "Sortuj %i pamięci malejąco"
 msgstr[1] "Sortuj %i pamięci malejąco"
 msgstr[2] "Sortuj %i pamięci malejąco"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr "Sortuj wg kolumny:"
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 msgid "Sort memories"
 msgstr "Sortuj pamięci"
 
@@ -1951,7 +1959,7 @@ msgstr "Stan"
 msgid "State/Province"
 msgstr "Stan/Prowincja"
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr "Sukces"
 
@@ -1984,7 +1992,7 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
@@ -1994,7 +2002,7 @@ msgstr ""
 "stwarzać ryzyko, dlatego rekomendujemy nie ładowanie tego modułu. "
 "Kontynuować pomimo tego?"
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2009,7 +2017,7 @@ msgstr ""
 "aktualnie otwartym pliku tymi z %(file)s. Czy chcesz otworzyć ten plik, aby "
 "kopiować/wklejać pamięci lub kontynuować import?"
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 msgid "This Memory"
 msgstr "Tą pamięć"
 
@@ -2053,11 +2061,11 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 msgid "This memory and shift all up"
 msgstr "Tą pamięć i przeusń wszystkie wyżej"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 msgid "This memory and shift block up"
 msgstr "Tą pamięć i przesuń blok wyżej"
 
@@ -2083,23 +2091,23 @@ msgstr ""
 "doprowadzić do nieprzewidywalnego lub niezgodnego z przepisami zachowania. "
 "Włączasz na własne ryzyko!"
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr "To załaduje moduł ze strony zgłoszenia"
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "Ton TX"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Tryb tonu"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 msgid "Tone Squelch"
 msgstr "Ton RX"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 msgid "Tuning Step"
 msgstr "Krok strojenia"
 
@@ -2114,11 +2122,11 @@ msgid ""
 msgstr ""
 "Nie można wykryć portu kabla. Należy sprawdzić sterowniki oraz połączenie."
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Przed pobraniem pamięci, nie można jej edytować"
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Nie znaleziono konfiguracji wstępnej %r"
@@ -2141,7 +2149,7 @@ msgstr ""
 "model na rynek US, ale radiostacja jest przeznaczona na inne regiony (lub "
 "szerokopasmowa). Należy wybrać właściwy model i spróbować ponownie."
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Nie można odkryć %s na tym systemie"
@@ -2163,11 +2171,11 @@ msgstr "Należy odpiąć kabel (jeśli to konieczne) i nacisnąć przycisk OK"
 msgid "Upload instructions"
 msgstr "Instrukcje wysyłania"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 msgid "Upload to radio"
 msgstr "Wyślij do radiostacji"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Wyślij do radiostacji"
@@ -2185,7 +2193,7 @@ msgstr "Używaj czcionki o stałej szerokości znaków"
 msgid "Use larger font"
 msgstr "Używaj większej czcionki"
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr "Wartość nie pasuje do %i bitów"
@@ -2200,16 +2208,16 @@ msgstr "Wartość musi wynosić przynajmniej %.4f"
 msgid "Value must be at most %.4f"
 msgstr "Wartość musi wynosić nie więcej niż %.4f"
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr "Wartość musi mieć dokładnie %i cyfr dziesiętnych"
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr "Wartość musi wynosić zero lub więcej"
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr "Wartości"
 
@@ -2217,7 +2225,7 @@ msgstr "Wartości"
 msgid "Vendor"
 msgstr "Producent"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 msgid "View"
 msgstr "Widok"
 
@@ -2225,11 +2233,11 @@ msgstr "Widok"
 msgid "WARNING!"
 msgstr "UWAGA!"
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr "Uwaga"
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr "Uwaga: %s"
@@ -2246,23 +2254,23 @@ msgstr "Czy CHIRP ma utworzyć ikonę na pulpicie?"
 msgid "Your cable appears to be on port:"
 msgstr "Kabel jest widoczny na porcie:"
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr "bitów"
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr "bajtów"
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr "bajtów każdy"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr "wyłączony"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr "włączony"
 

--- a/chirp/locale/pt_BR.po
+++ b/chirp/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2013-03-30 22:04-0300\n"
 "Last-Translator: Crezivando <crezivando@gmail.com>\n"
 "Language-Team: Language pt-BR\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Apagar (e deslocar)"
 msgstr[1] "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memórias"
 msgstr[1] "Memórias"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Apagar (e deslocar)"
 msgstr[1] "Apagar (e deslocar)"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Arquivo modificado, salvar alterações antes de fechar?"
@@ -63,7 +63,7 @@ msgstr "Arquivo modificado, salvar alterações antes de fechar?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -621,17 +621,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr ""
 
@@ -639,12 +639,12 @@ msgstr ""
 msgid "All"
 msgstr "Tudo"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "Arquivos CSV"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
@@ -660,11 +660,11 @@ msgstr "Ocorreu um erro"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr ""
 
@@ -676,7 +676,7 @@ msgstr ""
 msgid "Banks"
 msgstr "Bancos"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Browser"
 msgstr ""
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr ""
 
@@ -698,40 +698,40 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Modo Cross"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, fuzzy, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Selecionar um para importar de:"
@@ -768,22 +768,22 @@ msgstr "Descarregar a partir do Rádio"
 msgid "Cloning to radio"
 msgstr "Carregar para o Rádio"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Comentário"
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "Copiar"
 
@@ -815,7 +815,7 @@ msgstr "Copiar"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 #, fuzzy
 msgid "Cross mode"
 msgstr "Modo Cross"
@@ -828,16 +828,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -848,38 +848,38 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr ""
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 #, fuzzy
 msgid "Dec"
 msgstr "Detectar"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Desenvolvedor"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr "Código Digital"
 
@@ -888,15 +888,16 @@ msgstr "Código Digital"
 msgid "Digital Modes"
 msgstr "Código Digital"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -909,16 +910,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 #, fuzzy
 msgid "Download from radio"
 msgstr "Descarregar a partir do Rádio"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Descarregar a partir do Rádio"
@@ -936,25 +937,25 @@ msgstr ""
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr ""
 
@@ -963,11 +964,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Frequência"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -998,11 +999,11 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Exportar Para Arquivo"
@@ -1012,7 +1013,7 @@ msgstr "Exportar Para Arquivo"
 msgid "Export to CSV..."
 msgstr "Exportar Para Arquivo"
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr ""
 
@@ -1027,7 +1028,7 @@ msgid ""
 "required."
 msgstr ""
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr ""
 
@@ -1044,8 +1045,8 @@ msgstr ""
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 #, fuzzy
 msgid "Files"
 msgstr "_Arquivo"
@@ -1058,7 +1059,7 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr ""
 
@@ -1268,20 +1269,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Mostrar Memória Raw"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Ajuda"
 
@@ -1289,11 +1290,11 @@ msgstr "Ajuda"
 msgid "Help Me..."
 msgstr ""
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Sobrescrever?"
@@ -1303,7 +1304,7 @@ msgstr "Sobrescrever?"
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Importar"
 
@@ -1312,7 +1313,7 @@ msgstr "Importar"
 msgid "Import from file..."
 msgstr "Importar do Arquivo"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Importar de RFinder"
@@ -1325,11 +1326,11 @@ msgstr "Índice"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Inserir row acima"
@@ -1338,7 +1339,7 @@ msgstr "Inserir row acima"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1347,7 +1348,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Valor inválido. Deve ser um número inteiro."
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Valor Inválido para este campo"
@@ -1356,12 +1357,12 @@ msgstr "Valor Inválido para este campo"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1370,7 +1371,7 @@ msgstr ""
 msgid "Invalid value: %r"
 msgstr "Valor Inválido para este campo"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr ""
 
@@ -1378,11 +1379,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr ""
@@ -1408,17 +1410,17 @@ msgstr ""
 msgid "Load Module..."
 msgstr "Modo Tom"
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 #, fuzzy
 msgid "Load module from issue"
 msgstr "Modo Tom"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Modo Tom"
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1440,7 +1442,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1448,7 +1451,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Memórias"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1462,7 +1465,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 #, fuzzy
 msgid "Mode"
 msgstr "Modo"
@@ -1476,15 +1479,15 @@ msgstr "Modelo"
 msgid "Modes"
 msgstr "Modo"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1493,12 +1496,12 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 #, fuzzy
 msgid "Move Down"
 msgstr "Mover Abaix_o"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 #, fuzzy
 msgid "Move Up"
 msgstr "Mover _Acima"
@@ -1507,20 +1510,20 @@ msgstr "Mover _Acima"
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Inserir row abaixo"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr ""
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr ""
@@ -1533,7 +1536,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr ""
 
@@ -1557,7 +1560,7 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
@@ -1571,15 +1574,15 @@ msgstr "_Recente"
 msgid "Open Stock Config"
 msgstr "Abrir config do estoque"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
@@ -1587,7 +1590,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Abrir configuração de estoque {name}"
@@ -1609,7 +1612,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Sobrescrever?"
@@ -1625,31 +1628,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "Colar"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1679,7 +1682,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1699,11 +1702,11 @@ msgstr ""
 msgid "Port"
 msgstr "Porta"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Power"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 #, fuzzy
 msgid "Press enter to set this in memory"
 msgstr "Erro gravando memória"
@@ -1716,24 +1719,24 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr ""
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Rádio"
 
@@ -1774,11 +1777,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1793,19 +1796,19 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Emissão de Relatórios desabilitada"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr ""
 
@@ -1816,19 +1819,23 @@ msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../wxui/main.py:815
+msgid "Restore tabs on start"
+msgstr ""
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1844,11 +1851,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Selecionar Colunas"
@@ -1863,7 +1870,7 @@ msgstr "Selecionar Colunas"
 msgid "Select Modes"
 msgstr "Selecionar Colunas"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1875,53 +1882,53 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "Mostrar Memória Raw"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Memória colada {number} não é compatível com este rádio porque:"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 #, fuzzy
 msgid "Sort memories"
 msgstr "Sobrescrever?"
@@ -1938,7 +1945,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr ""
 
@@ -1971,14 +1978,14 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -1988,7 +1995,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 #, fuzzy
 msgid "This Memory"
 msgstr "Mostrar Memória Raw"
@@ -2033,12 +2040,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Apagar (e deslocar)"
@@ -2060,24 +2067,24 @@ msgid ""
 "own risk!"
 msgstr ""
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "Tom"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Modo Tom"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "TomSql"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Tune Step"
@@ -2092,11 +2099,11 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Abrir config do estoque"
@@ -2117,7 +2124,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Incapaz de efetuar alterações para este modelo"
@@ -2139,12 +2146,12 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Carregar para o Rádio"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Carregar para o Rádio"
@@ -2162,7 +2169,7 @@ msgstr ""
 msgid "Use larger font"
 msgstr ""
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr ""
@@ -2177,16 +2184,16 @@ msgstr ""
 msgid "Value must be at most %.4f"
 msgstr ""
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr ""
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr ""
 
@@ -2194,7 +2201,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Fornecedor"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 #, fuzzy
 msgid "View"
 msgstr "_Visualizar"
@@ -2203,11 +2210,11 @@ msgstr "_Visualizar"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2224,23 +2231,23 @@ msgstr ""
 msgid "Your cable appears to be on port:"
 msgstr ""
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr ""
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr ""
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/ru.po
+++ b/chirp/locale/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2023-10-11 16:47+0300\n"
 "Last-Translator: Olesya Gerasimenko <translation-team@basealt.ru>\n"
 "Language-Team: Basealt Translation Team\n"
@@ -38,7 +38,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s должно находиться в диапазоне от %(min)i до %(max)i"
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -46,7 +46,7 @@ msgstr[0] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[1] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[2] "Ячейки памяти (%i) и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -54,7 +54,7 @@ msgstr[0] "Ячейки памяти (%i)"
 msgstr[1] "Ячейки памяти (%i)"
 msgstr[2] "Ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -62,7 +62,7 @@ msgstr[0] "Ячейки памяти (%i) и сдвинуть блок ввер�
 msgstr[1] "Ячейки памяти (%i) и сдвинуть блок вверх"
 msgstr[2] "Ячейки памяти (%i) и сдвинуть блок вверх"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Сохранение %s не было выполнено. Сохранить перед закрытием?"
@@ -71,7 +71,7 @@ msgstr "Сохранение %s не было выполнено. Сохрани
 msgid "(none)"
 msgstr "(нет)"
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr "...и ещё %i"
@@ -966,7 +966,7 @@ msgstr ""
 "Отправка может не получиться, если вы включите станцию, когда кабель уже "
 "подключён"
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -974,11 +974,11 @@ msgstr ""
 "Доступная новая версия программы CHIRP. Как можно скорее загрузите её на веб-"
 "сайте!"
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "О программе"
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr "О программе CHIRP"
 
@@ -986,11 +986,11 @@ msgstr "О программе CHIRP"
 msgid "All"
 msgstr "Все"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Все файлы"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Все поддерживаемые форматы|"
 
@@ -1006,11 +1006,11 @@ msgstr "Ошибка"
 msgid "Applying settings"
 msgstr "Применение параметров"
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr "Доступные модули"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr "Частотный план"
 
@@ -1022,7 +1022,7 @@ msgstr "Полосы частот"
 msgid "Banks"
 msgstr "Банки"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr "Бинарный"
 
@@ -1030,7 +1030,7 @@ msgstr "Бинарный"
 msgid "Browser"
 msgstr "Браузер"
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr "Браузер станций"
 
@@ -1046,39 +1046,39 @@ msgstr ""
 "Для изменения этого параметра требуется обновить параметры из образа, что и "
 "будет сейчас выполнено."
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Каналы с эквивалентными TX и RX %s представлены видом субтона «%s»."
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Файлы образов Chirp"
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr "Необходимо сделать выбор"
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Выберите код DTCS %s"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Выберите тон %s"
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 msgid "Choose Cross Mode"
 msgstr "Выберите кросс-режим"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr "Выберите дуплекс"
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Выберите модуль для загрузки из задачи %i:"
@@ -1119,15 +1119,15 @@ msgstr "Клонирование из станции"
 msgid "Cloning to radio"
 msgstr "Клонирование на станцию"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr "Закрыть"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr "Закрыть файл"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1135,7 +1135,7 @@ msgstr[0] "Объединить ячейки памяти (%i) в кластер
 msgstr[1] "Объединить ячейки памяти (%i) в кластер"
 msgstr[2] "Объединить ячейки памяти (%i) в кластер"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Комментарий"
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "Копировать"
 
@@ -1168,7 +1168,7 @@ msgstr "Копировать"
 msgid "Country"
 msgstr "Страна"
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr "Кросс-режим"
 
@@ -1180,15 +1180,15 @@ msgstr "Пользовательский порт"
 msgid "Custom..."
 msgstr "Пользовательский..."
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "Вырезать"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -1200,38 +1200,38 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr "DV-память"
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr "Впереди опасность"
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 msgid "Dec"
 msgstr "Десятичный"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Режим разработчика"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Режим разработчика теперь %s. Для применения изменений необходимо "
 "перезапустить CHIRP"
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "Сравнить необработанные ячейки памяти"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr "Цифровой код"
 
@@ -1240,15 +1240,16 @@ msgstr "Цифровой код"
 msgid "Digital Modes"
 msgstr "Цифровой код"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr "Отключить отправку отчётов"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr "Отключено"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Расстояние"
 
@@ -1261,15 +1262,15 @@ msgstr "Не запрашивать снова для %s"
 msgid "Double-click to change bank name"
 msgstr "Сделайте двойной щелчок, чтобы изменить имя банка"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr "Загрузить"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 msgid "Download from radio"
 msgstr "Загрузить из станции"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "Загрузить из станции..."
 
@@ -1285,25 +1286,25 @@ msgstr ""
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Редактировать сведения о ячейках памяти (%i)"
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Редактировать сведения о ячейке памяти (%i)"
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Включить автоматическое редактирование"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr "Включено"
 
@@ -1311,11 +1312,11 @@ msgstr "Включено"
 msgid "Enter Frequency"
 msgstr "Введите частоту"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr "Введите смещение (МГц)"
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr "Введите частоту TX (МГц)"
 
@@ -1345,11 +1346,11 @@ msgstr "Ошибка обмена данными со станцией"
 msgid "Experimental driver"
 msgstr "Экспериментальный драйвер"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr "При экспорте можно выполнять запись только в файлы CSV"
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 msgid "Export to CSV"
 msgstr "Экспорт в CSV"
 
@@ -1357,7 +1358,7 @@ msgstr "Экспорт в CSV"
 msgid "Export to CSV..."
 msgstr "Экспорт в CSV..."
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr "Дополнительно"
 
@@ -1375,7 +1376,7 @@ msgstr ""
 "актуальные сведения о репитерах в Европе. Учётная запись\n"
 "не требуется."
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr "Не удалось загрузить браузер станций"
 
@@ -1392,8 +1393,8 @@ msgstr "Функции"
 msgid "File does not exist: %s"
 msgstr "Файл не существует: %s"
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 msgid "Files"
 msgstr "Файлы"
 
@@ -1405,7 +1406,7 @@ msgstr "Фильтр"
 msgid "Filter results with location matching this string"
 msgstr "Фильтровать результаты с расположением, соответствующим этой строке"
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr "Найти"
 
@@ -1713,19 +1714,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Получение параметров"
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 msgid "Goto Memory"
 msgstr "Перейти к ячейке памяти"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr "Переход к ячейке памяти:"
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr "Переход..."
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Справка"
 
@@ -1733,11 +1734,11 @@ msgstr "Справка"
 msgid "Help Me..."
 msgstr "Помощь..."
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr "Шестнадцатеричный"
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 msgid "Hide empty memories"
 msgstr "Скрыть пустые ячейки памяти"
 
@@ -1747,7 +1748,7 @@ msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Если установлено, упорядочить результаты по расстоянию от этих координат"
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Импорт"
 
@@ -1755,7 +1756,7 @@ msgstr "Импорт"
 msgid "Import from file..."
 msgstr "Импорт из файла..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr "Импорт не рекомендуется"
 
@@ -1767,11 +1768,11 @@ msgstr "Индекс"
 msgid "Info"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 msgid "Insert Row Above"
 msgstr "Вставить строку выше"
 
@@ -1779,7 +1780,7 @@ msgstr "Вставить строку выше"
 msgid "Install desktop icon?"
 msgstr "Создать значок на рабочем столе?"
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr "Обмен данными с драйвером"
 
@@ -1788,7 +1789,7 @@ msgstr "Обмен данными с драйвером"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s — неверно (используйте десятичные градусы)"
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 msgid "Invalid Entry"
 msgstr "Некорректная запись"
 
@@ -1796,12 +1797,12 @@ msgstr "Некорректная запись"
 msgid "Invalid ZIP code"
 msgstr "Неверный почтовый индекс"
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Некорректное изменение: %s"
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr "Некорректный или неподдерживаемый файл модуля"
 
@@ -1810,7 +1811,7 @@ msgstr "Некорректный или неподдерживаемый фай�
 msgid "Invalid value: %r"
 msgstr "Неверное значение: %r"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr "Номер задачи:"
 
@@ -1818,11 +1819,12 @@ msgstr "Номер задачи:"
 msgid "LIVE"
 msgstr "В ЭФИРЕ"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Широта"
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr "Длина должна составлять %i"
@@ -1847,15 +1849,15 @@ msgstr "Ограничить результаты этим расстояние�
 msgid "Load Module..."
 msgstr "Загрузить модуль..."
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 msgid "Load module from issue"
 msgstr "Загрузить модуль из задачи"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 msgid "Load module from issue..."
 msgstr "Загрузить модуль из задачи..."
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1883,7 +1885,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Долгота"
 
@@ -1891,7 +1894,7 @@ msgstr "Долгота"
 msgid "Memories"
 msgstr "Ячейки памяти"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Ячейку памяти %i нельзя удалить"
@@ -1905,7 +1908,7 @@ msgstr "Чтобы редактировать ячейку памяти, нео�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Ячейка памяти {num} отсутствует в банке {bank}"
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 msgid "Mode"
 msgstr "Режим"
 
@@ -1917,15 +1920,15 @@ msgstr "Модель"
 msgid "Modes"
 msgstr "Режимы"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr "Модуль"
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr "Модуль загружен"
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr "Модуль успешно загружен"
 
@@ -1934,11 +1937,11 @@ msgstr "Модуль успешно загружен"
 msgid "More than one port found: %s"
 msgstr "Найдено более одного порта: %s"
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 msgid "Move Down"
 msgstr "Переместить вниз"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 msgid "Move Up"
 msgstr "Переместить вверх"
 
@@ -1946,19 +1949,19 @@ msgstr "Переместить вверх"
 msgid "New Window"
 msgstr "Новое окно"
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr "Доступна новая версия"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 msgid "No empty rows below!"
 msgstr "Ниже нет пустых строк!"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr "Модули не найдены"
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr "В задаче %i не найдены модули"
@@ -1971,7 +1974,7 @@ msgstr "Нет результатов"
 msgid "No results!"
 msgstr "Нет результатов!"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr "Число"
 
@@ -1995,7 +1998,7 @@ msgstr "Можно экспортировать только вкладки па
 msgid "Only working repeaters"
 msgstr "Только работающие репитеры"
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Открыть"
 
@@ -2007,15 +2010,15 @@ msgstr "Открыть недавние"
 msgid "Open Stock Config"
 msgstr "Открыть предустановленную конфигурацию"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Открыть файл"
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr "Открыть модуль"
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Открыть журнал отладки"
 
@@ -2023,7 +2026,7 @@ msgstr "Открыть журнал отладки"
 msgid "Open in new window"
 msgstr "Открыть в новом окне"
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 msgid "Open stock config directory"
 msgstr "Открыть каталог предустановленной конфигурации"
 
@@ -2043,7 +2046,7 @@ msgstr "Опционально: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Опционально: округ, больница и т.д."
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 msgid "Overwrite memories?"
 msgstr "Перезаписать ячейки памяти?"
 
@@ -2061,31 +2064,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Анализ"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "Вставить"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Вставленные ячейки памяти перезапишут существующие ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейку памяти %s"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Вставленная ячейка памяти перезапишет ячейку памяти %s"
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Обязательно выйдите из программы CHIRP перед установкой новой версии!"
 
@@ -2133,7 +2136,7 @@ msgstr ""
 "4 - Затем нажмите кнопку «A» на вашей станции для начала клонирования.\n"
 "    (По завершении станция подаст звуковой сигнал.)\n"
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2158,11 +2161,11 @@ msgstr "Подключите кабель и нажмите «ОК»"
 msgid "Port"
 msgstr "Порт"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Мощность"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 msgid "Press enter to set this in memory"
 msgstr "Нажмите «Ввод» для добавления в память"
 
@@ -2174,24 +2177,24 @@ msgstr "Предпросмотр"
 msgid "Printing"
 msgstr "Печать"
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr "Свойства"
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr "Запрос %s"
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Запрос источника"
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Станция"
 
@@ -2234,11 +2237,11 @@ msgstr "Требуется обновление"
 msgid "Refreshed memory %s"
 msgstr "Обновлена ячейки памяти %s"
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Перезагрузить драйвер"
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Перезагрузить драйвер и файл"
 
@@ -2252,11 +2255,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Отправка отчётов включена"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2267,7 +2270,7 @@ msgstr ""
 "признательны, если вы оставите эту функцию включённой. Действительно "
 "отключить отправку отчётов?"
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr "Требуется перезапуск"
 
@@ -2279,19 +2282,24 @@ msgstr[0] "Восстановить вкладки (%i)"
 msgstr[1] "Восстановить вкладки (%i)"
 msgstr[2] "Восстановить вкладки (%i)"
 
+#: ../wxui/main.py:815
+#, fuzzy
+msgid "Restore tabs on start"
+msgstr "Восстановить вкладки (%i)"
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr "Полученные параметры"
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr "Сохранить"
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr "Сохранить перед закрытием?"
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Сохранить файл"
 
@@ -2307,11 +2315,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr "Угроза безопасности"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "Выбрать частотный план..."
 
@@ -2323,7 +2331,7 @@ msgstr "Выбор полос частот"
 msgid "Select Modes"
 msgstr "Выбор режимов"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr "Выбор частотного плана"
 
@@ -2335,27 +2343,27 @@ msgstr "Служба"
 msgid "Settings"
 msgstr "Параметры"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "Показать необработанную ячейку памяти"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Показать расположение журнала отладки"
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr "Показать дополнительные поля"
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 msgid "Some memories are incompatible with this radio"
 msgstr "Некоторые ячейки памяти несовместимы с этой станцией"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr "Некоторые ячейки памяти нельзя удалить"
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -2363,7 +2371,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i)"
 msgstr[1] "Упорядочить ячейки памяти (%i)"
 msgstr[2] "Упорядочить ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -2371,7 +2379,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по возра
 msgstr[1] "Упорядочить ячейки памяти (%i) по возрастанию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по возрастанию"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -2379,11 +2387,11 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по убыва
 msgstr[1] "Упорядочить ячейки памяти (%i) по убыванию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по убыванию"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr "Сортировать по столбцу:"
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 msgid "Sort memories"
 msgstr "Упорядочить ячейки памяти"
 
@@ -2399,7 +2407,7 @@ msgstr "Область"
 msgid "State/Province"
 msgstr "Область/регион"
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr "Успешно"
 
@@ -2448,7 +2456,7 @@ msgstr ""
 "Сохраните нередактированную копию первой успешной\n"
 "загрузки в файл CHIRP Radio Images (*.img).\n"
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
@@ -2458,7 +2466,7 @@ msgstr ""
 "загружать этот модуль, так как возможна угроза безопасности. Всё равно "
 "продолжить?"
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2473,7 +2481,7 @@ msgstr ""
 "текущем открытом файле на ячейки из %(file)s. Открыть этот файл для "
 "копирования/вставки ячеек памяти или продолжить импорт?"
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 msgid "This Memory"
 msgstr "Эта ячейка памяти"
 
@@ -2524,11 +2532,11 @@ msgstr ""
 "Также присылайте отчёты об ошибках и предложения по улучшению.\n"
 "Вы были предупреждены; продолжайте на свой страх и риск!"
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 msgid "This memory and shift all up"
 msgstr "Эта ячейка памяти и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 msgid "This memory and shift block up"
 msgstr "Эта ячейка памяти и сдвинуть блок вверх"
 
@@ -2559,23 +2567,23 @@ msgstr ""
 "что может привести к неопределённому или нерегулируемому поведению. "
 "Используйте на свой страх и риск!"
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr "Будет выполнена загрузка модуля из задачи на веб-сайте"
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "ТонПРД"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Вид субтона"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 msgid "Tone Squelch"
 msgstr "ТонШПД"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 msgid "Tuning Step"
 msgstr "Шаг настройки"
 
@@ -2591,11 +2599,11 @@ msgstr ""
 "Не удалось определить порт для вашего кабеля. Проверьте драйверы и "
 "подключения."
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Перед редактированием ячейки памяти необходимо загрузить станцию"
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Не удалось найти предустановленную конфигурацию %r"
@@ -2618,7 +2626,7 @@ msgstr ""
 "американская модель, но станция не является американской (или "
 "широкополосной). Выберите правильную модель и повторите попытку."
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Невозможно обнаружить %s в этой системе"
@@ -2640,11 +2648,11 @@ msgstr "Отключите кабель (если требуется) и наж�
 msgid "Upload instructions"
 msgstr "Отправка инструкций"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 msgid "Upload to radio"
 msgstr "Отправка на станцию"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "Отправка на станцию..."
 
@@ -2661,7 +2669,7 @@ msgstr "Использовать моноширинный шрифт"
 msgid "Use larger font"
 msgstr "Использовать более крупный шрифт"
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr "Значение не помещается в %i бит"
@@ -2676,16 +2684,16 @@ msgstr "Значение не должно быть меньше %.4f"
 msgid "Value must be at most %.4f"
 msgstr "Значение не должно превышать %.4f"
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr "Значение должно содержать десятичные цифры, ровно %i"
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr "Значение должно быть больше или равно нулю"
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr "Значения"
 
@@ -2693,7 +2701,7 @@ msgstr "Значения"
 msgid "Vendor"
 msgstr "Изготовитель"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 msgid "View"
 msgstr "Вид"
 
@@ -2701,11 +2709,11 @@ msgstr "Вид"
 msgid "WARNING!"
 msgstr "ПРЕДУПРЕЖДЕНИЕ!"
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr "Предупреждение: %s"
@@ -2722,23 +2730,23 @@ msgstr "Следует ли программе CHIRP создать значок
 msgid "Your cable appears to be on port:"
 msgstr "Похоже, ваш кабель вставлен в порт:"
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr "бит"
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr "байт"
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr "байт каждый"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr "отключён"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr "включён"
 

--- a/chirp/locale/tr_TR.po
+++ b/chirp/locale/tr_TR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2024-01-03 17:27+0300\n"
 "Last-Translator: Abdullah YILMAZ (TA1AUB) <h.abdullahyilmaz@hotmail.com>\n"
 "Language-Team: TURKISH\n"
@@ -42,28 +42,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s, %(min)i ile %(max)i arasında olmalıdır"
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Kaydı ve hepsini yukarı kaydır"
 msgstr[1] "%i Kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Kaydı"
 msgstr[1] "%i Kaydı"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Kaydı ve bloğu yukarı kaydır"
 msgstr[1] "%i Kaydı ve bloğu yukarı kaydır"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s kaydedilmedi. Kapanmadan önce kaydedilsin mi?"
@@ -72,7 +72,7 @@ msgstr "%s kaydedilmedi. Kapanmadan önce kaydedilsin mi?"
 msgid "(none)"
 msgstr "(hiçbiri)"
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr "...ve %i daha"
@@ -962,7 +962,7 @@ msgstr ""
 "\n"
 "Kablo takılıyken telsizi açarsanız çalışmayabilir"
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -970,11 +970,11 @@ msgstr ""
 "Yeni bir CHIRP sürümü mevcut. İndirmek için lütfen en kısa zamanda web "
 "sitesini ziyaret edin!"
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "Hakkında"
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr "CHIRP Hakkında"
 
@@ -982,11 +982,11 @@ msgstr "CHIRP Hakkında"
 msgid "All"
 msgstr "Tümü"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Tüm Dosyalar"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Desteklenen tüm biçimler|"
 
@@ -1002,11 +1002,11 @@ msgstr "Bir hata oluştu"
 msgid "Applying settings"
 msgstr "Ayarlar uygulanıyor"
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr "Mevcut modüller"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr "Bant planı"
 
@@ -1018,7 +1018,7 @@ msgstr "Bantlar"
 msgid "Banks"
 msgstr "Bankalar"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr "Bin"
 
@@ -1026,7 +1026,7 @@ msgstr "Bin"
 msgid "Browser"
 msgstr "Tarayıcı"
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr "Telsiz Tarayıcısı oluşturuluyor"
 
@@ -1042,40 +1042,40 @@ msgstr ""
 "Bu ayarın değiştirilmesi, imajdaki ayarların yenilenmesini gerektirir, bu "
 "işlem şimdi gerçekleşecektir."
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 "Eşdeğer TX ve RX %s'ye sahip kanallar, \"%s\" ton modu ile temsil edilir"
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Chirp İmaj Dosyaları"
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr "Seçim Gerekli"
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "%s DTCS Kodunu Seç"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr "%s Tonunu Seç"
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 msgid "Choose Cross Mode"
 msgstr "Çapraz Modu Seç"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr "Dubleks seç"
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Sorun %i'den yüklenecek modülü seçin:"
@@ -1116,22 +1116,22 @@ msgstr "Telsizden klonlanıyor"
 msgid "Cloning to radio"
 msgstr "Telsize klonlanıyor"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr "Kapat"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr "Dosyayı kapat"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "%i kaydı sırala"
 msgstr[1] "%i kaydı sırala"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Yorum"
 
@@ -1155,7 +1155,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "FM'e dönüştür"
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -1164,7 +1164,7 @@ msgstr "Kopyala"
 msgid "Country"
 msgstr "Ülke"
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr "Çapraz mod"
 
@@ -1176,15 +1176,15 @@ msgstr "Özel Bağlantı Noktası"
 msgid "Custom..."
 msgstr "Özel..."
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "Kes"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -1196,37 +1196,37 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "DTMF kod çöz"
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr "DV Kaydı"
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr "İleride Tehlike"
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "Sil"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Geliştirici Modu"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Geliştirici durumu artık %s. Etkili olması için CHIRP yeniden başlatılmalıdır"
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "Farklı Ham Kayıtlar"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr "Dijital Kod"
 
@@ -1234,15 +1234,16 @@ msgstr "Dijital Kod"
 msgid "Digital Modes"
 msgstr "Dijital Modlar"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr "Raporlamayı devre dışı bırak"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr "Devre dışı"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr "Mesafe"
 
@@ -1255,15 +1256,15 @@ msgstr "%s için tekrar sorma"
 msgid "Double-click to change bank name"
 msgstr "Banka adını değiştirmek için çift tıklayın"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr "İndir"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 msgid "Download from radio"
 msgstr "Telsizden indir"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "Telsizden indir..."
 
@@ -1281,25 +1282,25 @@ msgstr ""
 "Analogu destekleyen çift modlu dijital tekrarlayıcılar(röleler) FM olarak "
 "gösterilecek"
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "%i kaydı için ayrıntıları düzenle"
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "%i kaydı için ayrıntıları düzenle"
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Otomatik Düzenlemeleri Etkinleştir"
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr "Etkin"
 
@@ -1307,11 +1308,11 @@ msgstr "Etkin"
 msgid "Enter Frequency"
 msgstr "Frekans Gir"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr "Ofset girin (MHz)"
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr "TX Frekansını girin (MHz)"
 
@@ -1341,11 +1342,11 @@ msgstr "Telsizle iletişim hatası"
 msgid "Experimental driver"
 msgstr "Deneysel sürücü"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr "Dışa aktarma yalnızca CSV dosyalarını yazabilir"
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 msgid "Export to CSV"
 msgstr "CSV'ye aktar"
 
@@ -1353,7 +1354,7 @@ msgstr "CSV'ye aktar"
 msgid "Export to CSV..."
 msgstr "CSV'ye aktar..."
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -1371,7 +1372,7 @@ msgstr ""
 "bilgileri sağlayan ÜCRETSİZ tekrarlayıcı (röle) veritabanı.\n"
 "Hesap gerekmez."
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr "Telsiz tarayıcısı yüklenemedi"
 
@@ -1388,8 +1389,8 @@ msgstr "Özellikler"
 msgid "File does not exist: %s"
 msgstr "Dosya mevcut değil: %s"
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 msgid "Files"
 msgstr "Dosyalar"
 
@@ -1401,7 +1402,7 @@ msgstr "Filtre"
 msgid "Filter results with location matching this string"
 msgstr "Bu dizeyle eşleşen konuma sahip sonuçları filtrele"
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr "Bul"
 
@@ -1700,19 +1701,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Ayarlar alınıyor"
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 msgid "Goto Memory"
 msgstr "Kayda Git"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr "Kayda Git:"
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr "Git..."
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Yardım"
 
@@ -1720,11 +1721,11 @@ msgstr "Yardım"
 msgid "Help Me..."
 msgstr "Bana Yardım Et..."
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 msgid "Hide empty memories"
 msgstr "Boş kayıtları gizle"
 
@@ -1733,7 +1734,7 @@ msgstr "Boş kayıtları gizle"
 msgid "If set, sort results by distance from these coordinates"
 msgstr "Ayarlanırsa, sonuçları bu koordinatlardan uzaklığa göre sırala"
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "İçe Aktar"
 
@@ -1741,7 +1742,7 @@ msgstr "İçe Aktar"
 msgid "Import from file..."
 msgstr "Dosyadan İçe Aktar..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr "İçe aktarma önerilmez"
 
@@ -1753,11 +1754,11 @@ msgstr "Dizin"
 msgid "Info"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 msgid "Insert Row Above"
 msgstr "Yukarıya Satır Ekle"
 
@@ -1765,7 +1766,7 @@ msgstr "Yukarıya Satır Ekle"
 msgid "Install desktop icon?"
 msgstr "Masaüstü simgesi yüklensin mi?"
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr "Sürücü ile etkileşim"
 
@@ -1774,7 +1775,7 @@ msgstr "Sürücü ile etkileşim"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Geçersiz %(value)s (ondalık basamak kullanın)"
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 msgid "Invalid Entry"
 msgstr "Geçersiz Girdi"
 
@@ -1782,12 +1783,12 @@ msgstr "Geçersiz Girdi"
 msgid "Invalid ZIP code"
 msgstr "Geçersiz Posta kodu"
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Geçersiz düzenleme: %s"
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr "Geçersiz veya desteklenmeyen modül dosyası"
 
@@ -1796,7 +1797,7 @@ msgstr "Geçersiz veya desteklenmeyen modül dosyası"
 msgid "Invalid value: %r"
 msgstr "Geçersiz değer: %r"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr "Kayıt numarası:"
 
@@ -1804,11 +1805,12 @@ msgstr "Kayıt numarası:"
 msgid "LIVE"
 msgstr "CANLI"
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr "Enlem"
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr "Uzunluk %i olmalıdır"
@@ -1833,15 +1835,15 @@ msgstr "Sonuçları koordinatlardan bu mesafeye (km) sınırla"
 msgid "Load Module..."
 msgstr "Modül Yükle..."
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 msgid "Load module from issue"
 msgstr "Kayıttan modül yükle"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 msgid "Load module from issue..."
 msgstr "Kayıttan modül yükle..."
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1870,7 +1872,8 @@ msgstr "Logo dizesi 1 (12 karakter)"
 msgid "Logo string 2 (12 characters)"
 msgstr "Logo dizesi 2 (12 karakter)"
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr "Boylam"
 
@@ -1878,7 +1881,7 @@ msgstr "Boylam"
 msgid "Memories"
 msgstr "Kayıtlar"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Kayıt %i silinemez"
@@ -1892,7 +1895,7 @@ msgstr "Hafızanın düzenlenebilmesi için bir bankada olması gerekir"
 msgid "Memory {num} not in bank {bank}"
 msgstr "{num} kaydı {bank} bankasında değil"
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 msgid "Mode"
 msgstr "Mod"
 
@@ -1904,15 +1907,15 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Modlar"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr "Modül"
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr "Modül Yüklendi"
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr "Modül başarıyla yüklendi"
 
@@ -1921,11 +1924,11 @@ msgstr "Modül başarıyla yüklendi"
 msgid "More than one port found: %s"
 msgstr "Birden fazla bağlantı noktası bulundu: %s"
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 msgid "Move Down"
 msgstr "Aşağı Taşı"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 msgid "Move Up"
 msgstr "Yukarı Taşı"
 
@@ -1933,19 +1936,19 @@ msgstr "Yukarı Taşı"
 msgid "New Window"
 msgstr "Yeni Pencere"
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr "Yeni sürüm mevcut"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 msgid "No empty rows below!"
 msgstr "Aşağıda boş satır yok!"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr "Modül bulunamadı"
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr "%i kadında modül bulunamadı"
@@ -1958,7 +1961,7 @@ msgstr "Sonuç yok"
 msgid "No results!"
 msgstr "Sonuç yok!"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr "Numara"
 
@@ -1982,7 +1985,7 @@ msgstr "Yalnızca kayıt sekmeleri dışa aktarılabilir"
 msgid "Only working repeaters"
 msgstr "Yalnızca çalışan tekrarlayıcılar (röleler)"
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Aç"
 
@@ -1994,15 +1997,15 @@ msgstr "Son Kullanılanları Aç"
 msgid "Open Stock Config"
 msgstr "Hazır Yapılandırma Aç"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Bir dosya aç"
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr "Bir modül aç"
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Hata ayıklama günlüğünü aç"
 
@@ -2010,7 +2013,7 @@ msgstr "Hata ayıklama günlüğünü aç"
 msgid "Open in new window"
 msgstr "Yeni pencerede aç"
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 msgid "Open stock config directory"
 msgstr "Hazır yapılandırma dizinini aç"
 
@@ -2030,7 +2033,7 @@ msgstr "İsteğe bağlı: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "İsteğe bağlı: bölge, Hastane vb."
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 msgid "Overwrite memories?"
 msgstr "Kayıtların üzerine yazılsın mı?"
 
@@ -2048,31 +2051,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Ayrıştırılıyor"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Yapıştırılan kayıtlar, mevcut %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Yapıştırılan kayıtlar %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Yapıştırılan kayıtlar, %s kaydının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Yapıştırılan kayıt, %s kaydının üzerine yazacak"
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Lütfen yeni sürümü yüklemeden önce CHIRP'den çıktığınızdan emin olun!"
 
@@ -2120,7 +2123,7 @@ msgstr ""
 "4 - Ardından klonlamaya başlamak için telsizinizdeki \"A\" tuşuna basın.\n"
 "     (Sonunda telsiz bip sesi çıkaracaktır)\n"
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2145,11 +2148,11 @@ msgstr "Kablonuzu takın ve ardından Tamam'a tıklayın"
 msgid "Port"
 msgstr "Port"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Güç"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 msgid "Press enter to set this in memory"
 msgstr "Bu kayda almak için enter tuşuna basın"
 
@@ -2161,24 +2164,24 @@ msgstr "Baskı Önizleme"
 msgid "Printing"
 msgstr "Baskı"
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr "Özellikler"
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr "%s sorgusu"
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Kaynaktan Sorgula"
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "Telsiz"
 
@@ -2222,11 +2225,11 @@ msgstr "Yeniden Başlatma Gerekli"
 msgid "Refreshed memory %s"
 msgstr "Yenilenmiş %s kaydı"
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Sürücüyü Yeniden Yükle"
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Sürücüyü ve Dosyayı Yeniden Yükle"
 
@@ -2240,11 +2243,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Raporlama etkinleştirildi"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2255,7 +2258,7 @@ msgstr ""
 "bırakırsanız gerçekten minnettar oluruz. Raporlama gerçekten devre dışı "
 "bırakılsın mı?"
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr "Yeniden Başlatma Gerekiyor"
 
@@ -2266,19 +2269,24 @@ msgid_plural "Restore %i tabs"
 msgstr[0] "%i sekmesini geri yükle"
 msgstr[1] "%i sekmesini geri yükle"
 
+#: ../wxui/main.py:815
+#, fuzzy
+msgid "Restore tabs on start"
+msgstr "%i sekmesini geri yükle"
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr "Alınan ayarlar"
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr "Kaydet"
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr "Kapanmadan önce kaydedilsin mi?"
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Dosyayı kaydet"
 
@@ -2294,11 +2302,11 @@ msgstr "Tarama listeleri"
 msgid "Scrambler"
 msgstr "Karıştırıcı"
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr "Güvenlik Riski"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "Bant Planı Seç..."
 
@@ -2310,7 +2318,7 @@ msgstr "Bantları Seç"
 msgid "Select Modes"
 msgstr "Modları Seç"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr "Bir bant planı seçin"
 
@@ -2322,52 +2330,52 @@ msgstr "Servis"
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "Ham Kaydı Göster"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Hata ayıklama günlüğü konumunu göster"
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr "Ekstra alanları göster"
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 msgid "Some memories are incompatible with this radio"
 msgstr "Bazı kayıtlar bu telsizle uyumlu değil"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr "Bazı anılar silinemez"
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "%i kaydı sırala"
 msgstr[1] "%i kaydı sırala"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "%i kaydı artan şekilde sırala"
 msgstr[1] "%i kaydı artan şekilde sırala"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "%i kaydı azalan şekilde sırala"
 msgstr[1] "%i kaydı azalan şekilde sırala"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr "Sütuna göre sırala:"
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 msgid "Sort memories"
 msgstr "Kayıtları sırala"
 
@@ -2383,7 +2391,7 @@ msgstr "Devlet"
 msgid "State/Province"
 msgstr "Eyalet/İl"
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr "Başarılı"
 
@@ -2431,7 +2439,7 @@ msgstr ""
 "Lütfen ilk başarılı indirmenizin düzenlenmemiş bir kopyasını\n"
 "bir CHIRP Radio Images (*.img) dosyasına kaydedin.\n"
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
@@ -2441,7 +2449,7 @@ msgstr ""
 "oluşturabileceğinden bu modülü yüklememeniz önerilir. Yine de devam edilsin "
 "mi?"
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2457,7 +2465,7 @@ msgstr ""
 "yapıştırmak için bu dosyayı açmak mı yoksa içe aktarma işlemine devam etmek "
 "mi istiyorsunuz?"
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 msgid "This Memory"
 msgstr "Bu kaydı"
 
@@ -2517,11 +2525,11 @@ msgstr ""
 "Ayrıca lütfen hata raporu ve geliştirme istekleri gönderin!\n"
 "Uyarıldınız. Kendi sorumluluğunuzda ilerleyin!"
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 msgid "This memory and shift all up"
 msgstr "Bu kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 msgid "This memory and shift block up"
 msgstr "Bu kaydı ve bloğu yukarı kaydır"
 
@@ -2551,23 +2559,23 @@ msgstr ""
 "CHIRP'in OEM kısıtlamalarını uygulamamasına neden olur ve tanımlanmamış veya "
 "düzenlenmemiş davranışlara yol açabilir. Riski size ait olmak üzere kullanın!"
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr "Bu, bir web sitesi kaydından bir modül yükleyecektir"
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "Ton"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Ton Modu"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 msgid "Tone Squelch"
 msgstr "Ton Susturucu"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 msgid "Tuning Step"
 msgstr "Ayarlama Adımı"
 
@@ -2583,11 +2591,11 @@ msgstr ""
 "Kablonuz için bağlantı noktası belirlenemiyor. Sürücülerinizi ve "
 "bağlantılarınızı kontrol edin."
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Radyo yüklenmeden önce kayıt düzenlenemiyor"
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "%r stok yapılandırması bulunamadı"
@@ -2610,7 +2618,7 @@ msgstr ""
 "telsiz ABD dışı bir telsizdir (veya geniş bantlıdır). Lütfen doğru modeli "
 "seçin ve tekrar deneyin."
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "%s bu sistemde gösterilemiyor"
@@ -2632,11 +2640,11 @@ msgstr "(gerekirse) Kablonuzu çıkarın ve ardından Tamam'ı tıklayın"
 msgid "Upload instructions"
 msgstr "Yükleme talimatları"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 msgid "Upload to radio"
 msgstr "Telsize yükle"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "Telsize yükle..."
 
@@ -2653,7 +2661,7 @@ msgstr "Sabit genişlikte yazı tipi kullan"
 msgid "Use larger font"
 msgstr "Daha büyük yazı tipi kullan"
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr "Değer %i bit'e sığmıyor"
@@ -2668,16 +2676,16 @@ msgstr "Değer en az %.4f olmalıdır"
 msgid "Value must be at most %.4f"
 msgstr "Değer en fazla %.4f olmalıdır"
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr "Değer tam olarak %i ondalık basamak olmalıdır"
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr "Değer sıfır veya daha büyük olmalıdır"
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr "Değerler"
 
@@ -2685,7 +2693,7 @@ msgstr "Değerler"
 msgid "Vendor"
 msgstr "Tedarikçi"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 msgid "View"
 msgstr "Göster"
 
@@ -2693,11 +2701,11 @@ msgstr "Göster"
 msgid "WARNING!"
 msgstr "UYARI!"
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr "Uyarı"
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr "Uyarı: %s"
@@ -2714,23 +2722,23 @@ msgstr "CHIRP'in sizin için bir masaüstü simgesi yüklemesini ister misiniz?"
 msgid "Your cable appears to be on port:"
 msgstr "Kablonuz şu bağlantı noktasında görünüyor:"
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr "bitler"
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr "bytes"
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr "her biri bayt"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr "devre dışı bırakıldı"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr "etkinleştirildi"
 

--- a/chirp/locale/uk_UA.po
+++ b/chirp/locale/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2015-11-30 10:36+0200\n"
 "Last-Translator: laser <student.laser@gmail.com>\n"
 "Language-Team: laser <student.laser@gmail.com>\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Видалити (та зсунути вгору)"
 msgstr[1] "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Пам'ять"
 msgstr[1] "Пам'ять"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Видалити (та зсунути вгору)"
 msgstr[1] "Видалити (та зсунути вгору)"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Файл змінено, зберегти зміни перед закриттям?"
@@ -63,7 +63,7 @@ msgstr "Файл змінено, зберегти зміни перед закр
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -621,17 +621,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr ""
 
@@ -639,12 +639,12 @@ msgstr ""
 msgid "All"
 msgstr "Все"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "CSV-файли"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
@@ -660,11 +660,11 @@ msgstr "Сталася помилка"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr ""
 
@@ -676,7 +676,7 @@ msgstr ""
 msgid "Banks"
 msgstr "Банки"
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Browser"
 msgstr ""
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr ""
 
@@ -698,40 +698,40 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS код"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Кросрежим"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, fuzzy, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Виберіть один для Імпорту з:"
@@ -768,22 +768,22 @@ msgstr "Скопіювати з радіостанції"
 msgid "Cloning to radio"
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "Коментар"
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 #, fuzzy
 msgid "Copy"
 msgstr "Копіювати"
@@ -816,7 +816,7 @@ msgstr "Копіювати"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 #, fuzzy
 msgid "Cross mode"
 msgstr "Кросрежим"
@@ -829,17 +829,17 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 #, fuzzy
 msgid "Cut"
 msgstr "Вирізати"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -850,40 +850,40 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr ""
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 #, fuzzy
 msgid "Dec"
 msgstr "Визначити"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 #, fuzzy
 msgid "Delete"
 msgstr "Видалити"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Розробник"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 msgid "Digital Code"
 msgstr "Цифровий код"
 
@@ -892,15 +892,16 @@ msgstr "Цифровий код"
 msgid "Digital Modes"
 msgstr "Цифровий код"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Disabled"
 msgstr ""
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -913,16 +914,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 #, fuzzy
 msgid "Download from radio"
 msgstr "Скопіювати з радіостанції"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Скопіювати з радіостанції"
@@ -940,25 +941,25 @@ msgstr ""
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 msgid "Enabled"
 msgstr ""
 
@@ -967,11 +968,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Частота"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1002,11 +1003,11 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Експорт до файлу"
@@ -1016,7 +1017,7 @@ msgstr "Експорт до файлу"
 msgid "Export to CSV..."
 msgstr "Експорт до файлу"
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr ""
 
@@ -1031,7 +1032,7 @@ msgid ""
 "required."
 msgstr ""
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr ""
 
@@ -1048,8 +1049,8 @@ msgstr ""
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 #, fuzzy
 msgid "Files"
 msgstr "_Файл"
@@ -1062,7 +1063,7 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 msgid "Find"
 msgstr ""
 
@@ -1272,20 +1273,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Показати Raw пам'ять"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "Довідка"
 
@@ -1293,11 +1294,11 @@ msgstr "Довідка"
 msgid "Help Me..."
 msgstr ""
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Перезаписати?"
@@ -1307,7 +1308,7 @@ msgstr "Перезаписати?"
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "Імпорт"
 
@@ -1316,7 +1317,7 @@ msgstr "Імпорт"
 msgid "Import from file..."
 msgstr "Імпортувати з файлу"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Імпорт з RFinder"
@@ -1329,11 +1330,11 @@ msgstr "Зміст"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Додати рядок зверху"
@@ -1342,7 +1343,7 @@ msgstr "Додати рядок зверху"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1351,7 +1352,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Неприпустиме значення. Повинно бути цілим числом."
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Неприпустиме значення для цього поля"
@@ -1360,12 +1361,12 @@ msgstr "Неприпустиме значення для цього поля"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1374,7 +1375,7 @@ msgstr ""
 msgid "Invalid value: %r"
 msgstr "Неприпустиме значення для цього поля"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr ""
 
@@ -1382,11 +1383,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr ""
@@ -1412,17 +1414,17 @@ msgstr ""
 msgid "Load Module..."
 msgstr "Тоновий режим"
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 #, fuzzy
 msgid "Load module from issue"
 msgstr "Тоновий режим"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Тоновий режим"
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1444,7 +1446,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1453,7 +1456,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Пам'ять"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1467,7 +1470,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 #, fuzzy
 msgid "Mode"
 msgstr "Режим"
@@ -1481,15 +1484,15 @@ msgstr "Модель"
 msgid "Modes"
 msgstr "Режим"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1498,12 +1501,12 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 #, fuzzy
 msgid "Move Down"
 msgstr "Перемістити В_низ"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 #, fuzzy
 msgid "Move Up"
 msgstr "Перемістити В_гору"
@@ -1512,20 +1515,20 @@ msgstr "Перемістити В_гору"
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Додати рядок знизу"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr ""
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr ""
@@ -1538,7 +1541,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr ""
 
@@ -1562,7 +1565,7 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
@@ -1576,15 +1579,15 @@ msgstr "Ос_танні"
 msgid "Open Stock Config"
 msgstr "Відкрити заводські конфігурації"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
@@ -1592,7 +1595,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Відкрите заводські конфігурації {name}"
@@ -1614,7 +1617,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Перезаписати?"
@@ -1630,32 +1633,32 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 #, fuzzy
 msgid "Paste"
 msgstr "Вставити"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1685,7 +1688,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1705,11 +1708,11 @@ msgstr ""
 msgid "Port"
 msgstr "Порт"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "Потужність"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 #, fuzzy
 msgid "Press enter to set this in memory"
 msgstr "Помилка настройки пам'яті"
@@ -1722,24 +1725,24 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr ""
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 #, fuzzy
 msgid "Radio"
 msgstr "Радіостанція"
@@ -1781,11 +1784,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1800,19 +1803,19 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Звіти вимкнуто"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr ""
 
@@ -1823,19 +1826,23 @@ msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
+#: ../wxui/main.py:815
+msgid "Restore tabs on start"
+msgstr ""
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1851,11 +1858,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Виберіть Стовпці"
@@ -1870,7 +1877,7 @@ msgstr "Виберіть Стовпці"
 msgid "Select Modes"
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1882,54 +1889,54 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Показати Raw пам'ять"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Вставлена пам'ять {number} несумісна із цією радіостанцією тому що:"
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 #, fuzzy
 msgid "Sort memories"
 msgstr "Перезаписати?"
@@ -1946,7 +1953,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr ""
 
@@ -1979,14 +1986,14 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -1996,7 +2003,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 #, fuzzy
 msgid "This Memory"
 msgstr "Показати Raw пам'ять"
@@ -2041,12 +2048,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Видалити (та зсунути вгору)"
@@ -2068,24 +2075,24 @@ msgid ""
 "own risk!"
 msgstr ""
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "Тон"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "Тоновий режим"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Крок настройки"
@@ -2100,11 +2107,11 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Відкрити заводські конфігурації"
@@ -2125,7 +2132,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Не вдається внести зміни до цієї моделі"
@@ -2147,12 +2154,12 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Записати в радіостанцію"
@@ -2170,7 +2177,7 @@ msgstr ""
 msgid "Use larger font"
 msgstr ""
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr ""
@@ -2185,16 +2192,16 @@ msgstr ""
 msgid "Value must be at most %.4f"
 msgstr ""
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr ""
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr ""
 
@@ -2202,7 +2209,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Виробник"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 #, fuzzy
 msgid "View"
 msgstr "В_игляд"
@@ -2211,11 +2218,11 @@ msgstr "В_игляд"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2232,23 +2239,23 @@ msgstr ""
 msgid "Your cable appears to be on port:"
 msgstr ""
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr ""
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr ""
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/zh_CN.po
+++ b/chirp/locale/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-20 12:27+0100\n"
 "PO-Revision-Date: 2022-06-04 02:01+0800\n"
 "Last-Translator: DuckSoft, BH2UEP <realducksoft@gmail.com>\n"
 "Language: zh_CN\n"
@@ -32,25 +32,25 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1590
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "...并将区块上移"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1581
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "存储"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1585
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "...并将区块上移"
 
-#: ../wxui/main.py:1365
+#: ../wxui/main.py:1372
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "文件已更改，关闭前要保存变更吗？"
@@ -59,7 +59,7 @@ msgstr "文件已更改，关闭前要保存变更吗？"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1925
+#: ../wxui/memedit.py:1922
 #, fuzzy, python-format
 msgid "...and %i more"
 msgstr "...并将所有存储上移"
@@ -617,17 +617,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1773
+#: ../wxui/main.py:1784
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:912
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1648
+#: ../wxui/main.py:1659
 msgid "About CHIRP"
 msgstr ""
 
@@ -635,12 +635,12 @@ msgstr ""
 msgid "All"
 msgstr "全选"
 
-#: ../wxui/main.py:1196
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "全部文件"
 
-#: ../wxui/main.py:1207
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
@@ -656,11 +656,11 @@ msgstr "发生错误"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/developer.py:515
+#: ../wxui/developer.py:517
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "Bandplan"
 msgstr ""
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "Banks"
 msgstr ""
 
-#: ../wxui/developer.py:220
+#: ../wxui/developer.py:222
 msgid "Bin"
 msgstr ""
 
@@ -680,7 +680,7 @@ msgstr ""
 msgid "Browser"
 msgstr "浏览器"
 
-#: ../wxui/developer.py:409
+#: ../wxui/developer.py:411
 msgid "Building Radio Browser"
 msgstr ""
 
@@ -694,40 +694,40 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1267
+#: ../wxui/memedit.py:1264
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1195
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:342
+#: ../wxui/memedit.py:339
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1246
+#: ../wxui/memedit.py:1243
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS 接收代码"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1240
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1277
+#: ../wxui/memedit.py:1274
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "收发使用不同亚音频"
 
-#: ../wxui/memedit.py:1307
+#: ../wxui/memedit.py:1304
 msgid "Choose duplex"
 msgstr ""
 
-#: ../wxui/developer.py:514
+#: ../wxui/developer.py:516
 #, fuzzy, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "选择一个来导入："
@@ -764,22 +764,22 @@ msgstr "从电台下载"
 msgid "Cloning to radio"
 msgstr "上传到电台"
 
-#: ../wxui/main.py:990
+#: ../wxui/main.py:997
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:998
 #, fuzzy
 msgid "Close file"
 msgstr "全部文件"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1648
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:532
+#: ../wxui/memedit.py:529
 msgid "Comment"
 msgstr "备注"
 
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1569
+#: ../wxui/memedit.py:1566
 msgid "Copy"
 msgstr "复制"
 
@@ -811,7 +811,7 @@ msgstr "复制"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:524
+#: ../wxui/memedit.py:521
 msgid "Cross mode"
 msgstr "收发使用不同亚音频"
 
@@ -823,16 +823,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1565
+#: ../wxui/memedit.py:1562
 msgid "Cut"
 msgstr "剪切"
 
-#: ../wxui/memedit.py:455
+#: ../wxui/memedit.py:452
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS 策略"
 
-#: ../wxui/memedit.py:501
+#: ../wxui/memedit.py:498
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -843,39 +843,39 @@ msgstr "DTCS 策略"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2177
 #, fuzzy
 msgid "DV Memory"
 msgstr "该存储"
 
-#: ../wxui/main.py:1662
+#: ../wxui/main.py:1673
 msgid "Danger Ahead"
 msgstr ""
 
-#: ../wxui/developer.py:219
+#: ../wxui/developer.py:221
 #, fuzzy
 msgid "Dec"
 msgstr "探测"
 
-#: ../wxui/memedit.py:1578
+#: ../wxui/memedit.py:1575
 msgid "Delete"
 msgstr "删除"
 
-#: ../wxui/main.py:917
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "开发者"
 
-#: ../wxui/main.py:1668
+#: ../wxui/main.py:1679
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1688
+#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
 msgid "Diff Raw Memories"
 msgstr "对比原始存储"
 
-#: ../wxui/memedit.py:2105
+#: ../wxui/memedit.py:2102
 #, fuzzy
 msgid "Digital Code"
 msgstr "数字代码"
@@ -885,16 +885,17 @@ msgstr "数字代码"
 msgid "Digital Modes"
 msgstr "数字代码"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1690
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 #, fuzzy
 msgid "Disabled"
 msgstr "已启用"
 
-#: ../wxui/query_sources.py:312 ../wxui/query_sources.py:580
+#: ../wxui/query_sources.py:99 ../wxui/query_sources.py:312
+#: ../wxui/query_sources.py:580
 msgid "Distance"
 msgstr ""
 
@@ -907,16 +908,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:999
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1000
 #, fuzzy
 msgid "Download from radio"
 msgstr "从电台下载"
 
-#: ../wxui/main.py:824
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "从电台下载"
@@ -934,25 +935,25 @@ msgstr ""
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:394
+#: ../wxui/memedit.py:391
 msgid "Duplex"
 msgstr "差频方向"
 
-#: ../wxui/memedit.py:2135
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2133
+#: ../wxui/memedit.py:2130
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:861
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:431
+#: ../wxui/memedit.py:428
 #, fuzzy
 msgid "Enabled"
 msgstr "已启用"
@@ -962,11 +963,11 @@ msgstr "已启用"
 msgid "Enter Frequency"
 msgstr "频率"
 
-#: ../wxui/memedit.py:1294
+#: ../wxui/memedit.py:1291
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1286
+#: ../wxui/memedit.py:1283
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -998,11 +999,11 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "继续使用不稳定的驱动？"
 
-#: ../wxui/memedit.py:2063
+#: ../wxui/memedit.py:2060
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1350
+#: ../wxui/main.py:1357
 #, fuzzy
 msgid "Export to CSV"
 msgstr "导出到文件"
@@ -1012,7 +1013,7 @@ msgstr "导出到文件"
 msgid "Export to CSV..."
 msgstr "导出到文件"
 
-#: ../wxui/memedit.py:2169
+#: ../wxui/memedit.py:2166
 msgid "Extra"
 msgstr ""
 
@@ -1027,7 +1028,7 @@ msgid ""
 "required."
 msgstr ""
 
-#: ../wxui/developer.py:417
+#: ../wxui/developer.py:419
 msgid "Failed to load radio browser"
 msgstr ""
 
@@ -1044,8 +1045,8 @@ msgstr ""
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1199 ../wxui/main.py:1280 ../wxui/main.py:1290
-#: ../wxui/main.py:1346 ../wxui/main.py:1614 ../wxui/main.py:1615
+#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
 #, fuzzy
 msgid "Files"
 msgstr "文件 (_F)"
@@ -1058,7 +1059,7 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1420
+#: ../wxui/main.py:1427
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
@@ -1272,21 +1273,21 @@ msgstr ""
 msgid "Getting settings"
 msgstr "正在获取 %s 信息"
 
-#: ../wxui/memedit.py:853
+#: ../wxui/memedit.py:850
 #, fuzzy
 msgid "Goto Memory"
 msgstr "该存储"
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849
 #, fuzzy
 msgid "Goto Memory:"
 msgstr "该存储"
 
-#: ../wxui/memedit.py:821
+#: ../wxui/memedit.py:818
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:965
 msgid "Help"
 msgstr "帮助"
 
@@ -1295,11 +1296,11 @@ msgstr "帮助"
 msgid "Help Me..."
 msgstr "在线帮助..."
 
-#: ../wxui/developer.py:218
+#: ../wxui/developer.py:220
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:830
+#: ../wxui/memedit.py:827
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "要覆盖吗？"
@@ -1309,7 +1310,7 @@ msgstr "要覆盖吗？"
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1336
+#: ../wxui/main.py:1343
 msgid "Import"
 msgstr "导入"
 
@@ -1318,7 +1319,7 @@ msgstr "导入"
 msgid "Import from file..."
 msgstr "导入自文件"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1341
 msgid "Import not recommended"
 msgstr ""
 
@@ -1330,12 +1331,12 @@ msgstr "索引"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1269
+#: ../wxui/memedit.py:1266
 #, fuzzy
 msgid "Information"
 msgstr "{information}"
 
-#: ../wxui/memedit.py:1559
+#: ../wxui/memedit.py:1556
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "上方插入一行"
@@ -1344,7 +1345,7 @@ msgstr "上方插入一行"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:901
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1353,7 +1354,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "无效值。必须为整数。"
 
-#: ../wxui/memedit.py:1414 ../wxui/query_sources.py:65
+#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "设置值无效：%s"
@@ -1362,12 +1363,12 @@ msgstr "设置值无效：%s"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1413 ../wxui/memedit.py:2260
+#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "设置值无效：%s"
 
-#: ../wxui/main.py:1611
+#: ../wxui/main.py:1622
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1376,7 +1377,7 @@ msgstr ""
 msgid "Invalid value: %r"
 msgstr "%s 值无效"
 
-#: ../wxui/developer.py:536
+#: ../wxui/developer.py:538
 msgid "Issue number:"
 msgstr ""
 
@@ -1384,11 +1385,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/query_sources.py:303 ../wxui/query_sources.py:572
+#: ../wxui/query_sources.py:87 ../wxui/query_sources.py:303
+#: ../wxui/query_sources.py:572
 msgid "Latitude"
 msgstr ""
 
-#: ../wxui/developer.py:199
+#: ../wxui/developer.py:201
 #, python-format
 msgid "Length must be %i"
 msgstr ""
@@ -1414,17 +1416,17 @@ msgstr ""
 msgid "Load Module..."
 msgstr "加载模块"
 
-#: ../wxui/developer.py:537
+#: ../wxui/developer.py:539
 #, fuzzy
 msgid "Load module from issue"
 msgstr "加载模块"
 
-#: ../wxui/main.py:949
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "加载模块"
 
-#: ../wxui/main.py:1618
+#: ../wxui/main.py:1629
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1446,7 +1448,8 @@ msgstr ""
 msgid "Logo string 2 (12 characters)"
 msgstr ""
 
-#: ../wxui/query_sources.py:304 ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:93 ../wxui/query_sources.py:304
+#: ../wxui/query_sources.py:573
 msgid "Longitude"
 msgstr ""
 
@@ -1454,7 +1457,7 @@ msgstr ""
 msgid "Memories"
 msgstr "存储"
 
-#: ../wxui/memedit.py:1453
+#: ../wxui/memedit.py:1450
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1468,7 +1471,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:510 ../wxui/query_sources.py:524
+#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
 #, fuzzy
 msgid "Mode"
 msgstr "制式"
@@ -1482,17 +1485,17 @@ msgstr "型号"
 msgid "Modes"
 msgstr "制式"
 
-#: ../wxui/main.py:1615
+#: ../wxui/main.py:1626
 #, fuzzy
 msgid "Module"
 msgstr "模块"
 
-#: ../wxui/main.py:1587
+#: ../wxui/main.py:1598
 #, fuzzy
 msgid "Module Loaded"
 msgstr "模块"
 
-#: ../wxui/main.py:1702
+#: ../wxui/main.py:1713
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1501,12 +1504,12 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:817
+#: ../wxui/memedit.py:814
 #, fuzzy
 msgid "Move Down"
 msgstr "下移 (_N)"
 
-#: ../wxui/memedit.py:807
+#: ../wxui/memedit.py:804
 #, fuzzy
 msgid "Move Up"
 msgstr "上移 (_U)"
@@ -1515,21 +1518,21 @@ msgstr "上移 (_U)"
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1775
+#: ../wxui/main.py:1786
 #, fuzzy
 msgid "New version available"
 msgstr "CHIRP 新版本可用：{ver}。"
 
-#: ../wxui/memedit.py:1724
+#: ../wxui/memedit.py:1721
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "下方插入一行"
 
-#: ../wxui/developer.py:552
+#: ../wxui/developer.py:554
 msgid "No modules found"
 msgstr ""
 
-#: ../wxui/developer.py:551
+#: ../wxui/developer.py:553
 #, python-format
 msgid "No modules found in issue %i"
 msgstr ""
@@ -1542,7 +1545,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:852
+#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
 msgid "Number"
 msgstr ""
 
@@ -1566,7 +1569,7 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:986 ../wxui/main.py:1336
+#: ../wxui/main.py:993 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
@@ -1579,16 +1582,16 @@ msgstr "打开最近 (_R)"
 msgid "Open Stock Config"
 msgstr "打开库存配置"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1210
+#: ../wxui/main.py:994 ../wxui/main.py:1217
 #, fuzzy
 msgid "Open a file"
 msgstr "打开最近的文件"
 
-#: ../wxui/main.py:1633
+#: ../wxui/main.py:1644
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:938
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
@@ -1596,7 +1599,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:608
+#: ../wxui/main.py:609
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "打开库存配置 {name}"
@@ -1618,7 +1621,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1856
+#: ../wxui/memedit.py:1853
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "要覆盖吗？"
@@ -1634,31 +1637,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1570
 msgid "Paste"
 msgstr "粘贴"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1850
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1844
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1841
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1779
+#: ../wxui/main.py:1790
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1688,7 +1691,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1656
+#: ../wxui/main.py:1667
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1708,11 +1711,11 @@ msgstr ""
 msgid "Port"
 msgstr "端口"
 
-#: ../wxui/memedit.py:274
+#: ../wxui/memedit.py:271
 msgid "Power"
 msgstr "功率"
 
-#: ../wxui/developer.py:136
+#: ../wxui/developer.py:138
 #, fuzzy
 msgid "Press enter to set this in memory"
 msgstr "设置存储时出错"
@@ -1725,26 +1728,26 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1552
+#: ../wxui/memedit.py:1549
 msgid "Properties"
 msgstr "属性"
 
-#: ../wxui/main.py:1730
+#: ../wxui/main.py:1741
 #, fuzzy, python-format
 msgid "Query %s"
 msgstr "查询失败"
 
-#: ../wxui/main.py:838
+#: ../wxui/main.py:845
 #, fuzzy
 msgid "Query Source"
 msgstr "查询数据源"
 
-#: ../wxui/memedit.py:457
+#: ../wxui/memedit.py:454
 #, fuzzy
 msgid "RX DTCS"
 msgstr "DTCS 接收代码"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:964
 msgid "Radio"
 msgstr "电台"
 
@@ -1786,11 +1789,11 @@ msgstr "刷新"
 msgid "Refreshed memory %s"
 msgstr "这些存储"
 
-#: ../wxui/main.py:878
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:887
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1804,19 +1807,19 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:926
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "报告已禁用"
 
-#: ../wxui/main.py:1675
+#: ../wxui/main.py:1686
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1670
+#: ../wxui/main.py:1681
 msgid "Restart Required"
 msgstr ""
 
@@ -1826,19 +1829,23 @@ msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 
+#: ../wxui/main.py:815
+msgid "Restore tabs on start"
+msgstr ""
+
 #: ../wxui/common.py:318
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:988
+#: ../wxui/main.py:995
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1367
+#: ../wxui/main.py:1374
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:989 ../wxui/main.py:1294
+#: ../wxui/main.py:996 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1855,11 +1862,11 @@ msgstr ""
 msgid "Scrambler"
 msgstr ""
 
-#: ../wxui/developer.py:527
+#: ../wxui/developer.py:529
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "全选"
@@ -1874,7 +1881,7 @@ msgstr "选择列"
 msgid "Select Modes"
 msgstr "选择列"
 
-#: ../wxui/main.py:1715
+#: ../wxui/main.py:1726
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1886,50 +1893,50 @@ msgstr ""
 msgid "Settings"
 msgstr "设置"
 
-#: ../wxui/memedit.py:1680
+#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
 msgid "Show Raw Memory"
 msgstr "显示原始存储"
 
-#: ../wxui/main.py:944
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:826
+#: ../wxui/memedit.py:823
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1929
+#: ../wxui/memedit.py:1926
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "粘贴的存储 {number} 与此电台不兼容，原因："
 
-#: ../wxui/memedit.py:1797
+#: ../wxui/memedit.py:1794
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1633
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1637
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1659
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1529
+#: ../wxui/memedit.py:1526
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1528
+#: ../wxui/memedit.py:1525
 #, fuzzy
 msgid "Sort memories"
 msgstr "要覆盖吗？"
@@ -1947,7 +1954,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1714
 msgid "Success"
 msgstr ""
 
@@ -1980,14 +1987,14 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
-#: ../wxui/developer.py:524
+#: ../wxui/developer.py:526
 msgid ""
 "The author of this module is not a recognized CHIRP developer. It is "
 "recommended that you not load this module as it could pose a security risk. "
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1327
+#: ../wxui/main.py:1334
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -1997,7 +2004,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1598
+#: ../wxui/memedit.py:1595
 #, fuzzy
 msgid "This Memory"
 msgstr "该存储"
@@ -2042,12 +2049,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1602
+#: ../wxui/memedit.py:1599
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "...并将区块上移"
 
-#: ../wxui/memedit.py:1600
+#: ../wxui/memedit.py:1597
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "...并将区块上移"
@@ -2069,24 +2076,24 @@ msgid ""
 "own risk!"
 msgstr ""
 
-#: ../wxui/developer.py:534
+#: ../wxui/developer.py:536
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:360
+#: ../wxui/memedit.py:357
 msgid "Tone"
 msgstr "亚音频"
 
-#: ../wxui/memedit.py:886
+#: ../wxui/memedit.py:884
 msgid "Tone Mode"
 msgstr "亚音频制式"
 
-#: ../wxui/memedit.py:362
+#: ../wxui/memedit.py:359
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "接收亚音频"
 
-#: ../wxui/memedit.py:304 ../wxui/memedit.py:900
+#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
 #, fuzzy
 msgid "Tuning Step"
 msgstr "调谐间隔"
@@ -2101,11 +2108,11 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1334
+#: ../wxui/memedit.py:1331
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1252
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
@@ -2126,7 +2133,7 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:619
+#: ../wxui/common.py:621
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "无法变更此型号电台"
@@ -2149,12 +2156,12 @@ msgstr ""
 msgid "Upload instructions"
 msgstr "{instructions}"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:1002
 #, fuzzy
 msgid "Upload to radio"
 msgstr "上传到电台"
 
-#: ../wxui/main.py:832
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "上传到电台"
@@ -2172,7 +2179,7 @@ msgstr ""
 msgid "Use larger font"
 msgstr ""
 
-#: ../wxui/developer.py:252
+#: ../wxui/developer.py:254
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr ""
@@ -2187,16 +2194,16 @@ msgstr ""
 msgid "Value must be at most %.4f"
 msgstr ""
 
-#: ../wxui/developer.py:296
+#: ../wxui/developer.py:298
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr ""
 
-#: ../wxui/developer.py:250 ../wxui/developer.py:294
+#: ../wxui/developer.py:252 ../wxui/developer.py:296
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2160
+#: ../wxui/memedit.py:2157
 msgid "Values"
 msgstr ""
 
@@ -2204,7 +2211,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "厂商"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:963
 #, fuzzy
 msgid "View"
 msgstr "查看 (_V)"
@@ -2213,11 +2220,11 @@ msgstr "查看 (_V)"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1420
+#: ../wxui/memedit.py:1417
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1419
+#: ../wxui/memedit.py:1416
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2234,24 +2241,24 @@ msgstr ""
 msgid "Your cable appears to be on port:"
 msgstr ""
 
-#: ../wxui/developer.py:172
+#: ../wxui/developer.py:174
 msgid "bits"
 msgstr ""
 
-#: ../wxui/developer.py:168
+#: ../wxui/developer.py:170
 msgid "bytes"
 msgstr ""
 
-#: ../wxui/developer.py:163
+#: ../wxui/developer.py:165
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 #, fuzzy
 msgid "disabled"
 msgstr "已启用"
 
-#: ../wxui/main.py:1653
+#: ../wxui/main.py:1664
 #, fuzzy
 msgid "enabled"
 msgstr "已启用"

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -811,6 +811,13 @@ class ChirpMain(wx.Frame):
         self.Bind(wx.EVT_MENU, self._menu_large_font, large_item)
         large_item.Check(CONF.get_bool('font_large', 'state', False))
 
+        restore_tabs = wx.MenuItem(view_menu, wx.NewId(),
+                                   _('Restore tabs on start'),
+                                   kind=wx.ITEM_CHECK)
+        view_menu.Append(restore_tabs)
+        self.Bind(wx.EVT_MENU, self._menu_restore_tabs, restore_tabs)
+        restore_tabs.Check(CONF.get_bool('restore_tabs', 'prefs', False))
+
         radio_menu = wx.Menu()
 
         if sys.platform == 'darwin':
@@ -1441,6 +1448,10 @@ class ChirpMain(wx.Frame):
         menuitem = event.GetEventObject().FindItemById(event.GetId())
         CONF.set_bool('font_large', menuitem.IsChecked(), 'state')
         self._update_font()
+
+    def _menu_restore_tabs(self, event):
+        menuitem = event.GetEventObject().FindItemById(event.GetId())
+        CONF.set_bool('restore_tabs', menuitem.IsChecked(), 'prefs')
 
     def _make_backup(self, radio):
         if not isinstance(radio, chirp_common.CloneModeRadio):


### PR DESCRIPTION
This PR adds under the "View" menu an option 'Restore tabs on start' to toggle the restore_tabs preference that was already honored by CHIRP if present in chirp.config, but couldn't be set or unset with the GUI.

When set, it has the same effect as if the command line option `--restore` was always specified (the welcome page and the menu item "File / Open Recent / Restore %i tabs" aren't visibile).

When not set, behavior is like before this PR.