### PR TITLE
Fix check for lines added to cpep8.manifest and cpep8.blacklist and remove clean files from cpep8.blacklist

### DIFF
--- a/tools/check_commit.sh
+++ b/tools/check_commit.sh
@@ -46,12 +46,12 @@ if grep -E "[^_]_\([^\"']" added_lines; then
     fail 'Translated strings must be literals!'
 fi
 
-if grep '/cpep8.manifest' added_lines; then
+if git diff ${BASE}.. 'tools/cpep8.manifest' | tail -n +5 | grep -q '^+'; then
     fail 'Do not add new files to cpep8.manifest; no longer needed'
 fi
 
-if grep '/cpep8.blacklist' added_lines; then
-    fail 'Do not add new files to cpep8.blacklist'
+if git diff ${BASE}.. 'tools/cpep8.blacklist' | tail -n +5 | grep -q '^+'; then
+    fail 'Do not add new files to cpep8.blacklist; fix the code'
 fi
 
 grep -i 'license' added_lines > license_lines

--- a/tools/cpep8.blacklist
+++ b/tools/cpep8.blacklist
@@ -2,13 +2,11 @@
 # DO NOT ADD NEW FILES!!  Instead, fix the code to be compliant.
 # Over time, this list should shrink and (eventually) be eliminated.
 ./chirp/drivers/kyd_IP620.py
-./chirp/drivers/kguv8dplus.py
 ./chirp/drivers/ft450d.py
 ./chirp/drivers/ft70.py
 ./chirp/drivers/hg_uv98.py
 ./chirp/drivers/hobbypcb.py
 ./chirp/drivers/retevis_rb28.py
-./chirp/drivers/bj9900.py
 ./chirp/drivers/th7800.py
 ./chirp/drivers/icx90.py
 ./chirp/drivers/kguv8e.py


### PR DESCRIPTION
This PR changes the lines in `tools/check_commit.sh` that check for lines added to `tools/cpep8.manifest` and `tools/cpep8.blacklist` (and adds the hint to fix the code in cpep8.blacklist), then removes clean files from `tools/cpep8.blacklist`. 

The check for added lines couldn't work because it was using the file `added_lines` that contained the lines from `*.py` files and since `git diff` adds an header containing line starting with `+++`, adding the files `cpep8.blacklist` and `cpep8.manifest`  would always give a false positive. The way I found to ignore the lines with `+++` is piping to `tail` because a command using `git diff -G` searches the actual lines so it can't find the `+` prefix and so does `git grep`; another way could be using something like `git diff --shortstat` and grepping for the word `insertion` but it will break if the output gets translated in a future version of git.