### PR TITLE
Fix marking tab as modified on menu delete

### DIFF
--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -1961,8 +1961,7 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
 
     def cb_delete(self):
         selected_rows = self.get_selected_rows_safe()
-        for row in selected_rows:
-            self.delete_memory_at(row, None)
+        self._delete_memories_at(selected_rows, None)
 
     def get_selected_rows_safe(self):
         """Return the currently-selected rows


### PR DESCRIPTION
This unifies our Edit->Delete and context->Delete paths to use the
same handler, which also fixes the issue where Edit->Delete does not
mark the tab as modified.

Fixes: #11090
