### PR TITLE
Autosize height of column headers of memedit

### DIFF
--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -43,6 +43,7 @@ WX_GTK = 'gtk' in wx.version().lower()
 class ChirpMemoryGrid(wx.grid.Grid, glr.GridWithLabelRenderersMixin):
     def __init__(self, *a, **k):
         wx.grid.Grid.__init__(self, *a, **k)
+        self.SetColLabelSize(wx.grid.GRID_AUTOSIZE)
         glr.GridWithLabelRenderersMixin.__init__(self)
 
 


### PR DESCRIPTION
This PR fixes a small rendering glitch for column headers that span 2 lines, where letters on the second line are incomplete, see "Tone Mode", "Tone Squelch, "DTCS Polarity", "PTT ID" in the image below:

Before: (click to enlarge)
![image](https://github.com/kk7ds/chirp/assets/1055635/3d4584c9-f9f6-4a63-9bf0-9a1c13add97f)

After: (click to enlarge)
![image](https://github.com/kk7ds/chirp/assets/1055635/64405455-8246-4d43-932e-fefb6272ab55)
