### PR TITLE
Capture and show driver messages during load

### DIFF
--- a/chirp/drivers/radioddity_r2.py
+++ b/chirp/drivers/radioddity_r2.py
@@ -576,7 +576,7 @@ class RadioddityR2(chirp_common.CloneModeRadio):
 
         # extra settings are unfortunately inverted
         for setting in mem.extra:
-            LOG.debug("@set_mem:", setting.get_name(), setting.value)
+            LOG.debug("@set_mem: %s %s", setting.get_name(), setting.value)
             setattr(_mem, setting.get_name(), not setting.value)
 
     def get_settings(self):

--- a/chirp/drivers/th7800.py
+++ b/chirp/drivers/th7800.py
@@ -378,7 +378,7 @@ class TYTTH7800Base(chirp_common.Radio):
         _mem.step = STEPS.index(mem.tuning_step)
 
         for setting in mem.extra:
-            LOG.debug("@set_mem:", setting.get_name(), setting.value)
+            LOG.debug("@set_mem: %s %s", setting.get_name(), setting.value)
             setattr(_mem, setting.get_name(), setting.value)
 
     def get_settings(self):

--- a/chirp/drivers/th_uvf8d.py
+++ b/chirp/drivers/th_uvf8d.py
@@ -632,7 +632,7 @@ class TYTUVF8DRadio(chirp_common.CloneModeRadio):
                     _settings.rxsave = 0
                 continue
             if element.get_name().endswith('_channel'):
-                LOG.debug(element.value, type(element.value))
+                LOG.debug('%s %s', element.value, type(element.value))
                 setattr(_settings, element.get_name(), int(element.value) - 1)
                 continue
             if not isinstance(element, RadioSetting):

--- a/chirp/locale/de.po
+++ b/chirp/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2012-10-02 22:11+0100\n"
 "Last-Translator: Benjamin, HB9EUK <hb9euk@hb9d.org>\n"
 "Language-Team: German\n"
@@ -35,28 +35,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Löschen (und nach oben verschieben)"
 msgstr[1] "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Speicher"
 msgstr[1] "Speicher"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Löschen (und nach oben verschieben)"
 msgstr[1] "Löschen (und nach oben verschieben)"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Datei wurde geändert, speichern Sie die Änderungen vor dem Schliessen?"
@@ -65,7 +65,7 @@ msgstr "Datei wurde geändert, speichern Sie die Änderungen vor dem Schliessen?
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -508,7 +508,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -518,7 +518,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -623,17 +623,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr ""
 
@@ -641,12 +641,12 @@ msgstr ""
 msgid "All"
 msgstr "Alle"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "CSV Datei"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -654,7 +654,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Ein Fehler ist aufgetreten"
 
@@ -666,7 +666,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr ""
 
@@ -694,42 +694,42 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross Mode"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr ""
 
@@ -756,36 +756,36 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Klonen"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Download vom Gerät"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Upload zum Gerät"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -817,7 +817,7 @@ msgstr "Kopieren"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr "Cross Mode"
 
@@ -829,16 +829,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -849,11 +849,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr ""
 
@@ -862,25 +862,25 @@ msgstr ""
 msgid "Dec"
 msgstr "Erkennung"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Entwickler"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr "Digital Code"
 
@@ -889,11 +889,11 @@ msgstr "Digital Code"
 msgid "Digital Modes"
 msgstr "Digital Code"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 #, fuzzy
 msgid "Disabled"
 msgstr "Aktiviert"
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download vom Gerät"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download vom Gerät"
@@ -935,43 +935,47 @@ msgstr "Download vom Gerät"
 msgid "Driver information"
 msgstr ""
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 #, fuzzy
 msgid "Enabled"
 msgstr "Aktiviert"
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frequenz"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -984,7 +988,7 @@ msgstr ""
 msgid "Enter custom port:"
 msgstr ""
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "Lösche Speicher {loc}"
@@ -1003,21 +1007,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Weiter mit dem experimentellen Treiber?"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 #, fuzzy
 msgid "Export to CSV"
 msgstr "In Datei exportieren"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "In Datei exportieren"
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr ""
 
@@ -1044,13 +1048,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 #, fuzzy
 msgid "Files"
 msgstr "_Datei"
@@ -1063,22 +1067,22 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 #, fuzzy
 msgid "Find Next"
 msgstr "RFinder"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 #, fuzzy
 msgid "Find..."
 msgstr "RFinder"
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1121,11 +1125,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1218,7 +1222,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1236,11 +1240,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1258,12 +1262,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Frequenz"
 
@@ -1276,20 +1280,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Zeige RAW Speicher"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Hilfe"
 
@@ -1301,7 +1305,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Überschreiben?"
@@ -1315,10 +1319,14 @@ msgstr ""
 msgid "Import"
 msgstr "Importieren"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importieren von Datei"
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 msgid "Import not recommended"
@@ -1332,11 +1340,11 @@ msgstr "Index"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Zeile oben einfügen"
@@ -1345,7 +1353,7 @@ msgstr "Zeile oben einfügen"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1354,7 +1362,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ungültiger Wert. Muss eine ganze Zahl sein."
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ungültiger Wert für dieses Feld"
@@ -1363,16 +1371,16 @@ msgstr "Ungültiger Wert für dieses Feld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr ""
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Ungültiger Wert für dieses Feld"
@@ -1411,7 +1419,7 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 #, fuzzy
 msgid "Load Module..."
 msgstr "Module laden"
@@ -1421,12 +1429,12 @@ msgstr "Module laden"
 msgid "Load module from issue"
 msgstr "Module laden"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Module laden"
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1457,7 +1465,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Speicher"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1471,7 +1479,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1485,17 +1493,17 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Mode"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 #, fuzzy
 msgid "Module"
 msgstr "Module laden"
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Module laden"
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1504,26 +1512,26 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 #, fuzzy
 msgid "Move Down"
 msgstr "Nach _Unten"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 #, fuzzy
 msgid "Move Up"
 msgstr "Nach _Oben"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 #, fuzzy
 msgid "New version available"
 msgstr "Eine neue Version von CHIRP ist verfügbar:"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Zeile unten einfügen"
@@ -1545,11 +1553,11 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr ""
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Offset"
 
@@ -1569,29 +1577,29 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Aktuell"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Speichervorgaben öffnen"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
@@ -1599,7 +1607,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Vorgaben öffnen {name}"
@@ -1621,7 +1629,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Überschreiben?"
@@ -1637,31 +1645,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1691,7 +1699,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1699,7 +1707,7 @@ msgid ""
 "EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr ""
 
@@ -1711,7 +1719,7 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Leistung"
 
@@ -1720,7 +1728,7 @@ msgstr "Leistung"
 msgid "Press enter to set this in memory"
 msgstr "Fehler beim Setzen der Speicher"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr ""
 
@@ -1728,25 +1736,25 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 #, fuzzy
 msgid "Query Source"
 msgstr "Datenquelle abfragen"
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Gerät"
 
@@ -1778,20 +1786,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1806,50 +1814,50 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Report ist deaktiviert"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 msgid "Restore tabs on start"
 msgstr ""
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 #, fuzzy
 msgid "Saved settings"
 msgstr "Einstellungen"
@@ -1866,7 +1874,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Spalten auswählen"
@@ -1881,7 +1889,7 @@ msgstr "Spalten auswählen"
 msgid "Select Modes"
 msgstr "Spalten auswählen"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1893,54 +1901,54 @@ msgstr ""
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "Zeige RAW Speicher"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "Eingefügter Speicher {number} ist nicht mit diesem Gerät kompatibel weil:"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 #, fuzzy
 msgid "Sort memories"
 msgstr "Überschreiben?"
@@ -1958,7 +1966,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr ""
 
@@ -2008,7 +2016,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 #, fuzzy
 msgid "This Memory"
 msgstr "Zeige RAW Speicher"
@@ -2053,12 +2061,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Löschen (und nach oben verschieben)"
@@ -2084,20 +2092,20 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "Tone"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Tone Mode"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Abstimmungsschritt"
@@ -2112,16 +2120,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Speichervorgaben öffnen"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "Kann Gerät auf {port} nicht erkennen"
@@ -2137,12 +2145,12 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Keine Änderungen bei diesem Modell möglich"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, fuzzy, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Keine Änderungen bei diesem Modell möglich"
@@ -2159,26 +2167,26 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Upload zum Gerät"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Upload zum Gerät"
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr ""
 
@@ -2187,12 +2195,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2206,7 +2214,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr ""
 
@@ -2214,20 +2222,20 @@ msgstr ""
 msgid "Vendor"
 msgstr "Hersteller"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 #, fuzzy
 msgid "View"
 msgstr "_Ansicht"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2256,12 +2264,12 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 #, fuzzy
 msgid "disabled"
 msgstr "Aktiviert"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 #, fuzzy
 msgid "enabled"
 msgstr "Aktiviert"

--- a/chirp/locale/el.po
+++ b/chirp/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2023-02-11 15:12+0200\n"
 "Last-Translator: Sokratis Alichanidis <sv2hzs@posteo.net>\n"
 "Language-Team: Greek\n"
@@ -37,28 +37,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 msgstr[1] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Μνήμες"
 msgstr[1] "Μνήμες"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
 msgstr[1] "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr ""
@@ -67,7 +67,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(καμία)"
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -510,7 +510,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -520,7 +520,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -625,7 +625,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -633,11 +633,11 @@ msgstr ""
 "Μία νέα έκδοση του CHIRP είναι διαθέσιμη. Παρακαλούμε επισκεφθείτε την "
 "ιστοσελίδα το συντομότερο δυνατό για να την κατεβάσετε!"
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "Σχετικά"
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr "Σχετικά με το CHIRP"
 
@@ -645,11 +645,11 @@ msgstr "Σχετικά με το CHIRP"
 msgid "All"
 msgstr "Όλες"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Όλα τα αρχεία"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Όλοι οι τύποι αρχείων|"
 
@@ -657,7 +657,7 @@ msgstr "Όλοι οι τύποι αρχείων|"
 msgid "Amateur"
 msgstr "Ραδιοερασιτέχνη"
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Παρουσιάστηκε ένα σφάλμα"
 
@@ -669,7 +669,7 @@ msgstr "Εφαρμογή ρυθμίσεων"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr "Χάρτης συχνοτήτων"
 
@@ -697,41 +697,41 @@ msgstr "Δημιουργία Περιηγητή Πομποδεκτών"
 msgid "Canada"
 msgstr "Καναδάς"
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Αρχεία ειδώλου CHIRP"
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr "Απαιτείται επιλογή"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Επιλέξτε κωδικό DTCS %s"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Επιλέξτε τόνο %s"
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 #, fuzzy
 msgid "Choose duplex"
 msgstr "Επιλογή duplex"
@@ -759,34 +759,34 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Αντιγραφή"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 msgid "Cloning from radio"
 msgstr "Λήψη από πομποδέκτη"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 msgid "Cloning to radio"
 msgstr "Αποστολή σε πομποδέκτη"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr "Κλείσιμο"
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr "Κλείσιμο αρχείου"
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Σχόλιο"
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr ""
 
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Country"
 msgstr "Χώρα"
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr ""
 
@@ -830,16 +830,16 @@ msgstr "Εισάγετε προσαρμοσμένη θύρα:"
 msgid "Custom..."
 msgstr "Προσαρμοσμένη..."
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 #, fuzzy
 msgid "Cut"
 msgstr "Χώρα"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -851,11 +851,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr "Μνήμη DV"
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr ""
 
@@ -863,24 +863,24 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Λειτουργία προγραμματιστή"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 #, fuzzy
 msgid "Digital Code"
 msgstr "Ψηφιακός Κωδικός"
@@ -890,12 +890,12 @@ msgstr "Ψηφιακός Κωδικός"
 msgid "Digital Modes"
 msgstr "Ψηφιακός Κωδικός"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 #, fuzzy
 msgid "Disable reporting"
 msgstr "Αναφορές απενεργοποιημένες"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr ""
 
@@ -913,15 +913,15 @@ msgstr "Να μην ερωτηθώ ξανά για %s"
 msgid "Double-click to change bank name"
 msgstr "Κάντε διπλό κλικ για μετονομασία της ομάδας μνημών"
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr "Λήψη"
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 msgid "Download from radio"
 msgstr "Λήψη Από Πομποδέκτη"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Λήψη Από Πομποδέκτη"
@@ -934,42 +934,46 @@ msgstr "Οδηγίες λήψης"
 msgid "Driver information"
 msgstr ""
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Επεξεργασία λεπτομερειών για %i μνήμες"
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Επεξεργασία λεπτομερειών για τη μνήμη %i"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 #, fuzzy
 msgid "Enable Automatic Edits"
 msgstr "Ενεργοποίηση αυτόματης επεξεργασίας"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr ""
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 msgid "Enter Frequency"
 msgstr "Εισάγετε συχνότητα"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr "Εισάγετε συχνότητα εκπομπής (MHz)"
 
@@ -982,7 +986,7 @@ msgstr "Εισάγετε ένα νέο όνομα για την ομάδα μν�
 msgid "Enter custom port:"
 msgstr "Εισάγετε προσαρμοσμένη θύρα:"
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, python-format
 msgid "Erased memory %s"
 msgstr "Διεγράφη η μνήμη %s"
@@ -999,20 +1003,20 @@ msgstr "Σφάλμα επικοινωνίας με τον πομποδέκτη"
 msgid "Experimental driver"
 msgstr "Πειραματικός οδηγός"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr "Η εξαγωγή είναι δυνατή μόνο σε αρχεία CSV"
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 msgid "Export to CSV"
 msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr "Περισσότερα"
 
@@ -1040,13 +1044,13 @@ msgstr "Αδυναμία φόρτωσης περιηγητή πομποδεκτ�
 msgid "Features"
 msgstr "Δυνατότητες"
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Το αρχείο δεν υπάρχει: %s"
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 msgid "Files"
 msgstr "Αρχεία"
 
@@ -1058,20 +1062,20 @@ msgstr "Φίλτρο"
 msgid "Filter results with location matching this string"
 msgstr "Φιλτράρισμα αποτελεσμάτων με τοποθεσία σύμφωνη με αυτό το λεκτικό"
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr "Εύρεση"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr "Εύρεση επόμενου"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 #, fuzzy
 msgid "Find..."
 msgstr "Εύρεση"
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Τελείωσε η εργασία %s"
@@ -1114,11 +1118,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1211,7 +1215,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1229,11 +1233,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1251,12 +1255,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Συχνότητα"
 
@@ -1269,20 +1273,20 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Λήψη ρυθμίσεων"
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 msgid "Goto Memory"
 msgstr "Μετάβαση σε Μνήμη"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr "Μετάβαση σε Μνήμη:"
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 #, fuzzy
 msgid "Goto..."
 msgstr "Μετάβαση σε"
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr ""
 
@@ -1294,7 +1298,7 @@ msgstr "Βοήθεια..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Αντικατάσταση μνημών;"
@@ -1308,8 +1312,12 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 msgid "Import from file..."
+msgstr ""
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
 msgstr ""
 
 #: ../wxui/main.py:1341
@@ -1324,11 +1332,11 @@ msgstr ""
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 msgid "Insert Row Above"
 msgstr "Εισαγωγή γραμμής επάνω"
 
@@ -1336,7 +1344,7 @@ msgstr "Εισαγωγή γραμμής επάνω"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 #, fuzzy
 msgid "Interact with driver"
 msgstr "Αλληλεπίδραση με οδηγό"
@@ -1346,7 +1354,7 @@ msgstr "Αλληλεπίδραση με οδηγό"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Μη έγκυρη τιμή: %s"
@@ -1355,16 +1363,16 @@ msgstr "Μη έγκυρη τιμή: %s"
 msgid "Invalid ZIP code"
 msgstr "Μη έγκυρος ΤΚ"
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Μη έγκυρη τιμή: %s"
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr ""
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, python-format
 msgid "Invalid value: %r"
 msgstr "Μη έγκυρη τιμή: %r"
@@ -1405,7 +1413,7 @@ msgstr "Περιορισμός Μπαντών"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 #, fuzzy
 msgid "Load Module..."
 msgstr "Φόρτωση Module"
@@ -1415,12 +1423,12 @@ msgstr "Φόρτωση Module"
 msgid "Load module from issue"
 msgstr "Φόρτωση Module"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Φόρτωση Module"
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1451,7 +1459,7 @@ msgstr "Γεωγραφικό μήκος"
 msgid "Memories"
 msgstr "Μνήμες"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Η μνήμη %i δεν μπορεί να διαγραφεί"
@@ -1465,7 +1473,7 @@ msgstr "Η μνήμη πρέπει να βρίσκεται σε ομάδα γι�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Η μνήμη {num} δεν βρίσκεται στην ομάδα μνημών {bank}"
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 #, fuzzy
 msgid "Mode"
 msgstr "Λειτουργία"
@@ -1478,16 +1486,16 @@ msgstr "Μοντέλο"
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr "Module"
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Module"
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1496,23 +1504,23 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr "Βρέθηκαν περισσότερες από μία θύρες: %s"
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 msgid "Move Down"
 msgstr ""
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 msgid "Move Up"
 msgstr ""
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr "Διαθέσιμη νέα έκδοση"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 msgid "No empty rows below!"
 msgstr "Καμία κενή σειρά από κάτω!"
 
@@ -1534,11 +1542,11 @@ msgstr "Κανένα αποτέλεσμα!"
 msgid "No results!"
 msgstr "Κανένα αποτέλεσμα!"
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr "Αριθμός"
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr ""
 
@@ -1558,27 +1566,27 @@ msgstr "Μόνο οι καρτέλες μνημών μπορούν να εξαχ
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Άνοιγμα"
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 msgid "Open Recent"
 msgstr "Άνοιγμα πρόσφατου"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 msgid "Open Stock Config"
 msgstr "Άνοιγμα προεπιλεγμένων ρυθμίσεων"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Άνοιγμα αρχείου"
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr "Άνοιγμα αρθρώματος"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Άνοιγμα αρχείου καταγραφής αποσφαλμάτωσης"
 
@@ -1586,7 +1594,7 @@ msgstr "Άνοιγμα αρχείου καταγραφής αποσφαλμάτ�
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Άνοιγμα προεπιλεγμένων ρυθμίσεων"
@@ -1608,7 +1616,7 @@ msgstr "Προαιρετικό: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Προαιρετικό: Επαρχία, Νοσοκομείο κλπ"
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 msgid "Overwrite memories?"
 msgstr "Αντικατάσταση μνημών;"
 
@@ -1623,31 +1631,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr ""
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 "Παρακαλούμε βεβαιωθείτε ότι έχετε κλείσει το CHIRP πριν εγκαταστήσετε την "
@@ -1679,7 +1687,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1687,7 +1695,7 @@ msgid ""
 "EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr "Παρακαλώ περιμένετε"
 
@@ -1699,7 +1707,7 @@ msgstr "Συνδέστε το καλώδιο σας και πατήστε OK"
 msgid "Port"
 msgstr "Θύρα"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Ισχύς"
 
@@ -1707,7 +1715,7 @@ msgstr "Ισχύς"
 msgid "Press enter to set this in memory"
 msgstr "Πατήστε enter για καταχώρηση στη μνήμη"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr "Προεπισκόπηση εκτύπωσης"
 
@@ -1715,24 +1723,24 @@ msgstr "Προεπισκόπηση εκτύπωσης"
 msgid "Printing"
 msgstr "Εκτύπωση"
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr "Ιδιότητες"
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr "Ερώτημα %s"
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Ερώτημα Πηγής"
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr "DTCS Λήψης"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Πομποδέκτης"
 
@@ -1763,21 +1771,21 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 #, fuzzy
 msgid "Refresh required"
 msgstr "Απαιτείται επανεκκίνηση"
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Ανανεώθηκε η μνήμη %s"
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Επαναφόρτωση Οδηγού"
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Επαναφόρτωση Οδηγού και Αρχείου"
 
@@ -1791,51 +1799,51 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Αναφορές ενεργοποιημένες"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr "Απαιτείται επανεκκίνηση"
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Επαναφορά %i καρτελών"
 msgstr[1] "Επαναφορά %i καρτελών"
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Επαναφορά %i καρτελών"
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr "Ρυθμίσεις ανακτήθηκαν"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr "Αποθήκευση πριν το κλείσιμο;"
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr "Αποθήκευση αρχείου"
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr "Ρυθμίσεις αποθηκεύθηκαν"
 
@@ -1851,7 +1859,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Επιλογή χάρτη συχνοτήτων"
@@ -1864,7 +1872,7 @@ msgstr "Επιλογή Μπαντών"
 msgid "Select Modes"
 msgstr ""
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr "Επιλογή χάρτη συνοτήτων"
 
@@ -1876,52 +1884,52 @@ msgstr "Υπηρεσία"
 msgid "Settings"
 msgstr "Ρυθμίσεις"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr ""
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Εμφάνιση τοποθεσίας αρχείου καταγραφής αποσφαλμάτωσης"
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 msgid "Some memories are incompatible with this radio"
 msgstr "Κάποιες μνήμες δεν είναι συμβατές με αυτόν τον πομποδέκτη"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr "Κάποιες μνήμες δεν είναι δυνατόν να διαγραφούν"
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 #, fuzzy
 msgid "Sort memories"
 msgstr "Αντικατάσταση μνημών;"
@@ -1939,7 +1947,7 @@ msgstr "Πολιτεία"
 msgid "State/Province"
 msgstr "Πολιτεία / Επαρχία"
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr ""
 
@@ -1989,7 +1997,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 #, fuzzy
 msgid "This Memory"
 msgstr "Μνήμη DV"
@@ -2041,12 +2049,12 @@ msgstr ""
 "δυνατοτήτων!\n"
 "Σας προειδοποιήσαμε. Προχωράτε με δική σας ευθύνη!"
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
@@ -2072,19 +2080,19 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "Τόνος"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Τύπος τόνου"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 msgid "Tone Squelch"
 msgstr "Τόνος Φίμωσης"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 msgid "Tuning Step"
 msgstr "Βήμα συντονισμού"
 
@@ -2098,16 +2106,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 msgid "Unable to open the clipboard"
 msgstr "Αδυναμία ανοίγματος του πρόχειρου"
 
@@ -2122,12 +2130,12 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, fuzzy, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Πατήστε enter για καταχώρηση στη μνήμη"
@@ -2144,25 +2152,25 @@ msgstr "Αποσυνδέστε το καλώδιο σας (αν χρειάζετ
 msgid "Upload instructions"
 msgstr "Οδηγίες αποστολής"
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 msgid "Upload to radio"
 msgstr "Αποστολή Σε Πομποδέκτη"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Αποστολή Σε Πομποδέκτη"
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Απεστάλη η μνήμη %s"
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr "Χρήση γραμματοσειράς σταθερού πλάτους"
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr "Χρήση μεγαλύτερης γραμματοσειράς"
 
@@ -2171,12 +2179,12 @@ msgstr "Χρήση μεγαλύτερης γραμματοσειράς"
 msgid "Value does not fit in %i bits"
 msgstr "Η τιμή δεν χωράει σε %i bits"
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Η τιμή πρέπει να είναι τουλάχιστον %.4f"
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Η τιμή πρέπει να είναι το πολύ  %.4f"
@@ -2190,7 +2198,7 @@ msgstr "Η τιμή πρέπει να έιναι ακριβώς %i δεκαδι�
 msgid "Value must be zero or greater"
 msgstr "Η τιμή πρέπει να είναι μηδέν ή μεγαλύτερη"
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr ""
 
@@ -2198,19 +2206,19 @@ msgstr ""
 msgid "Vendor"
 msgstr "Προμηθευτής"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 msgid "View"
 msgstr "Εμφάνιση"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr "Προειδοποίηση"
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr "Προειδοποίηση: %s"
@@ -2239,11 +2247,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "bytes το καθένα"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/en_US.po
+++ b/chirp/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2011-11-29 16:07-0800\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "_Delete"
 msgstr[1] "_Delete"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "_Delete"
 msgstr[1] "_Delete"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "File is modified, save changes before closing?"
@@ -63,7 +63,7 @@ msgstr "File is modified, save changes before closing?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -506,7 +506,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -516,7 +516,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -621,17 +621,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr ""
 
@@ -639,12 +639,12 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "CSV Files"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -652,7 +652,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr ""
 
@@ -664,7 +664,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr ""
 
@@ -692,41 +692,41 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr ""
 
@@ -753,36 +753,36 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr ""
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Download From Radio"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Upload To Radio"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr ""
 
@@ -804,7 +804,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 #, fuzzy
 msgid "Copy"
 msgstr "_Copy"
@@ -814,7 +814,7 @@ msgstr "_Copy"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr ""
 
@@ -826,16 +826,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 #, fuzzy
 msgid "Cut"
 msgstr "_Cut"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 msgid "DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -845,11 +845,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr ""
 
@@ -857,27 +857,27 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 #, fuzzy
 msgid "Delete"
 msgstr "_Delete"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Developer"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr ""
 
@@ -885,11 +885,11 @@ msgstr ""
 msgid "Digital Modes"
 msgstr ""
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr ""
 
@@ -907,16 +907,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download From Radio"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download From Radio"
@@ -930,41 +930,45 @@ msgstr "Download From Radio"
 msgid "Driver information"
 msgstr ""
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr ""
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 msgid "Enter Frequency"
 msgstr ""
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -977,7 +981,7 @@ msgstr ""
 msgid "Enter custom port:"
 msgstr ""
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "E_xchange"
@@ -994,21 +998,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Import from RFinder"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Import from RFinder"
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr ""
 
@@ -1035,13 +1039,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 #, fuzzy
 msgid "Files"
 msgstr "_File"
@@ -1054,19 +1058,19 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 msgid "Find..."
 msgstr ""
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1109,11 +1113,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1206,7 +1210,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1224,11 +1228,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1246,12 +1250,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr ""
 
@@ -1264,20 +1268,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Show raw memory"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Help"
 
@@ -1289,7 +1293,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Diff raw memories"
@@ -1303,10 +1307,14 @@ msgstr ""
 msgid "Import"
 msgstr "Import"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Import from file..."
 msgstr "Import from RFinder"
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 #, fuzzy
@@ -1321,11 +1329,11 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 msgid "Insert Row Above"
 msgstr ""
 
@@ -1333,7 +1341,7 @@ msgstr ""
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1342,7 +1350,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1350,16 +1358,16 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr ""
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, python-format
 msgid "Invalid value: %r"
 msgstr ""
@@ -1398,7 +1406,7 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 msgid "Load Module..."
 msgstr ""
 
@@ -1406,11 +1414,11 @@ msgstr ""
 msgid "Load module from issue"
 msgstr ""
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1442,7 +1450,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1456,7 +1464,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 msgid "Mode"
 msgstr ""
 
@@ -1468,15 +1476,15 @@ msgstr ""
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1485,25 +1493,25 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 #, fuzzy
 msgid "Move Down"
 msgstr "Move D_n"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 #, fuzzy
 msgid "Move Up"
 msgstr "Move _Up"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 msgid "No empty rows below!"
 msgstr ""
 
@@ -1524,11 +1532,11 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr ""
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr ""
 
@@ -1548,28 +1556,28 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Recent"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 msgid "Open Stock Config"
 msgstr ""
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
@@ -1577,7 +1585,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 msgid "Open stock config directory"
 msgstr ""
 
@@ -1597,7 +1605,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Diff raw memories"
@@ -1613,32 +1621,32 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 #, fuzzy
 msgid "Paste"
 msgstr "_Paste"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1668,7 +1676,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1676,7 +1684,7 @@ msgid ""
 "EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr ""
 
@@ -1688,7 +1696,7 @@ msgstr ""
 msgid "Port"
 msgstr ""
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr ""
 
@@ -1696,7 +1704,7 @@ msgstr ""
 msgid "Press enter to set this in memory"
 msgstr ""
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr ""
 
@@ -1704,24 +1712,24 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr ""
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 #, fuzzy
 msgid "Radio"
 msgstr "_Radio"
@@ -1753,20 +1761,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1780,50 +1788,50 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Reporting is disabled"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 msgid "Restore tabs on start"
 msgstr ""
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr ""
 
@@ -1839,7 +1847,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Select Columns"
@@ -1854,7 +1862,7 @@ msgstr "Select Columns"
 msgid "Select Modes"
 msgstr "Select Columns"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1866,53 +1874,53 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Show raw memory"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 #, fuzzy
 msgid "Sort memories"
 msgstr "Diff raw memories"
@@ -1929,7 +1937,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr ""
 
@@ -1979,7 +1987,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 #, fuzzy
 msgid "This Memory"
 msgstr "Show raw memory"
@@ -2024,12 +2032,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "_Delete"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "_Delete"
@@ -2055,19 +2063,19 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 msgid "Tone Squelch"
 msgstr ""
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 msgid "Tuning Step"
 msgstr ""
 
@@ -2081,16 +2089,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 msgid "Unable to open the clipboard"
 msgstr ""
 
@@ -2105,12 +2113,12 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, python-format
 msgid "Unable to set %s on this memory"
 msgstr ""
@@ -2127,26 +2135,26 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Upload To Radio"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Upload To Radio"
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr ""
 
@@ -2155,12 +2163,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2174,7 +2182,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr ""
 
@@ -2182,20 +2190,20 @@ msgstr ""
 msgid "Vendor"
 msgstr ""
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 #, fuzzy
 msgid "View"
 msgstr "_View"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2224,11 +2232,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/es.po
+++ b/chirp/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2024-01-17 21:19-0300\n"
 "Last-Translator: MELERIX\n"
 "Language-Team: \n"
@@ -43,28 +43,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s debe estar entre %(min)i y %(max)i"
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1591
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Memoria y desplazar todo hacia arriba"
 msgstr[1] "%i Memorias y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1582
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Memoria"
 msgstr[1] "%i Memorias"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1586
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Memoria y desplazar bloque hacia arriba"
 msgstr[1] "%i Memorias y desplazar bloque hacia arriba"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s no ha sido guardado. ¿Guardar antes de cerrar?"
@@ -73,7 +73,7 @@ msgstr "%s no ha sido guardado. ¿Guardar antes de cerrar?"
 msgid "(none)"
 msgstr "(nada)"
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr "...y %i más"
@@ -806,7 +806,7 @@ msgstr ""
 "5. Asegúrate de que la radio esté sintonizada a un canal sin actividad.\n"
 "6. Cliquea Aceptar para cargar la imagen al dispositivo.\n"
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -822,7 +822,7 @@ msgstr ""
 "5. Asegúrate de que la radio esté sintonizada a un canal sin actividad.\n"
 "6. Cliquea Aceptar para descargar la imagen desde dispositivo.\n"
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -995,7 +995,7 @@ msgstr ""
 "\n"
 "Esto podría no funcionar si enciendes la radio con el cable ya conectado"
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -1003,11 +1003,11 @@ msgstr ""
 "Una nueva versión de CHIRP está disponible, ¡Por favor visita el sitio web "
 "tan pronto como sea posible para descargarla!"
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "Acerca de"
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr "Acerca de CHIRP"
 
@@ -1015,11 +1015,11 @@ msgstr "Acerca de CHIRP"
 msgid "All"
 msgstr "Todo"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Todos los archivos"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Todos los formatos soportados|"
 
@@ -1027,7 +1027,7 @@ msgstr "Todos los formatos soportados|"
 msgid "Amateur"
 msgstr "Aficionado"
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Ha ocurrido un error"
 
@@ -1039,7 +1039,7 @@ msgstr "Aplicando ajustes"
 msgid "Available modules"
 msgstr "Módulos disponibles"
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr "Plan de banda"
 
@@ -1067,7 +1067,7 @@ msgstr "Construyendo navegador de radio"
 msgid "Canada"
 msgstr "Canada"
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
@@ -1075,7 +1075,7 @@ msgstr ""
 "Cambiar este ajuste requiere actualizar los ajustes desde la imagen, lo cual "
 "ocurrirá ahora."
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
@@ -1083,29 +1083,29 @@ msgstr ""
 "Canales con TX y RX equivalentes %s son representados por modo de tono de "
 "\"%s\""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Archivos de imagen Chirp"
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr "Elección requerida"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Elegir %s código DTCS"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Elegir %s tono"
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 msgid "Choose Cross Mode"
 msgstr "Elegir modo cruzado"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr "Elegir Dúplex"
 
@@ -1139,34 +1139,34 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Clonado completado, comprobando por bytes espurios"
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Clonando"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 msgid "Cloning from radio"
 msgstr "Clonando desde radio"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 msgid "Cloning to radio"
 msgstr "Clonando a radio"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr "Cerrar"
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr "Cerrar archivo"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1649
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Agrupar %i memoria"
 msgstr[1] "Agrupar %i memorias"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Comentario"
 
@@ -1190,7 +1190,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Convertir a FM"
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "Copiar"
 
@@ -1199,7 +1199,7 @@ msgstr "Copiar"
 msgid "Country"
 msgstr "País"
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr "Modo cruzado"
 
@@ -1211,15 +1211,15 @@ msgstr "Puerto personalizado"
 msgid "Custom..."
 msgstr "Personalizado..."
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -1231,11 +1231,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Decodificación DTMF"
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr "Memoria DV"
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr "Peligro adelante"
 
@@ -1243,26 +1243,26 @@ msgstr "Peligro adelante"
 msgid "Dec"
 msgstr "Decimal"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Modo desarrollador"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Estado de desarrollador ahora está %s. CHIRP debe ser reiniciado para que "
 "tome efecto"
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "Diferenciar memorias en bruto"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr "Código digital"
 
@@ -1270,11 +1270,11 @@ msgstr "Código digital"
 msgid "Digital Modes"
 msgstr "Modos digitales"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr "Deshabilitar reportes"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr "Desahbilitado"
 
@@ -1292,15 +1292,15 @@ msgstr "No preguntar de nuevo para %s"
 msgid "Double-click to change bank name"
 msgstr "Doble clic para cambiar nombre de banco"
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr "Descargar"
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 msgid "Download from radio"
 msgstr "Descargar desde radio"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "Descargar desde radio..."
 
@@ -1312,43 +1312,47 @@ msgstr "Descargar instrucciones"
 msgid "Driver information"
 msgstr "Información del controlador"
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 "Los repetidores digitales de modo dual que soportan análogo se mostrarán "
 "como FM"
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Dúplex"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Editar detalles para %i memorias"
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editar detalles para memoria %i"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Habilitar ediciones automáticas"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 msgid "Enter Frequency"
 msgstr "Ingresar frecuencia"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr "Ingresar desplazamiento (MHz)"
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr "Ingresar frecuencia TX (MHz)"
 
@@ -1361,7 +1365,7 @@ msgstr "Ingresa un nuevo nombre para el banco %s:"
 msgid "Enter custom port:"
 msgstr "Ingresar puerto personalizado:"
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, python-format
 msgid "Erased memory %s"
 msgstr "Memoria borrada %s"
@@ -1378,19 +1382,19 @@ msgstr "Error comunicándose con la radio"
 msgid "Experimental driver"
 msgstr "Controlador experimental"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr "Exportar solo puede escribir archivos CSV"
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 msgid "Export to CSV"
 msgstr "Exportar a CSV"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 msgid "Export to CSV..."
 msgstr "Exportar a CSV..."
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr "Extra"
 
@@ -1420,13 +1424,13 @@ msgstr "Fallo al analizar el resultado"
 msgid "Features"
 msgstr "Caracteristicas"
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr "El archivo no existe: %s"
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 msgid "Files"
 msgstr "Archivos"
 
@@ -1438,19 +1442,19 @@ msgstr "Filtrar"
 msgid "Filter results with location matching this string"
 msgstr "Filtrar resultados con ubicación coincidiendo esta cadena"
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr "Buscar"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr "Buscar siguiente"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 msgid "Find..."
 msgstr "Buscar..."
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Trabajos de radio terminados %s"
@@ -1515,11 +1519,11 @@ msgstr ""
 "5 - ¡Desconecta el cable de interfaz! ¡De lo contrario no habrá\n"
 "    audio del lado derecho!\n"
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1665,7 +1669,7 @@ msgstr ""
 "3 - Enciende tu radio\n"
 "4 - Cliquea Aceptar para iniciar\n"
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1693,11 +1697,11 @@ msgstr ""
 "3 - Enciende tu radio\n"
 "4 - Haz la descarga de tus datos de radio\n"
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1725,12 +1729,12 @@ msgstr ""
 "3 - Enciende tu radio\n"
 "4 - Haz la carga de tus datos de radio\n"
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr "Encontrado valor de lista vacía para %(name)s: %(value)r"
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Frecuencia"
 
@@ -1743,19 +1747,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Obteniendo ajustes"
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 msgid "Goto Memory"
 msgstr "Ir a memoria"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr "Ir a memoria:"
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr "Ir a..."
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Ayuda"
 
@@ -1767,7 +1771,7 @@ msgstr "Ayúdame..."
 msgid "Hex"
 msgstr "Hexadecimal"
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 msgid "Hide empty memories"
 msgstr "Ocultar memorias vacías"
 
@@ -1781,9 +1785,13 @@ msgstr ""
 msgid "Import"
 msgstr "Importar"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 msgid "Import from file..."
 msgstr "Importar desde archivo..."
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 msgid "Import not recommended"
@@ -1797,11 +1805,11 @@ msgstr "Índice"
 msgid "Info"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 msgid "Insert Row Above"
 msgstr "Insertar fila arriba"
 
@@ -1809,7 +1817,7 @@ msgstr "Insertar fila arriba"
 msgid "Install desktop icon?"
 msgstr "¿Instalar icono de escritorio?"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Interactuar con controlador"
 
@@ -1818,7 +1826,7 @@ msgstr "Interactuar con controlador"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s inválido (usa grados decimales)"
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 msgid "Invalid Entry"
 msgstr "Entrada inválida"
 
@@ -1826,16 +1834,16 @@ msgstr "Entrada inválida"
 msgid "Invalid ZIP code"
 msgstr "Código postal inválido"
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Edición inválida: %s"
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr "Archivo de módulo inválido o no soportado"
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, python-format
 msgid "Invalid value: %r"
 msgstr "Valor inválido: %r"
@@ -1874,7 +1882,7 @@ msgstr "Estado límite"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Limitar resultados a esta distancia (km) desde coordenadas"
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 msgid "Load Module..."
 msgstr "Cargar modulo..."
 
@@ -1882,11 +1890,11 @@ msgstr "Cargar modulo..."
 msgid "Load module from issue"
 msgstr "Cargar módulo desde problema"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 msgid "Load module from issue..."
 msgstr "Cargar módulo desde problema..."
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1923,7 +1931,7 @@ msgstr "Longitud"
 msgid "Memories"
 msgstr "Memorias"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoria %i no es borrable"
@@ -1937,7 +1945,7 @@ msgstr "La memoria debe estar en un banco para ser editada"
 msgid "Memory {num} not in bank {bank}"
 msgstr "La memoria {num} no está en banco {bank}"
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 msgid "Mode"
 msgstr "Modo"
 
@@ -1949,15 +1957,15 @@ msgstr "Modelo"
 msgid "Modes"
 msgstr "Modos"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr "Modulo"
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr "Módulo cargado"
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr "Módulo cargado exitosamente"
 
@@ -1966,23 +1974,23 @@ msgstr "Módulo cargado exitosamente"
 msgid "More than one port found: %s"
 msgstr "Más de un puerto encontrado: %s"
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 msgid "Move Down"
 msgstr "Mover abajo"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 msgid "Move Up"
 msgstr "Mover arriba"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr "Nueva versión disponible"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 msgid "No empty rows below!"
 msgstr "¡No hay filas vacías debajo!"
 
@@ -2003,11 +2011,11 @@ msgstr "No hay resultados"
 msgid "No results!"
 msgstr "¡No hay resultados!"
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr "Numero"
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Desplazamiento"
 
@@ -2027,27 +2035,27 @@ msgstr "Solo pestañas de memorias pueden ser exportadas"
 msgid "Only working repeaters"
 msgstr "Sólo repetidores funcionando"
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Abrir"
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 msgid "Open Recent"
 msgstr "Abrir reciente"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 msgid "Open Stock Config"
 msgstr "Abrir configuración original"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Abrir un archivo"
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr "Abrir un modulo"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Abrir registro de depuración"
 
@@ -2055,7 +2063,7 @@ msgstr "Abrir registro de depuración"
 msgid "Open in new window"
 msgstr "Abrir en nueva ventana"
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 msgid "Open stock config directory"
 msgstr "Abrir directorio de configuración original"
 
@@ -2075,7 +2083,7 @@ msgstr "Opcional: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcional: Condado, Hospital, etc."
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 msgid "Overwrite memories?"
 msgstr "¿Sobrescribir memorias?"
 
@@ -2093,31 +2101,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Analizando"
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Las memorias pegadas sobrescribirán %s memorias existentes"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Las memorias pegadas sobrescribirán memorias %s"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Las memorias pegadas sobrescribirán la memoria %s"
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria pegada sobrescribirá la memoria %s"
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 "¡Por favor asegúrate de salir de CHIRP antes de instalar la nueva versión!"
@@ -2166,7 +2174,7 @@ msgstr ""
 "4 - Entonces presiona el botón \"A\" en tu radio para iniciar la clonación.\n"
 "    (Al final la radio emitirá un pitido)\n"
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2179,7 +2187,7 @@ msgstr ""
 "tu radio si no se usan con EXTREMO cuidado. ¡has sido advertido! ¿Proceder "
 "de todos modos?"
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr "Por favor espera"
 
@@ -2191,7 +2199,7 @@ msgstr "Conecta tu cable y luego haz clic en ACEPTAR"
 msgid "Port"
 msgstr "Puerto"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Poder"
 
@@ -2199,7 +2207,7 @@ msgstr "Poder"
 msgid "Press enter to set this in memory"
 msgstr "Presiona enter para configurar esto en memoria"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr "Previsualización de impresión"
 
@@ -2207,24 +2215,24 @@ msgstr "Previsualización de impresión"
 msgid "Printing"
 msgstr "Imprimiendo"
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr "Consulta %s"
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Consultar fuente"
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Radio"
 
@@ -2263,20 +2271,20 @@ msgstr ""
 "de comunicaciones de radio mas largo del mundo\n"
 "<small>Requiere cuenta premium</small>"
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr "Actualización requerida"
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Memoria actualizada %s"
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Recargar controlador"
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Recargar controlador y archivo"
 
@@ -2292,11 +2300,11 @@ msgstr ""
 "RepeaterBook es el directorio GRATUITO de repetidores,\n"
 "mundial, de Radio Aficionados más completo."
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Reportes habilitados"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2306,39 +2314,39 @@ msgstr ""
 "plataformas de SO gastar nuestros limitados esfuerzos. Apreciamos mucho si "
 "lo dejas habilitado. ¿Realmente deshabilitar reportes?"
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr "Reinicio requerido"
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Restaurar %i pestaña"
 msgstr[1] "Restaurar %i pestañas"
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Restaurar %i pestañas"
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr "Ajustes recuperados"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr "Guardar"
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr "¿Guardar antes de cerrar?"
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr "Guardar archivo"
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr "Ajustes guardados"
 
@@ -2354,7 +2362,7 @@ msgstr "Codificador"
 msgid "Security Risk"
 msgstr "Riesgo de seguridad"
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "Seleccionar plan de banda..."
 
@@ -2366,7 +2374,7 @@ msgstr "Seleccionar bandas"
 msgid "Select Modes"
 msgstr "Seleccionar modos"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr "Seleccionar plan de banda"
 
@@ -2378,52 +2386,52 @@ msgstr "Servicio"
 msgid "Settings"
 msgstr "Ajustes"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "Mostrar memoria en bruto"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Mostrar ubicación del registro de depuración"
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr "Mostrar campos adicionales"
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 msgid "Some memories are incompatible with this radio"
 msgstr "Algunas memorias son incompatibles con esta radio"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr "Algunas memorias no son borrables"
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1634
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Ordenar %i memoria"
 msgstr[1] "Ordenar %i memorias"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1638
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Ordenar %i memoria de forma ascendente"
 msgstr[1] "Ordenar %i memorias de forma ascendente"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1660
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Ordenar %i memoria de forma descendente"
 msgstr[1] "Ordenar %i memorias de forma descendente"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr "Ordenar por columna:"
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 msgid "Sort memories"
 msgstr "Ordenar memorias"
 
@@ -2439,7 +2447,7 @@ msgstr "Estado"
 msgid "State/Province"
 msgstr "Estado/Provincia"
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr "Éxito"
 
@@ -2517,7 +2525,7 @@ msgstr ""
 "abrir este archivo para copiar/pegar memorias a través de este, o proceder "
 "con la importación?"
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 msgid "This Memory"
 msgstr "Esta memoria"
 
@@ -2580,11 +2588,11 @@ msgstr ""
 "¡También por favor envía en solicitudes de errores y mejoras!\n"
 "Has sido advertido. ¡Procede bajo tu propio riesgo!"
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 msgid "This memory and shift all up"
 msgstr "Esta memoria y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 msgid "This memory and shift block up"
 msgstr "Esta memoria y desplazar bloque hacia arriba"
 
@@ -2619,19 +2627,19 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr "Esto va a cargar un módulo desde un problema del sitio web"
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "Tono"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Modo de tono"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 msgid "Tone Squelch"
 msgstr "Silenciador de tono"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 msgid "Tuning Step"
 msgstr "Paso de sintonización"
 
@@ -2647,16 +2655,16 @@ msgstr ""
 "No se puede determinar puerto para tu cable. Comprueba tus controladores y "
 "conexiones."
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr "No se puede editar memoria antes de que la radio este cargada"
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "No se puede buscar la configuración original %r"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 msgid "Unable to open the clipboard"
 msgstr "No se puede abrir el portapapeles"
 
@@ -2674,12 +2682,12 @@ msgstr ""
 "seleccionado es de EE.UU pero la radio no es una de EE.UU (o de banda "
 "ancha). Por favor elije el modelo correcto e intenta de nuevo."
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "No se puede revelar %s en este sistema"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, python-format
 msgid "Unable to set %s on this memory"
 msgstr "No se puede establecer %s en esta memoria"
@@ -2696,24 +2704,24 @@ msgstr "Desconecta tu cable (si es necesario) y entonces haz clic en ACEPTAR"
 msgid "Upload instructions"
 msgstr "Cargar instrucciones"
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 msgid "Upload to radio"
 msgstr "Cargar a radio"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "Cargar a radio..."
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Memoria cargada %s"
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr "Usar fuente de ancho fijo"
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr "Usar fuente más grande"
 
@@ -2722,12 +2730,12 @@ msgstr "Usar fuente más grande"
 msgid "Value does not fit in %i bits"
 msgstr "Valor no cabe en %i bits"
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Valor debe ser al menos %.4f"
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Valor debe ser como máximo %.4f"
@@ -2741,7 +2749,7 @@ msgstr "Valor debe ser exactamente %i dígitos decimales"
 msgid "Value must be zero or greater"
 msgstr "Valor debe ser cero o superior"
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr "Valores"
 
@@ -2749,19 +2757,19 @@ msgstr "Valores"
 msgid "Vendor"
 msgstr "Vendedor"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 msgid "View"
 msgstr "Ver"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr "¡ADVERTENCIA!"
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr "Advertencia: %s"
@@ -2790,11 +2798,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "bytes cada"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr "habilitado"
 

--- a/chirp/locale/fr.po
+++ b/chirp/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2023-12-13 00:03+0100\n"
 "Last-Translator: Matthieu Lapadu-Hargues <mlhpub@free.fr>\n"
 "Language-Team: French\n"
@@ -41,28 +41,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s doit etre entre %(min)i et %(max)i"
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Memoires et tout changer"
 msgstr[1] "%i Memoires et tout changer"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Memoires"
 msgstr[1] "%i Memoires"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Memoires et tout decaler vers le haut"
 msgstr[1] "%i Memoires et tout decaler vers le haut"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s n'a pas ete enregistre. Enregistrer avant de fermer?"
@@ -71,7 +71,7 @@ msgstr "%s n'a pas ete enregistre. Enregistrer avant de fermer?"
 msgid "(none)"
 msgstr "(vide)"
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr "...et %i plus"
@@ -514,7 +514,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -524,7 +524,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -629,7 +629,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -637,11 +637,11 @@ msgstr ""
 "Une nouvelle version de CHIRP est disponible. Visitez le site internet des "
 "que possible pour la telecharger!"
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "A propos"
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr "A propos de CHIRP"
 
@@ -649,11 +649,11 @@ msgstr "A propos de CHIRP"
 msgid "All"
 msgstr "Tout"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Tous fichiers"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Tours formats supportes|"
 
@@ -661,7 +661,7 @@ msgstr "Tours formats supportes|"
 msgid "Amateur"
 msgstr "Amateur"
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Une erreur s'est produite"
 
@@ -673,7 +673,7 @@ msgstr "Application des preferences"
 msgid "Available modules"
 msgstr "Modules disponibles"
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr "Plan de frequences"
 
@@ -701,7 +701,7 @@ msgstr "Etablissement navigateur radio"
 msgid "Canada"
 msgstr "Canada"
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
@@ -709,7 +709,7 @@ msgstr ""
 "Modifier ce parametre necessite de refraichir tous les parametres depuis "
 "l'image, ce qui va etre fait maintenant."
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
@@ -717,29 +717,29 @@ msgstr ""
 "Les canaux avec TX et RX equivalents %s sont representes par le mode de "
 "tonalite de \"%s\""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Fichiers image Chirp"
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr "Choix necessaire"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Choisir %s DTCS Code"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Choisir %s Tone"
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 msgid "Choose Cross Mode"
 msgstr "Choisir cross mode"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr "Choisir duplex"
 
@@ -772,34 +772,34 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Clonage termine, verification des octets parasites"
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Clonage"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 msgid "Cloning from radio"
 msgstr "Telechargement depuis la radio - Lire"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 msgid "Cloning to radio"
 msgstr "Telechargement vers la radio - Ecrire"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr "Fermer"
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr "Fermer fichier"
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Groupement %i memoires"
 msgstr[1] "Groupement %i memoires"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -823,7 +823,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Convertir en FM"
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "Copier"
 
@@ -832,7 +832,7 @@ msgstr "Copier"
 msgid "Country"
 msgstr "Pays"
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr "Cross mode"
 
@@ -844,15 +844,15 @@ msgstr "Personnalisation du port"
 msgid "Custom..."
 msgstr "Personnalisation..."
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "Couper"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -864,11 +864,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr "Memoire DV"
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr "Danger devant"
 
@@ -876,26 +876,26 @@ msgstr "Danger devant"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Mode developpeur"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Le mode developpement est maintenant %s. CHIRP doit etre redemarre pour que "
 "ceci prenne effet"
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "Comparaison memoires brutes"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr "Digital Code"
 
@@ -903,11 +903,11 @@ msgstr "Digital Code"
 msgid "Digital Modes"
 msgstr "Modes numeriques"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr "Desactiver le rapport d'utilisation"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr "Descative"
 
@@ -925,15 +925,15 @@ msgstr "Ne plus demander pendant %s"
 msgid "Double-click to change bank name"
 msgstr "Double-cliquer pour modifier le nom de la banque"
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr "Telecharger"
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 msgid "Download from radio"
 msgstr "Telecharger depuis la radio - Lire"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "Telecharger depuis la radio - Lire..."
 
@@ -946,43 +946,47 @@ msgstr "Instructions de telechargement"
 msgid "Driver information"
 msgstr "Informations de la radio"
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 "Les repeteurs numeriques bimodes supportant l'analogique seront presentes "
 "comme FM"
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Editer les details pour %i memoires"
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editer les details pour la memoire %i"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Aciter l'edition automatique"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr "Active"
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 msgid "Enter Frequency"
 msgstr "Entrer la frequence"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr "Saisir le decalage (MHz)"
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr "Saisir la frequence d'emission (MHz)"
 
@@ -995,7 +999,7 @@ msgstr "Saisir un nouveau nom pour la banque %s:"
 msgid "Enter custom port:"
 msgstr "Saisir un port personnalise:"
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, python-format
 msgid "Erased memory %s"
 msgstr "Effacer la memoire %s"
@@ -1012,19 +1016,19 @@ msgstr "Erreur de communication avec la radio"
 msgid "Experimental driver"
 msgstr "Pilote experimental"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr "L'exportation ne peut ecrire que des fichiers CSV"
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 msgid "Export to CSV"
 msgstr "Exporter vers un fichier CSV"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 msgid "Export to CSV..."
 msgstr "Exporter vers un fichier CSV..."
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr "Extra"
 
@@ -1055,13 +1059,13 @@ msgstr "Echec d'analyse des resultats"
 msgid "Features"
 msgstr "Caracteristiques"
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Fichier inexistant: %s"
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 msgid "Files"
 msgstr "Fichiers"
 
@@ -1075,19 +1079,19 @@ msgstr ""
 "Filtrer les resultats avec emplacement correspondant a cette chaine de "
 "caracteres"
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr "Rechercher"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr "Rechercher le suivant"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 msgid "Find..."
 msgstr "Rechercher..."
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Tache radio terminee %s"
@@ -1130,11 +1134,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1227,7 +1231,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1245,11 +1249,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1267,12 +1271,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr "Liste de valeurs vide trouvee pour %(name)s: %(value)r"
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Frequence"
 
@@ -1285,19 +1289,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Acquisition des preferences"
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 msgid "Goto Memory"
 msgstr "Aller a la memoire"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr "Aller a la memoire:"
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr "Aller..."
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Aide"
 
@@ -1309,7 +1313,7 @@ msgstr "Aidez moi..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 msgid "Hide empty memories"
 msgstr "Cacher les memoires vides"
 
@@ -1323,9 +1327,13 @@ msgstr ""
 msgid "Import"
 msgstr "Importer"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 msgid "Import from file..."
 msgstr "Importer depuis un fichier..."
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 msgid "Import not recommended"
@@ -1339,11 +1347,11 @@ msgstr "Index"
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr "Information"
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 msgid "Insert Row Above"
 msgstr "Inserer une ligne avant"
 
@@ -1351,7 +1359,7 @@ msgstr "Inserer une ligne avant"
 msgid "Install desktop icon?"
 msgstr "Installer une icone sur le bureau?"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Interaction avec le pilote"
 
@@ -1360,7 +1368,7 @@ msgstr "Interaction avec le pilote"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Invalide %(value)s (utiliser degres decimaux)"
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 msgid "Invalid Entry"
 msgstr "Entree invalide"
 
@@ -1368,16 +1376,16 @@ msgstr "Entree invalide"
 msgid "Invalid ZIP code"
 msgstr "Code postal invalide"
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Edition invalide: %s"
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr "Fichier module invalide ou pas supporte"
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, python-format
 msgid "Invalid value: %r"
 msgstr "Valeur invalide: %r"
@@ -1416,7 +1424,7 @@ msgstr "Limites les etats"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Limite les resultats a cette distance (km) depuis les coordonnees"
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 msgid "Load Module..."
 msgstr "Chargement module..."
 
@@ -1424,11 +1432,11 @@ msgstr "Chargement module..."
 msgid "Load module from issue"
 msgstr "Chargement module depuis un probleme"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 msgid "Load module from issue..."
 msgstr "Chargement module depuis un probleme..."
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1465,7 +1473,7 @@ msgstr "Longitude"
 msgid "Memories"
 msgstr "Memoires"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoire %i n'est pas supprimable"
@@ -1479,7 +1487,7 @@ msgstr "La memoire doit entre dans une banque pour etre editee"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Memoire {num} pas dans la banque {bank}"
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 msgid "Mode"
 msgstr "Mode"
 
@@ -1491,15 +1499,15 @@ msgstr "Modele"
 msgid "Modes"
 msgstr "Modes"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr "Module"
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr "Module charge"
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr "Module charge avec succes"
 
@@ -1508,23 +1516,23 @@ msgstr "Module charge avec succes"
 msgid "More than one port found: %s"
 msgstr "Plus d'un port trouve: %s"
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 msgid "Move Down"
 msgstr "Descendre"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 msgid "Move Up"
 msgstr "Monter"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr "Nouvelle fenetre"
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr "Nouvelle version disponible"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 msgid "No empty rows below!"
 msgstr "Pas de ligne vide dessous!"
 
@@ -1545,11 +1553,11 @@ msgstr "Aucun resultat"
 msgid "No results!"
 msgstr "Aucun resultat!"
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr "Nombre"
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Decalage"
 
@@ -1569,27 +1577,27 @@ msgstr "Seuls les onglets des memoires peuvent etre exportes"
 msgid "Only working repeaters"
 msgstr "Uniquement les repeteurs en fonctionnement"
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Ouvrir"
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 msgid "Open Recent"
 msgstr "Ouvrir recent"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 msgid "Open Stock Config"
 msgstr "Ouvrir base de donnees"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Ouvrir un fichier"
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr "Ouvrir un module"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Ouvrir le fichier de debogage"
 
@@ -1597,7 +1605,7 @@ msgstr "Ouvrir le fichier de debogage"
 msgid "Open in new window"
 msgstr "Ouvrir dans une nouvelle fenetre"
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 msgid "Open stock config directory"
 msgstr "Ouvrir le repertoire de base de donnees"
 
@@ -1617,7 +1625,7 @@ msgstr "Optionnel: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Optionnel: County, Hospital, etc."
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 msgid "Overwrite memories?"
 msgstr "Ecraser les memoires?"
 
@@ -1635,31 +1643,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Analyse"
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "Coller"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Les memoires collees vont ecraser %s memoires existantes"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Les memoires collees vont ecraser les memoires %s"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Les memoires collees vont ecraser la memoire %s"
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoire collee va ecraser la memoire %s"
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Soyez certain de quitter CHIRP avant d'installer la nouvelle version!"
 
@@ -1708,7 +1716,7 @@ msgstr ""
 "clonage\n"
 "    (A la fin la radio va sonner)\n"
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1721,7 +1729,7 @@ msgstr ""
 "endommager votre ordinateur et votre radio s'ils ne sont pas utilises avec "
 "un EXTREME soin. Vous etes prevenu! Continuer malgré tout?"
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr "Patientez s'il vous plait"
 
@@ -1733,7 +1741,7 @@ msgstr "Branchez votre cable et cliquez sur OK"
 msgid "Port"
 msgstr "Port"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Puissance"
 
@@ -1741,7 +1749,7 @@ msgstr "Puissance"
 msgid "Press enter to set this in memory"
 msgstr "Appuyez sur entree pour inscrire ceci en memoire"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr "Apercu avant impression"
 
@@ -1749,24 +1757,24 @@ msgstr "Apercu avant impression"
 msgid "Printing"
 msgstr "Impression"
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr "Proprietes"
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr "Interroger %s"
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Interroger Source"
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Radio"
 
@@ -1800,20 +1808,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr "Rafraichissement necessaire"
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Rafraichir la memoire %s"
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Recharger pilote"
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Recharger pilote et fichier"
 
@@ -1827,11 +1835,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Rapport d'utilisation active"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -1842,39 +1850,39 @@ msgstr ""
 "la. Nous apprecierions vraiment que vous le laissiez actif. Etes-vous "
 "certain de vouloir desactiver le rapport d'utilisation?"
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr "Redemarrage necessaire"
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Restaurer %i onglets"
 msgstr[1] "Restaurer %i onglets"
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Restaurer %i onglets"
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr "Preferences recuperees"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr "Enregistrer"
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr "Enregistrer avant de fermer?"
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr "Enregistrer fichier"
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr "Preferences enregistrees"
 
@@ -1890,7 +1898,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr "Risque de securite"
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "Choix d'un plan de frequences..."
 
@@ -1902,7 +1910,7 @@ msgstr "Choix des bandes"
 msgid "Select Modes"
 msgstr "Choix des modes"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr "Choix d'un plan de frequences"
 
@@ -1914,52 +1922,52 @@ msgstr "Service"
 msgid "Settings"
 msgstr "Preferences"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "Afficher les donnees de memoires brutes"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Montrer l'emplacement du fichier de debogage"
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr "Montrer les champs supplementaires"
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 msgid "Some memories are incompatible with this radio"
 msgstr "Des memoires sont incompatibles avec cette radio"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr "Des memoires ne sont pas supprimables"
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Tri %i memoires"
 msgstr[1] "Tri %i memoires"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Tri  croissant %i memoires"
 msgstr[1] "Tri  croissant %i memoires"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Tri  decroissant %i memoires"
 msgstr[1] "Tri  decroissant %i memoires"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr "Tri par colonne:"
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 msgid "Sort memories"
 msgstr "Tri des memoires"
 
@@ -1975,7 +1983,7 @@ msgstr "Etat"
 msgid "State/Province"
 msgstr "Etat/Province"
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr "Reussi"
 
@@ -2055,7 +2063,7 @@ msgstr ""
 "%(file)s. Souhaitez-vous ouvrir ce fichier pour copier/coller entre eux ou "
 "l'importer?"
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 msgid "This Memory"
 msgstr "Cette memoire"
 
@@ -2112,11 +2120,11 @@ msgstr ""
 "Envoyez aussi vos demandes d'ameliorations ou rapports de bogues!\n"
 "Vous avez ete prevenu. Procedez a vos risques et perils!"
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 msgid "This memory and shift all up"
 msgstr "Remonter ces memoires et decalage"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 msgid "This memory and shift block up"
 msgstr "Bloquer cette memoire et le decalage"
 
@@ -2154,19 +2162,19 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr "Ceci chargera un module a partir d'un site web"
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "Tone"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Tone Mode"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 msgid "Tone Squelch"
 msgstr "Tone Squelch"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 msgid "Tuning Step"
 msgstr "Pas de reglage"
 
@@ -2182,16 +2190,16 @@ msgstr ""
 "Impossible de determiner le port de votre cable. Verifiez les pilotes et "
 "connexions."
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Impossible d'editer une memoire avant telechargement de la radio"
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Impossible de trouver la configuration de base %r"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 msgid "Unable to open the clipboard"
 msgstr "Impossible d'ouvrir le presse-papier"
 
@@ -2209,12 +2217,12 @@ msgstr ""
 "modele selectionne est US mais que la radio n'est pas US (ou large-bande). "
 "Selectionnez le bon modele et reessayez."
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Impossible de montrer %s dans ce systeme"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Impossible de regler %s dans cette memoire"
@@ -2231,24 +2239,24 @@ msgstr "Debranchez votre cable (si necessaire) et cliquez sur OK"
 msgid "Upload instructions"
 msgstr "Instruction de telechargement"
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 msgid "Upload to radio"
 msgstr "Telecharger vers la radio"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "Telecharger vers la radio..."
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Memoire telechargee %s"
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr "Utiliser une police a chasse fixe"
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr "Utiliser une plus grande police"
 
@@ -2257,12 +2265,12 @@ msgstr "Utiliser une plus grande police"
 msgid "Value does not fit in %i bits"
 msgstr "La valeur ne correspond pas a %i bits"
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "La valeur doit etre d'au moins %.4f"
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "La valeur ne doit pas depasser %.4f"
@@ -2276,7 +2284,7 @@ msgstr "La valeur doit comporter exactement %i decimales"
 msgid "Value must be zero or greater"
 msgstr "Les valeur doivent etre zero ou positives"
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr "Valeurs"
 
@@ -2284,19 +2292,19 @@ msgstr "Valeurs"
 msgid "Vendor"
 msgstr "Fabricant"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 msgid "View"
 msgstr "Voir"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr "ATTENTION!"
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr "Attention"
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr "Attention: %s"
@@ -2327,11 +2335,11 @@ msgstr "octets"
 msgid "bytes each"
 msgstr "octets chacun"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr "desactive"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr "active"
 

--- a/chirp/locale/hu.po
+++ b/chirp/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2015-01-28 13:47+0100\n"
 "Last-Translator: Attila Joubert <joubert.attila@gmail.com>\n"
 "Language-Team: English\n"
@@ -34,28 +34,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "... és a tömböt felfelé lépteti"
 msgstr[1] "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memória"
 msgstr[1] "Memória"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "... és a tömböt felfelé lépteti"
 msgstr[1] "... és a tömböt felfelé lépteti"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "A fájl megváltozott! Menti bezárás előtt?"
@@ -64,7 +64,7 @@ msgstr "A fájl megváltozott! Menti bezárás előtt?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, fuzzy, python-format
 msgid "...and %i more"
 msgstr "...és minden memória felfelé lép"
@@ -507,7 +507,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -517,7 +517,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -622,17 +622,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr ""
 
@@ -640,12 +640,12 @@ msgstr ""
 msgid "All"
 msgstr "Mind"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "CSV fájlok"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -653,7 +653,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Hiba történt"
 
@@ -665,7 +665,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr ""
 
@@ -693,42 +693,42 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "RX DTCS kód"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Kereszt-üzem"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr ""
 
@@ -755,36 +755,36 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Klónozás"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Letöltés a rádióról"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Megjegyzés"
 
@@ -807,7 +807,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "Másolás"
 
@@ -816,7 +816,7 @@ msgstr "Másolás"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr "Kereszt-üzem"
 
@@ -828,16 +828,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "Kivágás"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS pol."
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -848,12 +848,12 @@ msgstr "DTCS pol."
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 #, fuzzy
 msgid "DV Memory"
 msgstr "ez a memória"
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr ""
 
@@ -862,25 +862,25 @@ msgstr ""
 msgid "Dec"
 msgstr "Érzékelés"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Fejlesztői"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr "Digitális kód"
 
@@ -889,11 +889,11 @@ msgstr "Digitális kód"
 msgid "Digital Modes"
 msgstr "Digitális kód"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 #, fuzzy
 msgid "Disabled"
 msgstr "Engedélyezve"
@@ -912,16 +912,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 #, fuzzy
 msgid "Download from radio"
 msgstr "Letöltés a rádióról"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Letöltés a rádióról"
@@ -935,43 +935,47 @@ msgstr "{name} Utasítások"
 msgid "Driver information"
 msgstr ""
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, fuzzy, python-format
 msgid "Edit details for %i memories"
 msgstr "Több memória szerkesztése"
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 #, fuzzy
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frekvencia"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -984,7 +988,7 @@ msgstr ""
 msgid "Enter custom port:"
 msgstr ""
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "A(z) {loc}. memóriahely törlése"
@@ -1003,21 +1007,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Folytassam kísérleti driver-rel?"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Export fájlba"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Export fájlba"
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr ""
 
@@ -1044,13 +1048,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 #, fuzzy
 msgid "Files"
 msgstr "_Fájl"
@@ -1063,22 +1067,22 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 #, fuzzy
 msgid "Find Next"
 msgstr "RFinder"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 #, fuzzy
 msgid "Find..."
 msgstr "RFinder"
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1121,11 +1125,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1218,7 +1222,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1236,11 +1240,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1258,12 +1262,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Frekvencia"
 
@@ -1277,21 +1281,21 @@ msgstr ""
 msgid "Getting settings"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 #, fuzzy
 msgid "Goto Memory"
 msgstr "ez a memória"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 #, fuzzy
 msgid "Goto Memory:"
 msgstr "ez a memória"
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Súgó"
 
@@ -1303,7 +1307,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Felülírja?"
@@ -1317,10 +1321,14 @@ msgstr ""
 msgid "Import"
 msgstr "Importálás"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importálás fájlból"
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 msgid "Import not recommended"
@@ -1334,12 +1342,12 @@ msgstr "Sorszám"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 #, fuzzy
 msgid "Information"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Memória beszúrása fölé"
@@ -1348,7 +1356,7 @@ msgstr "Memória beszúrása fölé"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1357,7 +1365,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Érvénytelen érték! Egész szám kell legyen."
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Érvénytelen érték %s"
@@ -1366,16 +1374,16 @@ msgstr "Érvénytelen érték %s"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "Érvénytelen érték %s"
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr ""
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Érvénytelen %s mezőérték"
@@ -1414,7 +1422,7 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 #, fuzzy
 msgid "Load Module..."
 msgstr "Modul betöltése"
@@ -1424,12 +1432,12 @@ msgstr "Modul betöltése"
 msgid "Load module from issue"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1460,7 +1468,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Memória"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1474,7 +1482,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 #, fuzzy
 msgid "Mode"
 msgstr "Mód"
@@ -1488,17 +1496,17 @@ msgstr "Modell"
 msgid "Modes"
 msgstr "Mód"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 #, fuzzy
 msgid "Module"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1507,26 +1515,26 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 #, fuzzy
 msgid "Move Down"
 msgstr "Lefel_é"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 #, fuzzy
 msgid "Move Up"
 msgstr "Fe_lfelé"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 #, fuzzy
 msgid "New version available"
 msgstr "A CHIRP egy új verziója érhető el:"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Memória beszúrása alá"
@@ -1548,11 +1556,11 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr ""
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Offszet"
 
@@ -1572,29 +1580,29 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 #, fuzzy
 msgid "Open Recent"
 msgstr "Leg_utóbbi"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "A csoportos beállítás megnyitása"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
@@ -1602,7 +1610,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "A(z) {name} konfigurációs készlet megnyitása"
@@ -1624,7 +1632,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Felülírja?"
@@ -1640,31 +1648,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1694,7 +1702,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1702,7 +1710,7 @@ msgid ""
 "EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr ""
 
@@ -1714,7 +1722,7 @@ msgstr ""
 msgid "Port"
 msgstr "Port"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Teljesítmény"
 
@@ -1723,7 +1731,7 @@ msgstr "Teljesítmény"
 msgid "Press enter to set this in memory"
 msgstr "Memória beállítási hiba"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr ""
 
@@ -1731,26 +1739,26 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, fuzzy, python-format
 msgid "Query %s"
 msgstr "Lekérdezés hiba"
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 #, fuzzy
 msgid "Query Source"
 msgstr "Lekérd. adatforrása"
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 #, fuzzy
 msgid "RX DTCS"
 msgstr "RX DTCS kód"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Rádió"
 
@@ -1782,20 +1790,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, fuzzy, python-format
 msgid "Refreshed memory %s"
 msgstr "ezek a memóriák"
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1809,50 +1817,50 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Listázás letiltva"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 msgid "Restore tabs on start"
 msgstr ""
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 #, fuzzy
 msgid "Saved settings"
 msgstr "Beállítás"
@@ -1869,7 +1877,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Oszlopok kiválasztása"
@@ -1884,7 +1892,7 @@ msgstr "Oszlopok kiválasztása"
 msgid "Select Modes"
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1896,55 +1904,55 @@ msgstr ""
 msgid "Settings"
 msgstr "Beállítás"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "Memóriasor mutatása"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "A beillesztett {number}. számú memória nem kompatibilis ezzel a rádióval, "
 "mert:"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 #, fuzzy
 msgid "Sort memories"
 msgstr "Felülírja?"
@@ -1962,7 +1970,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr ""
 
@@ -2012,7 +2020,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 #, fuzzy
 msgid "This Memory"
 msgstr "ez a memória"
@@ -2057,12 +2065,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "... és a tömböt felfelé lépteti"
@@ -2088,20 +2096,20 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "CTCSS"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Hang (CTCSS) mód"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Lépésköz"
@@ -2116,16 +2124,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "A csoportos beállítás megnyitása"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "Nem érzékelek a {port} porton!"
@@ -2141,12 +2149,12 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Ennél a modellnél nem változtatható"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, fuzzy, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Ennél a modellnél nem változtatható"
@@ -2164,26 +2172,26 @@ msgstr ""
 msgid "Upload instructions"
 msgstr "{instructions}"
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr ""
 
@@ -2192,12 +2200,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2211,7 +2219,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr ""
 
@@ -2219,20 +2227,20 @@ msgstr ""
 msgid "Vendor"
 msgstr "Gyártó"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 #, fuzzy
 msgid "View"
 msgstr "Né_zet"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2261,12 +2269,12 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 #, fuzzy
 msgid "disabled"
 msgstr "Engedélyezve"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 #, fuzzy
 msgid "enabled"
 msgstr "Engedélyezve"

--- a/chirp/locale/it.po
+++ b/chirp/locale/it.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:22+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2024-01-20 12:24+0100\n"
 "Last-Translator: Daniele Forsi <iu5hkx@gmail.com>\n"
 "Language-Team: \n"
@@ -35,28 +35,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s deve essere tra %(min)i e %(max)i"
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i memoria e sposta tutto su"
 msgstr[1] "%i memorie e sposta tutto su"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i memoria"
 msgstr[1] "%i memorie"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i memoria e sposta il blocco su"
 msgstr[1] "%i memoria e sposta il blocco su"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s non è stato salvato. Salvarlo prima di chiudere?"
@@ -65,7 +65,7 @@ msgstr "%s non è stato salvato. Salvarlo prima di chiudere?"
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr "...e altri %i"
@@ -508,7 +508,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -518,7 +518,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -623,7 +623,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -631,11 +631,11 @@ msgstr ""
 "È disponibile una nuova versione di CHIRP. Visitare il sito web prima "
 "possibile per scaricarla!"
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "Informazioni"
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr "Informazioni su CHIRP"
 
@@ -643,11 +643,11 @@ msgstr "Informazioni su CHIRP"
 msgid "All"
 msgstr "Tutto"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Tutti i file"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Tutti i formati supportati|"
 
@@ -655,7 +655,7 @@ msgstr "Tutti i formati supportati|"
 msgid "Amateur"
 msgstr "Radioamatore"
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Si è verificato un errore"
 
@@ -667,7 +667,7 @@ msgstr ""
 msgid "Available modules"
 msgstr "Moduli disponibili"
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr ""
 
@@ -695,41 +695,41 @@ msgstr ""
 msgid "Canada"
 msgstr "Canada"
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "File immagine di Chirp"
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr "Scelta richiesta"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Scegliere il codice DTCS %s"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Scegliere il Tono %s"
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 msgid "Choose Cross Mode"
 msgstr "Scegliere il modo Cross"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr "Scegliere il duplex"
 
@@ -756,34 +756,34 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Programmazione"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 msgid "Cloning from radio"
 msgstr "Clonazione dalla radio"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 msgid "Cloning to radio"
 msgstr "Clonazione verso la radio"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr "Chiudi"
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr "Chiude il file"
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Raggruppa %i memoria"
 msgstr[1] "Raggruppa %i memorie"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Commento"
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Converti in FM"
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "Copia"
 
@@ -814,7 +814,7 @@ msgstr "Copia"
 msgid "Country"
 msgstr "Nazione"
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr "Modo cross"
 
@@ -826,15 +826,15 @@ msgstr "Porta personalizzata"
 msgid "Custom..."
 msgstr "Personalizza..."
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "Taglia"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -846,11 +846,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr "Memoria DV"
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr ""
 
@@ -858,24 +858,24 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Elimina"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Modalità sviluppatore"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "Diff memorie grezze"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr ""
 
@@ -883,11 +883,11 @@ msgstr ""
 msgid "Digital Modes"
 msgstr "Modi digitali"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr "Disabilitata"
 
@@ -905,15 +905,15 @@ msgstr "Non mostrarlo più per %s"
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr "Scarica"
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 msgid "Download from radio"
 msgstr "Scarica dalla radio"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "Scarica dalla radio..."
 
@@ -925,43 +925,47 @@ msgstr "Istruzioni per lo scaricamento"
 msgid "Driver information"
 msgstr "Informazioni sul driver"
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 "I ripetitori digitali dual-mode che supportano l'analogico saranno mostrati "
 "come FM"
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Modifica dettagli per %i memorie"
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Modifica dettagli per la memoria %i"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Abilita modifiche automatiche"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr "Abilitata"
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 msgid "Enter Frequency"
 msgstr "Inserire la frequenza"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr "Inserire l'offset (MHz)"
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr "Inserire la frequenza TX (MHz)"
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Enter custom port:"
 msgstr "Inserire la porta personalizzata:"
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, python-format
 msgid "Erased memory %s"
 msgstr "Memoria %s cancellata"
@@ -992,19 +996,19 @@ msgstr "Errore durante la comunicazione con la radio"
 msgid "Experimental driver"
 msgstr "Driver sperimentale"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr "L'esportazione può scrivere solo file CSV"
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 msgid "Export to CSV"
 msgstr "Esporta in CSV"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 msgid "Export to CSV..."
 msgstr "Esporta in CSV..."
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr ""
 
@@ -1034,13 +1038,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Il file non esiste: %s"
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 msgid "Files"
 msgstr "File"
 
@@ -1052,19 +1056,19 @@ msgstr "Filtro"
 msgid "Filter results with location matching this string"
 msgstr "Filtra i risultati con i luoghi che corrispondono a questa stringa"
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr "Trova"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr "Trova successivo"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 msgid "Find..."
 msgstr "Trova..."
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1107,11 +1111,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1204,7 +1208,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1222,11 +1226,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1244,12 +1248,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Frequenza"
 
@@ -1262,19 +1266,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 msgid "Goto Memory"
 msgstr "Vai alla memoria"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr "Vai alla memoria:"
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr "Vai..."
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Aiuto"
 
@@ -1286,7 +1290,7 @@ msgstr "Aiutami..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 msgid "Hide empty memories"
 msgstr "Nascondi memorie vuote"
 
@@ -1300,9 +1304,13 @@ msgstr ""
 msgid "Import"
 msgstr "Importa"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 msgid "Import from file..."
 msgstr "Importa da file..."
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 msgid "Import not recommended"
@@ -1316,11 +1324,11 @@ msgstr "Indice"
 msgid "Info"
 msgstr "Informazioni"
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr "Informazioni"
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 msgid "Insert Row Above"
 msgstr "Inserisci riga sopra"
 
@@ -1328,7 +1336,7 @@ msgstr "Inserisci riga sopra"
 msgid "Install desktop icon?"
 msgstr "Installare l'icona per il desktop?"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1337,7 +1345,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Valore %(value)s non valido (usare gradi decimali)"
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 msgid "Invalid Entry"
 msgstr "Valore non valido"
 
@@ -1345,16 +1353,16 @@ msgstr "Valore non valido"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Modifica non valida: %s"
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr ""
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, python-format
 msgid "Invalid value: %r"
 msgstr "Valore non valido: %r"
@@ -1393,7 +1401,7 @@ msgstr "Limita stato"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Limita i risultati a questa distanza (km) dalle coordinate"
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 msgid "Load Module..."
 msgstr "Carica modulo..."
 
@@ -1401,11 +1409,11 @@ msgstr "Carica modulo..."
 msgid "Load module from issue"
 msgstr ""
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1436,7 +1444,7 @@ msgstr "Longitudine"
 msgid "Memories"
 msgstr "Memorie"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoria %i non è eliminabile"
@@ -1450,7 +1458,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 msgid "Mode"
 msgstr "Modo"
 
@@ -1462,15 +1470,15 @@ msgstr "Modello"
 msgid "Modes"
 msgstr "Modi"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr "Modulo"
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr "Modulo caricato"
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr "Modulo caricato con successo"
 
@@ -1479,23 +1487,23 @@ msgstr "Modulo caricato con successo"
 msgid "More than one port found: %s"
 msgstr "Trovata più di una porta: %s"
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 msgid "Move Down"
 msgstr "Sposta giù"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 msgid "Move Up"
 msgstr "Sposta su"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr "Nuova finestra"
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr "Nuova versione disponibile"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 msgid "No empty rows below!"
 msgstr ""
 
@@ -1516,11 +1524,11 @@ msgstr "Nessun risultato"
 msgid "No results!"
 msgstr "Nessun risultato!"
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr "Numero"
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Offset"
 
@@ -1540,27 +1548,27 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr "Solo ripetitori funzionanti"
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Apri"
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 msgid "Open Recent"
 msgstr "Apri recente"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 msgid "Open Stock Config"
 msgstr "Apri configurazione standard"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Apri file"
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr "Apri modulo"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Apri registro di debug"
 
@@ -1568,7 +1576,7 @@ msgstr "Apri registro di debug"
 msgid "Open in new window"
 msgstr "Apri in nuova finestra"
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 msgid "Open stock config directory"
 msgstr "Apri directory configurazioni standard"
 
@@ -1588,7 +1596,7 @@ msgstr "Opzionale: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opzionale: contea, ospedale, ecc."
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 msgid "Overwrite memories?"
 msgstr "Sovrascrivere le memorie?"
 
@@ -1603,31 +1611,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "Incolla"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Le memorie incollate sovrascriveranno %s memorie esistenti"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Le memorie incollate sovrascriveranno le memorie %s"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Le memorie incollate sovrascriveranno la memoria %s"
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria incollata sovrascrivera la memoria %s"
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Assicurarsi di uscire da CHIRP prima di installare la nuova versione!"
 
@@ -1657,7 +1665,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1665,7 +1673,7 @@ msgid ""
 "EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr "Attendere"
 
@@ -1677,7 +1685,7 @@ msgstr "Collegare il cavo e premere OK"
 msgid "Port"
 msgstr "Porta"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Potenza"
 
@@ -1685,7 +1693,7 @@ msgstr "Potenza"
 msgid "Press enter to set this in memory"
 msgstr "Premere Invio per impostarlo in memoria"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr "Anteprima di stampa"
 
@@ -1693,24 +1701,24 @@ msgstr "Anteprima di stampa"
 msgid "Printing"
 msgstr "Stampa in corso"
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr "Proprietà"
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr "Interroga %s"
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Interroga fonte"
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Radio"
 
@@ -1741,20 +1749,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1770,49 +1778,49 @@ msgstr ""
 "RepeaterBook è l'elenco mondiale e GRATUITO\n"
 "più completo di ripetitori per radioamatori."
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Reporting abilitato"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr "Riavvio richiesto"
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Ripristina %i scheda"
 msgstr[1] "Ripristina %i schede"
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 msgid "Restore tabs on start"
 msgstr "Ripristina schede all'avvio"
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr "Impostazioni recuperate"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr "Salva"
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr "Salvare prima di chiudere?"
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr "Salva file"
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr "Impostazioni salvate"
 
@@ -1828,7 +1836,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr "Rischio di sicurezza"
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "Seleziona bandplan..."
 
@@ -1840,7 +1848,7 @@ msgstr "Selezionare le bande"
 msgid "Select Modes"
 msgstr "Selezionare i modi"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr "Selezionare un bandplan"
 
@@ -1852,52 +1860,52 @@ msgstr "Servizio"
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "Mostra memoria grezza"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Mostra posizione di debug"
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr "Mostra campi aggiuntivi"
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 msgid "Some memories are incompatible with this radio"
 msgstr "Alcune memorie sono incompatibili con questa radio"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr "Alcune memorie non sono cancellabili"
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Ordina %i memoria"
 msgstr[1] "Ordina %i memorie"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "%i memoria in ordine decrescente"
 msgstr[1] "%i memorie in ordine decrescente"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "%i memoria in ordine decrescente"
 msgstr[1] "%i memorie in ordine decrescente"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr "Colonna per l'ordinamento:"
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 msgid "Sort memories"
 msgstr "Ordina memorie"
 
@@ -1913,7 +1921,7 @@ msgstr "Stato"
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr "Successo"
 
@@ -1963,7 +1971,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 msgid "This Memory"
 msgstr "Questa memoria"
 
@@ -2007,11 +2015,11 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 msgid "This memory and shift all up"
 msgstr "Questa memoria e sposta tutto in alto"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 msgid "This memory and shift block up"
 msgstr "Questa memoria e sposta il blocco in alto"
 
@@ -2036,19 +2044,19 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "Tono"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Modalità tono"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 msgid "Tone Squelch"
 msgstr "Tone squelch"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 msgid "Tuning Step"
 msgstr "Step sintonia"
 
@@ -2064,16 +2072,16 @@ msgstr ""
 "Impossibile determinare la porta per il cavo. Controllare i driver e i "
 "collegamenti."
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Impossibile modificare la memoria prima di averla caricata dalla radio"
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Impossibile trovare la configurazione standard %r"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 msgid "Unable to open the clipboard"
 msgstr "Impossibile aprire gli appunti"
 
@@ -2088,12 +2096,12 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Impossibile rivelare %s su questo sistema"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Impossibile impostare %s su questa memoria"
@@ -2110,24 +2118,24 @@ msgstr "Scollegare il cavo (se necessario) e poi premere OK"
 msgid "Upload instructions"
 msgstr "Istruzioni per il caricamento"
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 msgid "Upload to radio"
 msgstr "Carica sulla radio"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "Carica sulla radio..."
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr "Usa carattere a larghezza fissa"
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr "Usa carattere più grande"
 
@@ -2136,12 +2144,12 @@ msgstr "Usa carattere più grande"
 msgid "Value does not fit in %i bits"
 msgstr "Il valore non entra in %i bit"
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Il valore deve essere almeno %.4f"
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Il valore deve essere al massimo %.4f"
@@ -2155,7 +2163,7 @@ msgstr "Il valore deve essere di esattamente %i cifre decimali"
 msgid "Value must be zero or greater"
 msgstr "Il valore deve essere maggiore o uguale a zero"
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr "Valori"
 
@@ -2163,19 +2171,19 @@ msgstr "Valori"
 msgid "Vendor"
 msgstr "Produttore"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 msgid "View"
 msgstr "Visualizza"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2204,11 +2212,11 @@ msgstr "byte"
 msgid "bytes each"
 msgstr "byte ciascuno"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/ja_JP.po
+++ b/chirp/locale/ja_JP.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2023-12-03 11:04+0900\n"
 "Last-Translator: weboo <weboo@users.noreply.github.com>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
@@ -33,25 +33,25 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i 件削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i 件の内容を削除"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i 件削除してグループを上方向にシフト"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s は保存されていません。保存しますか？"
@@ -60,7 +60,7 @@ msgstr "%s は保存されていません。保存しますか？"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -503,7 +503,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -513,7 +513,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -630,7 +630,7 @@ msgstr ""
 "\n"
 "ケーブルを接続した状態で電源オンにするとうまく動かない場合があります。"
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -638,11 +638,11 @@ msgstr ""
 "新しいバージョンのCHIRPが利用可能です。できるだけ早く更新されることをお勧めし"
 "ます。今すぐ更新しますか？"
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "このアプリについて"
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr "CHIRP について"
 
@@ -650,11 +650,11 @@ msgstr "CHIRP について"
 msgid "All"
 msgstr "すべて"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr ""
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -662,7 +662,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr "バンドプラン"
 
@@ -702,41 +702,41 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr ""
 
@@ -763,33 +763,33 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr ""
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 msgid "Cloning from radio"
 msgstr ""
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 msgid "Cloning to radio"
 msgstr ""
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr "閉じる"
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr "ファイルを閉じる"
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "%i 件を同一グループにまとめる"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "コメント"
 
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "コピー"
 
@@ -820,7 +820,7 @@ msgstr "コピー"
 msgid "Country"
 msgstr "国"
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr ""
 
@@ -832,15 +832,15 @@ msgstr "ポートを手動で設定"
 msgid "Custom..."
 msgstr "カスタム..."
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "切り取り"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 msgid "DTCS"
 msgstr ""
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -850,11 +850,11 @@ msgstr "DTCS極性"
 msgid "DTMF decode"
 msgstr "DTMF デコード"
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr ""
 
@@ -862,24 +862,24 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "削除"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "開発者モード"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr ""
 
@@ -887,11 +887,11 @@ msgstr ""
 msgid "Digital Modes"
 msgstr ""
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr "診断レポート送信を停止"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr ""
 
@@ -909,15 +909,15 @@ msgstr "次回から %s に接続する際にプロンプトを表示しない"
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr "ダウンロード"
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 msgid "Download from radio"
 msgstr "無線機からダウンロード"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "無線機からダウンロード..."
 
@@ -929,41 +929,45 @@ msgstr "ダウンロード手順"
 msgid "Driver information"
 msgstr "ドライバー情報"
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "値を自動設定"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr ""
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 msgid "Enter Frequency"
 msgstr "周波数を入力"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -976,7 +980,7 @@ msgstr ""
 msgid "Enter custom port:"
 msgstr "ポートを入力:"
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, python-format
 msgid "Erased memory %s"
 msgstr ""
@@ -993,19 +997,19 @@ msgstr "無線機との通信エラー"
 msgid "Experimental driver"
 msgstr "実験的ドライバー"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 msgid "Export to CSV"
 msgstr "CSVにエクスポート"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 msgid "Export to CSV..."
 msgstr "CSVにエクスポート..."
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr ""
 
@@ -1032,13 +1036,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 msgid "Files"
 msgstr ""
 
@@ -1050,19 +1054,19 @@ msgstr "フィルター"
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr "検索"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr "次を検索"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 msgid "Find..."
 msgstr "検索..."
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1105,11 +1109,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1202,7 +1206,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1220,11 +1224,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1242,12 +1246,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "周波数(MHz)"
 
@@ -1260,19 +1264,19 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 msgid "Goto Memory"
 msgstr "行移動"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr "指定した行に移動:"
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr "行移動..."
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "ヘルプ"
 
@@ -1284,7 +1288,7 @@ msgstr "ポートが不明の場合..."
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 msgid "Hide empty memories"
 msgstr "空のメモリーを非表示"
 
@@ -1297,9 +1301,13 @@ msgstr ""
 msgid "Import"
 msgstr "インポート"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 msgid "Import from file..."
 msgstr "ファイルからインポート..."
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 msgid "Import not recommended"
@@ -1313,11 +1321,11 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 msgid "Insert Row Above"
 msgstr "上に1行追加"
 
@@ -1325,7 +1333,7 @@ msgstr "上に1行追加"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1334,7 +1342,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1342,16 +1350,16 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr ""
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, python-format
 msgid "Invalid value: %r"
 msgstr ""
@@ -1390,7 +1398,7 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 msgid "Load Module..."
 msgstr ""
 
@@ -1398,11 +1406,11 @@ msgstr ""
 msgid "Load module from issue"
 msgstr ""
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1433,7 +1441,7 @@ msgstr "軽度"
 msgid "Memories"
 msgstr "メモリー"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1447,7 +1455,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 msgid "Mode"
 msgstr "受信モード"
 
@@ -1459,15 +1467,15 @@ msgstr "モデル"
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1476,23 +1484,23 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 msgid "Move Down"
 msgstr "下に移動"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 msgid "Move Up"
 msgstr "上に移動"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr "新規ウィンドウ"
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr "新しいバージョンが利用可能です"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 msgid "No empty rows below!"
 msgstr ""
 
@@ -1513,11 +1521,11 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr "行"
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "オフセット"
 
@@ -1537,27 +1545,27 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr "開く"
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 msgid "Open Recent"
 msgstr "最近使ったファイル"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 msgid "Open Stock Config"
 msgstr ""
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "ファイルを開く"
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
@@ -1565,7 +1573,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr "新しいウィンドウで開く"
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 msgid "Open stock config directory"
 msgstr ""
 
@@ -1585,7 +1593,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 msgid "Overwrite memories?"
 msgstr "メモリーを上書きしますか？"
 
@@ -1600,31 +1608,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "ペースト"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "新しいバージョンをインストールする前に必ずCHIRPを終了してください。"
 
@@ -1654,7 +1662,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1662,7 +1670,7 @@ msgid ""
 "EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr "お待ちください"
 
@@ -1674,7 +1682,7 @@ msgstr "ケーブルを接続してOKをクリックしてください。"
 msgid "Port"
 msgstr "ポート"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "出力"
 
@@ -1682,7 +1690,7 @@ msgstr "出力"
 msgid "Press enter to set this in memory"
 msgstr ""
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr "印刷プレビュー"
 
@@ -1690,24 +1698,24 @@ msgstr "印刷プレビュー"
 msgid "Printing"
 msgstr "印刷"
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr "プロパティ"
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr ""
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "無線機"
 
@@ -1738,20 +1746,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "%s 件のメモリーを取得しました"
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1765,11 +1773,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "診断レポート送信"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -1779,38 +1787,38 @@ msgstr ""
 "かを判断するのに役立ちます。このまま有効にしておいていただけると有り難いで"
 "す。本当に無効にしますか？"
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr "再起動が必要です"
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "最近閉じた%i個のタブを開く"
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "最近閉じた%i個のタブを開く"
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr "設定を取得しました"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr "保存"
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr "保存しますか？"
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr "ファイルに保存"
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr "設定を保存"
 
@@ -1826,7 +1834,7 @@ msgstr "スクランブル"
 msgid "Security Risk"
 msgstr "セキュリティリスク"
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "バンドプランを選択..."
 
@@ -1838,7 +1846,7 @@ msgstr ""
 msgid "Select Modes"
 msgstr ""
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr "バンドプラン選択"
 
@@ -1850,49 +1858,49 @@ msgstr "サービス"
 msgid "Settings"
 msgstr "設定"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr ""
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr "追加フィールドを表示"
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "昇順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "降順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr "カラムを選択"
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 msgid "Sort memories"
 msgstr "並び替え"
 
@@ -1908,7 +1916,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr "成功"
 
@@ -1963,7 +1971,7 @@ msgstr ""
 "に置き換えます。このファイルを開いて「メモリ」をコピー＆ペーストしますか？そ"
 "れともインポートを続けますか？"
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 msgid "This Memory"
 msgstr "この行の内容を削除"
 
@@ -2015,11 +2023,11 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 msgid "This memory and shift all up"
 msgstr "この行を削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 msgid "This memory and shift block up"
 msgstr "この行を削除してグループを上方向にシフト"
 
@@ -2044,19 +2052,19 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "トーン(Hz)"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "トーンモード"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 msgid "Tone Squelch"
 msgstr "トーンスケルチ"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 msgid "Tuning Step"
 msgstr "ステップ(kHz)"
 
@@ -2072,16 +2080,16 @@ msgstr ""
 "ポートを検出できませんでした。ドライバーがインストールされているかと接続状態"
 "をもう一度確認してください。"
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 msgid "Unable to open the clipboard"
 msgstr ""
 
@@ -2096,12 +2104,12 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, python-format
 msgid "Unable to set %s on this memory"
 msgstr ""
@@ -2118,24 +2126,24 @@ msgstr "ケーブルを抜いてからOKをクリックしてください。"
 msgid "Upload instructions"
 msgstr "アップロード手順"
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 msgid "Upload to radio"
 msgstr "無線機にアップロード"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "無線機にアップロード..."
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr "固定幅フォントを使用"
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr "大きいフォントを使用"
 
@@ -2144,12 +2152,12 @@ msgstr "大きいフォントを使用"
 msgid "Value does not fit in %i bits"
 msgstr "値は %i bitにしてください"
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "値は %.4f 以上にしてください"
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "値は %.4f 以下にしてください"
@@ -2163,7 +2171,7 @@ msgstr "値は %i 桁にしてください"
 msgid "Value must be zero or greater"
 msgstr "値は 0 以上にしてください"
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr "値"
 
@@ -2171,19 +2179,19 @@ msgstr "値"
 msgid "Vendor"
 msgstr "メーカー"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 msgid "View"
 msgstr "表示"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2212,11 +2220,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr "無効"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr "有効"
 

--- a/chirp/locale/nl.po
+++ b/chirp/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2012-03-18 12:01+0100\n"
 "Last-Translator: Michael Tel <m.tel@xs4all.nl>\n"
 "Language-Team: Dutch\n"
@@ -34,28 +34,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Verwijderen (en naar boven verplaatsen)"
 msgstr[1] "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Kanalen"
 msgstr[1] "Kanalen"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Verwijderen (en naar boven verplaatsen)"
 msgstr[1] "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Het bestand is aangepast. Wilt u de wijzigingen opslaan?"
@@ -64,7 +64,7 @@ msgstr "Het bestand is aangepast. Wilt u de wijzigingen opslaan?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -507,7 +507,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -517,7 +517,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -622,17 +622,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr ""
 
@@ -640,12 +640,12 @@ msgstr ""
 msgid "All"
 msgstr "Alles"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "Komma gescheiden bestanden"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -653,7 +653,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Er is een fout opgetreden"
 
@@ -665,7 +665,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr ""
 
@@ -693,42 +693,42 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS code"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross-mode"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr ""
 
@@ -755,36 +755,36 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Klonen"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Download van radio"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Naar radio uploaden"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Opmerking"
 
@@ -807,7 +807,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "Kopiëren"
 
@@ -816,7 +816,7 @@ msgstr "Kopiëren"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 #, fuzzy
 msgid "Cross mode"
 msgstr "Cross-mode"
@@ -829,16 +829,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "Knippen"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -849,11 +849,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr ""
 
@@ -862,25 +862,25 @@ msgstr ""
 msgid "Dec"
 msgstr "Detecteren"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Ontwerper"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr "Digitale code"
 
@@ -889,11 +889,11 @@ msgstr "Digitale code"
 msgid "Digital Modes"
 msgstr "Digitale code"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr ""
 
@@ -911,16 +911,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download van radio"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download van radio"
@@ -934,42 +934,46 @@ msgstr "Download van radio"
 msgid "Driver information"
 msgstr ""
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr ""
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frequentie"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -982,7 +986,7 @@ msgstr ""
 msgid "Enter custom port:"
 msgstr ""
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "Wis kanaal {loc}"
@@ -1000,21 +1004,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Exporteren naar bestand"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Exporteren naar bestand"
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr ""
 
@@ -1041,13 +1045,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 #, fuzzy
 msgid "Files"
 msgstr "_Bestanden"
@@ -1060,19 +1064,19 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 msgid "Find..."
 msgstr ""
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1115,11 +1119,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1212,7 +1216,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1230,11 +1234,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1252,12 +1256,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Frequentie"
 
@@ -1270,20 +1274,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Toon ruw kanaal"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Help"
 
@@ -1295,7 +1299,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Overschrijven?"
@@ -1309,10 +1313,14 @@ msgstr ""
 msgid "Import"
 msgstr "Importeren"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importeren van bestand"
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 #, fuzzy
@@ -1327,11 +1335,11 @@ msgstr "Index"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Regel hierboven invoegen"
@@ -1340,7 +1348,7 @@ msgstr "Regel hierboven invoegen"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1349,7 +1357,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ongeldige waarde. Het moet een integer zijn."
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ongeldige waarde voor dit veld"
@@ -1358,16 +1366,16 @@ msgstr "Ongeldige waarde voor dit veld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr ""
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Ongeldige waarde voor dit veld"
@@ -1406,7 +1414,7 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 #, fuzzy
 msgid "Load Module..."
 msgstr "Toonmodus"
@@ -1416,12 +1424,12 @@ msgstr "Toonmodus"
 msgid "Load module from issue"
 msgstr "Toonmodus"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Toonmodus"
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1452,7 +1460,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Kanalen"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1466,7 +1474,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1480,15 +1488,15 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Mode"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1497,25 +1505,25 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 #, fuzzy
 msgid "Move Down"
 msgstr "Verplaats omlaa_g"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 #, fuzzy
 msgid "Move Up"
 msgstr "Verplaats om_hoog"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Regel hieronder invoegen"
@@ -1537,11 +1545,11 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr ""
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Offset"
 
@@ -1561,29 +1569,29 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Recent"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Openen aanwezige configuratie"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
@@ -1591,7 +1599,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Openen van aanwezige configuratie {name}"
@@ -1613,7 +1621,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Overschrijven?"
@@ -1629,31 +1637,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "Plakken"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1683,7 +1691,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1691,7 +1699,7 @@ msgid ""
 "EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr ""
 
@@ -1703,7 +1711,7 @@ msgstr ""
 msgid "Port"
 msgstr "Poort"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Vermogen"
 
@@ -1712,7 +1720,7 @@ msgstr "Vermogen"
 msgid "Press enter to set this in memory"
 msgstr "Fout bij het instellen van het geheugen"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr ""
 
@@ -1720,24 +1728,24 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr ""
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Radio"
 
@@ -1769,20 +1777,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1797,50 +1805,50 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Rapportering is uitgeschakeld"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 msgid "Restore tabs on start"
 msgstr ""
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr ""
 
@@ -1856,7 +1864,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Kolommen selecteren"
@@ -1871,7 +1879,7 @@ msgstr "Kolommen selecteren"
 msgid "Select Modes"
 msgstr "Kolommen selecteren"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1883,53 +1891,53 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "Toon ruw kanaal"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Geplakt kanaal {number} is niet compatibel met deze radio omdat:"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 #, fuzzy
 msgid "Sort memories"
 msgstr "Overschrijven?"
@@ -1946,7 +1954,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr ""
 
@@ -1996,7 +2004,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 #, fuzzy
 msgid "This Memory"
 msgstr "Toon ruw kanaal"
@@ -2041,12 +2049,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
@@ -2072,20 +2080,20 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "Toon"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Toonmodus"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "Toon squelch"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Kanaal-afstand"
@@ -2100,16 +2108,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Openen aanwezige configuratie"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "Niet in staat om de radio op {port} te detecteren"
@@ -2125,12 +2133,12 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Niet in staat om wijzigingen voor dit model te maken"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, fuzzy, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Niet in staat om wijzigingen voor dit model te maken"
@@ -2147,26 +2155,26 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Naar radio uploaden"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Naar radio uploaden"
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr ""
 
@@ -2175,12 +2183,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2194,7 +2202,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr ""
 
@@ -2202,20 +2210,20 @@ msgstr ""
 msgid "Vendor"
 msgstr "Merk"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 #, fuzzy
 msgid "View"
 msgstr "Bee_ld"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2244,11 +2252,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/pl.po
+++ b/chirp/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2023-07-12 21:21+0200\n"
 "Last-Translator: szporwolik\n"
 "Language-Team: Polish\n"
@@ -35,7 +35,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s muszą być pomiędzy %(min)i oraz %(max)i"
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -43,7 +43,7 @@ msgstr[0] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[1] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[2] "%i pamięci oraz przesuń wszystkie do góry"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -51,7 +51,7 @@ msgstr[0] "%i pamięci"
 msgstr[1] "%i pamięci"
 msgstr[2] "%i pamięci"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -59,7 +59,7 @@ msgstr[0] "%i pamięci oraz przesuń blok do góry"
 msgstr[1] "%i pamięci oraz przesuń blok do góry"
 msgstr[2] "%i pamięci oraz przesuń blok do góry"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s nie został zapisany. Zapisać przed zamknięciem?"
@@ -68,7 +68,7 @@ msgstr "%s nie został zapisany. Zapisać przed zamknięciem?"
 msgid "(none)"
 msgstr "(brak)"
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr "...oraz %i więcej"
@@ -511,7 +511,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -521,7 +521,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -638,7 +638,7 @@ msgstr ""
 "\n"
 "Obraz może nie działać, jeśli radio zostanie włączone z podłączonym kablem"
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -646,11 +646,11 @@ msgstr ""
 "Nowa wersja programu CHIRP jest dostępna. Odwiedź stronę internetową "
 "projektu i pobierz ją!"
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "O programie"
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr "O programie CHIRP"
 
@@ -658,11 +658,11 @@ msgstr "O programie CHIRP"
 msgid "All"
 msgstr "Wszystkie"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Wszystkie pliki"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Wszystkie wspierane formaty|"
 
@@ -670,7 +670,7 @@ msgstr "Wszystkie wspierane formaty|"
 msgid "Amateur"
 msgstr "Amatorska"
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Wystąpił błąd"
 
@@ -682,7 +682,7 @@ msgstr "Stosowanie ustawień"
 msgid "Available modules"
 msgstr "Dostępne moduły"
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr "Bandplan"
 
@@ -710,7 +710,7 @@ msgstr "Budowanie przeglądarki radiostacji"
 msgid "Canada"
 msgstr "Kanada"
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
@@ -718,36 +718,36 @@ msgstr ""
 "Zmiana tego ustawienia wymaga odświeżenia z obrazu, co zostanie teraz "
 "wykonane."
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 "Kanały z takim samym TX oraz RX %s są reprezentowane trybem tonu \"%s\""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Pliki obrazu CHIRP"
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr "Wymagany wybór"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Wybierz %s kod DTCS "
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Wybierz %s ton"
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 msgid "Choose Cross Mode"
 msgstr "Wybierz tryb krzyżowy"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr "Wybierz duplex"
 
@@ -774,27 +774,27 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Klonowane zakończone, sprawdzanie niewłaściwych bajtów"
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Klonowanie"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 msgid "Cloning from radio"
 msgstr "Pobieranie z radiostacji"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 msgid "Cloning to radio"
 msgstr "Wysyłanie do radiostacji"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr "Zamknij"
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr "Zamknij plik"
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -802,7 +802,7 @@ msgstr[0] "Grupuj %i pamięci"
 msgstr[1] "Grupuj %i pamięci"
 msgstr[2] "Grupuj %i pamięci"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -824,7 +824,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "Kopiuj"
 
@@ -833,7 +833,7 @@ msgstr "Kopiuj"
 msgid "Country"
 msgstr "Kraj"
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr "Tryb krzyżowy"
 
@@ -846,15 +846,15 @@ msgstr "Wprowadź port:"
 msgid "Custom..."
 msgstr "Nietypowy..."
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "Wytnij"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 msgid "DTCS"
 msgstr "DTCS TX"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -866,11 +866,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr "Pamięć DV"
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr "Niebezpieczeństwo"
 
@@ -878,26 +878,26 @@ msgstr "Niebezpieczeństwo"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Tryb dewelopera"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Tryb developera jest teraz %s. CHIRP musi zostać ponowie uruchomiony, aby "
 "zmiany przyniosły efekt"
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "Porównaj surowe pamięci"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr "Kod cyfrowy"
 
@@ -906,11 +906,11 @@ msgstr "Kod cyfrowy"
 msgid "Digital Modes"
 msgstr "Kod cyfrowy"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr "Wyłącz raportowanie"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr "Wyłączony"
 
@@ -928,15 +928,15 @@ msgstr "Nie pytaj ponownie dla %s"
 msgid "Double-click to change bank name"
 msgstr "Kliknij podwójnie w celu zmiany nazwy banku"
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr "Pobierz"
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 msgid "Download from radio"
 msgstr "Pobierz z radiostacji"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Pobierz z radiostacji"
@@ -949,41 +949,45 @@ msgstr "Instrukcje pobierania"
 msgid "Driver information"
 msgstr ""
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Dupleks"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Zmień szczegóły dla %i pamięci"
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Zmień szczególy dla pamięci %i"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Zezwól na automatyczną edycję"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr "Włączony"
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 msgid "Enter Frequency"
 msgstr "Wprowadź częstotliwość"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr "Wprowadź przesunięcie (MHz)"
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr "Wprowadź częstotliwość nadawania (MHz)"
 
@@ -996,7 +1000,7 @@ msgstr "Wprowadź nową nazwę dla banku %s:"
 msgid "Enter custom port:"
 msgstr "Wprowadź port:"
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, python-format
 msgid "Erased memory %s"
 msgstr "Skasowano pamięć %s"
@@ -1013,20 +1017,20 @@ msgstr "Błąd komunikacji z radiostacją"
 msgid "Experimental driver"
 msgstr "Sterownik eksperymentalny"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr "Eksport może tylko zapisywać pliki CSV"
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 msgid "Export to CSV"
 msgstr "Eksportuj do pliku CSV"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Eksportuj do pliku CSV"
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr "Dodatkowa"
 
@@ -1056,13 +1060,13 @@ msgstr "Parsowanie wyniku nie udało się"
 msgid "Features"
 msgstr "Funkcje"
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Plik nie istnieje: %s"
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 msgid "Files"
 msgstr "Pliki"
 
@@ -1074,20 +1078,20 @@ msgstr "Filtr"
 msgid "Filter results with location matching this string"
 msgstr "Filtruj wyniki z lokalizacją pasująco do tej wartości tekstowej"
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr "Wyszukaj"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr "Wyszukaj następny"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 #, fuzzy
 msgid "Find..."
 msgstr "Wyszukaj"
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Zakończono zadanie radiostacji %s"
@@ -1130,11 +1134,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1227,7 +1231,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1245,11 +1249,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1267,12 +1271,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr "Znaleziono pustą wartość listy dla %(name)s: %(value)r"
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Częstotliwość"
 
@@ -1285,20 +1289,20 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Pobieranie ustawień"
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 msgid "Goto Memory"
 msgstr "Idź do pamięci"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr "Idź do pamięci:"
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 #, fuzzy
 msgid "Goto..."
 msgstr "Idź do"
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Pomoc"
 
@@ -1310,7 +1314,7 @@ msgstr "Pomocy..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 msgid "Hide empty memories"
 msgstr "Ukrywaj puste pamięci"
 
@@ -1323,10 +1327,14 @@ msgstr "Jeśli ustawiono, sortuje wyniki po odległości od tych współrzędnyc
 msgid "Import"
 msgstr "Importuj"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importuj z pliku"
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 msgid "Import not recommended"
@@ -1340,11 +1348,11 @@ msgstr "Indeks"
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr "Informacja"
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 msgid "Insert Row Above"
 msgstr "Umieść wiersz wyżej"
 
@@ -1352,7 +1360,7 @@ msgstr "Umieść wiersz wyżej"
 msgid "Install desktop icon?"
 msgstr "Utworzyć skrót pulpitu?"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Interakcja ze sterownikiem"
 
@@ -1361,7 +1369,7 @@ msgstr "Interakcja ze sterownikiem"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Niewłaściwe %(value)s (używaj stopni dziesiętnych)"
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 msgid "Invalid Entry"
 msgstr "Niewłaściwy wpis: %s"
 
@@ -1369,16 +1377,16 @@ msgstr "Niewłaściwy wpis: %s"
 msgid "Invalid ZIP code"
 msgstr "Niewłaściwy kod pocztowy"
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Niewłaściwa edycja: %s"
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr "Niewłaściwy lub niespierany plik modułu"
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, python-format
 msgid "Invalid value: %r"
 msgstr "Niewłaściwa wartość: %r"
@@ -1417,7 +1425,7 @@ msgstr "Ogranicz status"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Ogranicz wyniki do odległości (km) od współrzędnych"
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 #, fuzzy
 msgid "Load Module..."
 msgstr "Załaduj moduł"
@@ -1426,12 +1434,12 @@ msgstr "Załaduj moduł"
 msgid "Load module from issue"
 msgstr "Załaduj moduł ze zgłoszenia"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Załaduj moduł ze zgłoszenia"
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1468,7 +1476,7 @@ msgstr "Długość geograficzna"
 msgid "Memories"
 msgstr "Pamięci"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Pamięć %i jest nieusuwalna"
@@ -1482,7 +1490,7 @@ msgstr "Pamięć musi być w banku, aby można ją było edytować"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Pamięć {num} nie jest w banku {bank}"
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 msgid "Mode"
 msgstr "Tryb"
 
@@ -1494,15 +1502,15 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Tryby"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr "Moduł"
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr "Załadowano moduł"
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr "Pomyślnie załadowano moduł"
 
@@ -1511,23 +1519,23 @@ msgstr "Pomyślnie załadowano moduł"
 msgid "More than one port found: %s"
 msgstr "Znaleziono więcej niż jeden port: %s"
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 msgid "Move Down"
 msgstr "Przesuń w dół"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 msgid "Move Up"
 msgstr "Przesuń w górę"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr "Nowe okno"
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr "Nowa wersja jest dostępna"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 msgid "No empty rows below!"
 msgstr "Brak pustych wierszy poniżej!"
 
@@ -1548,11 +1556,11 @@ msgstr "Brak wyników"
 msgid "No results!"
 msgstr "Brak wyników!"
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr "Numer"
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Przesunięcie"
 
@@ -1572,27 +1580,27 @@ msgstr "Tylko zakładki pamięci mogą być wyeksportowane"
 msgid "Only working repeaters"
 msgstr "Tylko czynne przemienniki"
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Otwórz"
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 msgid "Open Recent"
 msgstr "Otwórz ostatnio używany"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 msgid "Open Stock Config"
 msgstr "Otwórz konfigurację wstępną"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Otwórz plik"
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr "Otwórz moduł"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Otwórz log debugowy"
 
@@ -1600,7 +1608,7 @@ msgstr "Otwórz log debugowy"
 msgid "Open in new window"
 msgstr "Otwórz w nowym oknie"
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 msgid "Open stock config directory"
 msgstr "Otwórz katalog konfiguracji wstępnych"
 
@@ -1620,7 +1628,7 @@ msgstr "Opcjonalnie: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcjonalnie: Szpital, Hrabstwo itp."
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 msgid "Overwrite memories?"
 msgstr "Nadpisać pamięci?"
 
@@ -1635,31 +1643,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Parsowanie"
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "Wklej"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Wklejone pamięci nadpisze %s istniejących pamięci"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Wklejone pamięci nadpisze pamięci %s"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Wklejone pamięci nadpiszą pamięć %s"
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Wklejona pamięć nadpisze pamięć %s"
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Proszę wyjdź z programu CHIRP przed instalacją nowej wersji!"
 
@@ -1689,7 +1697,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1701,7 +1709,7 @@ msgstr ""
 "oraz funkcje, które mogą uszkodzić komputer oraz radiostację, jeśli nie będą "
 "wykorzystywane z EKSTREMALNĄ uwagą. Zostałeś ostrzeżony! Kontynuować?"
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr "Proszę czekać"
 
@@ -1713,7 +1721,7 @@ msgstr "Podłącz kabel i naciśnij przycisk OK"
 msgid "Port"
 msgstr "Port"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Moc"
 
@@ -1721,7 +1729,7 @@ msgstr "Moc"
 msgid "Press enter to set this in memory"
 msgstr "Naciśnij przycisk enter, aby ustawić to w pamięci"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr "Podgląd wydruku"
 
@@ -1729,24 +1737,24 @@ msgstr "Podgląd wydruku"
 msgid "Printing"
 msgstr "Drukowanie"
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr "Właściwości"
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr "Odpytywanie %s"
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Źródło zapytań"
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Radiostacja"
 
@@ -1780,20 +1788,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr "Wymagane jest odświeżenie"
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Odświeżono pamięć %s"
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Przeładuj sterownik"
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Przeładuj sterownik oraz plik"
 
@@ -1807,11 +1815,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Raportowanie jest włączone"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -1821,11 +1829,11 @@ msgstr ""
 "oraz systemów operacyjnych należy traktować priorytetowo. Naprawdę doceniamy "
 "zostawienie tej opcji włączonej. Naprawdę wyłączyć raportowanie?"
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr "Wymagany jest restart"
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
@@ -1833,28 +1841,28 @@ msgstr[0] "Przywrócono %i zakładek"
 msgstr[1] "Przywrócono %i zakładek"
 msgstr[2] "Przywrócono %i zakładek"
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Przywrócono %i zakładek"
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr "Pobrano ustawienia"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr "Zapisać przed zamknięciem?"
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr "Zapisz plik"
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr "Zapisano ustawienia"
 
@@ -1870,7 +1878,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Wybierz bandplan"
@@ -1883,7 +1891,7 @@ msgstr "Wybierz pasma"
 msgid "Select Modes"
 msgstr "Wybierz tryby"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr "Wybierz bandplan"
 
@@ -1895,27 +1903,27 @@ msgstr "Usługa"
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "Pokaż surową pamięć"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Pokaż lokalizację pliku debug"
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr "Pokazuj dodatkowe pola"
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 msgid "Some memories are incompatible with this radio"
 msgstr "Niektóre pamięci są niekompatybilne z tą radiostacją"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr "Niektóre pamięci są nieusuwalne"
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -1923,7 +1931,7 @@ msgstr[0] "Sortuj %i pamięci"
 msgstr[1] "Sortuj %i pamięci"
 msgstr[2] "Sortuj %i pamięci"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -1931,7 +1939,7 @@ msgstr[0] "Sortuj %i pamięci rosnąco"
 msgstr[1] "Sortuj %i pamięci rosnąco"
 msgstr[2] "Sortuj %i pamięci rosnąco"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -1939,11 +1947,11 @@ msgstr[0] "Sortuj %i pamięci malejąco"
 msgstr[1] "Sortuj %i pamięci malejąco"
 msgstr[2] "Sortuj %i pamięci malejąco"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr "Sortuj wg kolumny:"
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 msgid "Sort memories"
 msgstr "Sortuj pamięci"
 
@@ -1959,7 +1967,7 @@ msgstr "Stan"
 msgid "State/Province"
 msgstr "Stan/Prowincja"
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr "Sukces"
 
@@ -2017,7 +2025,7 @@ msgstr ""
 "aktualnie otwartym pliku tymi z %(file)s. Czy chcesz otworzyć ten plik, aby "
 "kopiować/wklejać pamięci lub kontynuować import?"
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 msgid "This Memory"
 msgstr "Tą pamięć"
 
@@ -2061,11 +2069,11 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 msgid "This memory and shift all up"
 msgstr "Tą pamięć i przeusń wszystkie wyżej"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 msgid "This memory and shift block up"
 msgstr "Tą pamięć i przesuń blok wyżej"
 
@@ -2095,19 +2103,19 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr "To załaduje moduł ze strony zgłoszenia"
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "Ton TX"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Tryb tonu"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 msgid "Tone Squelch"
 msgstr "Ton RX"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 msgid "Tuning Step"
 msgstr "Krok strojenia"
 
@@ -2122,16 +2130,16 @@ msgid ""
 msgstr ""
 "Nie można wykryć portu kabla. Należy sprawdzić sterowniki oraz połączenie."
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Przed pobraniem pamięci, nie można jej edytować"
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Nie znaleziono konfiguracji wstępnej %r"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 msgid "Unable to open the clipboard"
 msgstr "Nie można otworzyć schowka"
 
@@ -2149,12 +2157,12 @@ msgstr ""
 "model na rynek US, ale radiostacja jest przeznaczona na inne regiony (lub "
 "szerokopasmowa). Należy wybrać właściwy model i spróbować ponownie."
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Nie można odkryć %s na tym systemie"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Nie można ustawić %s na tej pamięci"
@@ -2171,25 +2179,25 @@ msgstr "Należy odpiąć kabel (jeśli to konieczne) i nacisnąć przycisk OK"
 msgid "Upload instructions"
 msgstr "Instrukcje wysyłania"
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 msgid "Upload to radio"
 msgstr "Wyślij do radiostacji"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Wyślij do radiostacji"
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Wysłano pamięć %s"
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr "Używaj czcionki o stałej szerokości znaków"
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr "Używaj większej czcionki"
 
@@ -2198,12 +2206,12 @@ msgstr "Używaj większej czcionki"
 msgid "Value does not fit in %i bits"
 msgstr "Wartość nie pasuje do %i bitów"
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Wartość musi wynosić przynajmniej %.4f"
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Wartość musi wynosić nie więcej niż %.4f"
@@ -2217,7 +2225,7 @@ msgstr "Wartość musi mieć dokładnie %i cyfr dziesiętnych"
 msgid "Value must be zero or greater"
 msgstr "Wartość musi wynosić zero lub więcej"
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr "Wartości"
 
@@ -2225,19 +2233,19 @@ msgstr "Wartości"
 msgid "Vendor"
 msgstr "Producent"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 msgid "View"
 msgstr "Widok"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr "UWAGA!"
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr "Uwaga"
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr "Uwaga: %s"
@@ -2266,11 +2274,11 @@ msgstr "bajtów"
 msgid "bytes each"
 msgstr "bajtów każdy"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr "wyłączony"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr "włączony"
 

--- a/chirp/locale/pt_BR.po
+++ b/chirp/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2013-03-30 22:04-0300\n"
 "Last-Translator: Crezivando <crezivando@gmail.com>\n"
 "Language-Team: Language pt-BR\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Apagar (e deslocar)"
 msgstr[1] "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memórias"
 msgstr[1] "Memórias"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Apagar (e deslocar)"
 msgstr[1] "Apagar (e deslocar)"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Arquivo modificado, salvar alterações antes de fechar?"
@@ -63,7 +63,7 @@ msgstr "Arquivo modificado, salvar alterações antes de fechar?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -506,7 +506,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -516,7 +516,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -621,17 +621,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr ""
 
@@ -639,12 +639,12 @@ msgstr ""
 msgid "All"
 msgstr "Tudo"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "Arquivos CSV"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -652,7 +652,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Ocorreu um erro"
 
@@ -664,7 +664,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr ""
 
@@ -692,42 +692,42 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Modo Cross"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr ""
 
@@ -754,36 +754,36 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Clonando"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Descarregar a partir do Rádio"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Carregar para o Rádio"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Comentário"
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "Copiar"
 
@@ -815,7 +815,7 @@ msgstr "Copiar"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 #, fuzzy
 msgid "Cross mode"
 msgstr "Modo Cross"
@@ -828,16 +828,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -848,11 +848,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr ""
 
@@ -861,25 +861,25 @@ msgstr ""
 msgid "Dec"
 msgstr "Detectar"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Desenvolvedor"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr "Código Digital"
 
@@ -888,11 +888,11 @@ msgstr "Código Digital"
 msgid "Digital Modes"
 msgstr "Código Digital"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr ""
 
@@ -910,16 +910,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 #, fuzzy
 msgid "Download from radio"
 msgstr "Descarregar a partir do Rádio"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Descarregar a partir do Rádio"
@@ -933,42 +933,46 @@ msgstr "Descarregar a partir do Rádio"
 msgid "Driver information"
 msgstr ""
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr ""
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Frequência"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -981,7 +985,7 @@ msgstr ""
 msgid "Enter custom port:"
 msgstr ""
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "Apagando memória {loc}"
@@ -999,21 +1003,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Exportar Para Arquivo"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Exportar Para Arquivo"
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr ""
 
@@ -1040,13 +1044,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 #, fuzzy
 msgid "Files"
 msgstr "_Arquivo"
@@ -1059,19 +1063,19 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 msgid "Find..."
 msgstr ""
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1114,11 +1118,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1211,7 +1215,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1229,11 +1233,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1251,12 +1255,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Frequência"
 
@@ -1269,20 +1273,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Mostrar Memória Raw"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Ajuda"
 
@@ -1294,7 +1298,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Sobrescrever?"
@@ -1308,10 +1312,14 @@ msgstr ""
 msgid "Import"
 msgstr "Importar"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importar do Arquivo"
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 #, fuzzy
@@ -1326,11 +1334,11 @@ msgstr "Índice"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Inserir row acima"
@@ -1339,7 +1347,7 @@ msgstr "Inserir row acima"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1348,7 +1356,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Valor inválido. Deve ser um número inteiro."
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Valor Inválido para este campo"
@@ -1357,16 +1365,16 @@ msgstr "Valor Inválido para este campo"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr ""
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Valor Inválido para este campo"
@@ -1405,7 +1413,7 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 #, fuzzy
 msgid "Load Module..."
 msgstr "Modo Tom"
@@ -1415,12 +1423,12 @@ msgstr "Modo Tom"
 msgid "Load module from issue"
 msgstr "Modo Tom"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Modo Tom"
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1451,7 +1459,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Memórias"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1465,7 +1473,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 #, fuzzy
 msgid "Mode"
 msgstr "Modo"
@@ -1479,15 +1487,15 @@ msgstr "Modelo"
 msgid "Modes"
 msgstr "Modo"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1496,25 +1504,25 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 #, fuzzy
 msgid "Move Down"
 msgstr "Mover Abaix_o"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 #, fuzzy
 msgid "Move Up"
 msgstr "Mover _Acima"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Inserir row abaixo"
@@ -1536,11 +1544,11 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr ""
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Offset"
 
@@ -1560,29 +1568,29 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Recente"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Abrir config do estoque"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
@@ -1590,7 +1598,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Abrir configuração de estoque {name}"
@@ -1612,7 +1620,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Sobrescrever?"
@@ -1628,31 +1636,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "Colar"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1682,7 +1690,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1690,7 +1698,7 @@ msgid ""
 "EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr ""
 
@@ -1702,7 +1710,7 @@ msgstr ""
 msgid "Port"
 msgstr "Porta"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Power"
 
@@ -1711,7 +1719,7 @@ msgstr "Power"
 msgid "Press enter to set this in memory"
 msgstr "Erro gravando memória"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr ""
 
@@ -1719,24 +1727,24 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr ""
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Rádio"
 
@@ -1768,20 +1776,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1796,50 +1804,50 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Emissão de Relatórios desabilitada"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 msgid "Restore tabs on start"
 msgstr ""
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr ""
 
@@ -1855,7 +1863,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Selecionar Colunas"
@@ -1870,7 +1878,7 @@ msgstr "Selecionar Colunas"
 msgid "Select Modes"
 msgstr "Selecionar Colunas"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1882,53 +1890,53 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "Mostrar Memória Raw"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Memória colada {number} não é compatível com este rádio porque:"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 #, fuzzy
 msgid "Sort memories"
 msgstr "Sobrescrever?"
@@ -1945,7 +1953,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr ""
 
@@ -1995,7 +2003,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 #, fuzzy
 msgid "This Memory"
 msgstr "Mostrar Memória Raw"
@@ -2040,12 +2048,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Apagar (e deslocar)"
@@ -2071,20 +2079,20 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "Tom"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Modo Tom"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "TomSql"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Tune Step"
@@ -2099,16 +2107,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Abrir config do estoque"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "Incapaz de detectar rádio na {port}"
@@ -2124,12 +2132,12 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Incapaz de efetuar alterações para este modelo"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, fuzzy, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Incapaz de efetuar alterações para este modelo"
@@ -2146,26 +2154,26 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Carregar para o Rádio"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Carregar para o Rádio"
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr ""
 
@@ -2174,12 +2182,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2193,7 +2201,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr ""
 
@@ -2201,20 +2209,20 @@ msgstr ""
 msgid "Vendor"
 msgstr "Fornecedor"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 #, fuzzy
 msgid "View"
 msgstr "_Visualizar"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2243,11 +2251,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/ru.po
+++ b/chirp/locale/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2023-10-11 16:47+0300\n"
 "Last-Translator: Olesya Gerasimenko <translation-team@basealt.ru>\n"
 "Language-Team: Basealt Translation Team\n"
@@ -38,7 +38,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s должно находиться в диапазоне от %(min)i до %(max)i"
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -46,7 +46,7 @@ msgstr[0] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[1] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[2] "Ячейки памяти (%i) и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -54,7 +54,7 @@ msgstr[0] "Ячейки памяти (%i)"
 msgstr[1] "Ячейки памяти (%i)"
 msgstr[2] "Ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -62,7 +62,7 @@ msgstr[0] "Ячейки памяти (%i) и сдвинуть блок ввер�
 msgstr[1] "Ячейки памяти (%i) и сдвинуть блок вверх"
 msgstr[2] "Ячейки памяти (%i) и сдвинуть блок вверх"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Сохранение %s не было выполнено. Сохранить перед закрытием?"
@@ -71,7 +71,7 @@ msgstr "Сохранение %s не было выполнено. Сохрани
 msgid "(none)"
 msgstr "(нет)"
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr "...и ещё %i"
@@ -783,7 +783,7 @@ msgstr ""
 "5. Убедитесь, что станция настроена на неактивный канал.\n"
 "6. Нажмите «ОК» для отправки образа на устройство.\n"
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -799,7 +799,7 @@ msgstr ""
 "5. Убедитесь, что станция настроена на неактивный канал.\n"
 "6. Нажмите «ОК» для загрузки образа с устройства.\n"
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -966,7 +966,7 @@ msgstr ""
 "Отправка может не получиться, если вы включите станцию, когда кабель уже "
 "подключён"
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -974,11 +974,11 @@ msgstr ""
 "Доступная новая версия программы CHIRP. Как можно скорее загрузите её на веб-"
 "сайте!"
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "О программе"
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr "О программе CHIRP"
 
@@ -986,11 +986,11 @@ msgstr "О программе CHIRP"
 msgid "All"
 msgstr "Все"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Все файлы"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Все поддерживаемые форматы|"
 
@@ -998,7 +998,7 @@ msgstr "Все поддерживаемые форматы|"
 msgid "Amateur"
 msgstr "Любительская радиосвязь"
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Ошибка"
 
@@ -1010,7 +1010,7 @@ msgstr "Применение параметров"
 msgid "Available modules"
 msgstr "Доступные модули"
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr "Частотный план"
 
@@ -1038,7 +1038,7 @@ msgstr "Браузер станций"
 msgid "Canada"
 msgstr "Канада"
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
@@ -1046,35 +1046,35 @@ msgstr ""
 "Для изменения этого параметра требуется обновить параметры из образа, что и "
 "будет сейчас выполнено."
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Каналы с эквивалентными TX и RX %s представлены видом субтона «%s»."
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Файлы образов Chirp"
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr "Необходимо сделать выбор"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Выберите код DTCS %s"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Выберите тон %s"
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 msgid "Choose Cross Mode"
 msgstr "Выберите кросс-режим"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr "Выберите дуплекс"
 
@@ -1107,27 +1107,27 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Клонирование завершено, проверка наличия ложных байтов"
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Клонирование"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 msgid "Cloning from radio"
 msgstr "Клонирование из станции"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 msgid "Cloning to radio"
 msgstr "Клонирование на станцию"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr "Закрыть"
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr "Закрыть файл"
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1135,7 +1135,7 @@ msgstr[0] "Объединить ячейки памяти (%i) в кластер
 msgstr[1] "Объединить ячейки памяти (%i) в кластер"
 msgstr[2] "Объединить ячейки памяти (%i) в кластер"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Комментарий"
 
@@ -1159,7 +1159,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "Копировать"
 
@@ -1168,7 +1168,7 @@ msgstr "Копировать"
 msgid "Country"
 msgstr "Страна"
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr "Кросс-режим"
 
@@ -1180,15 +1180,15 @@ msgstr "Пользовательский порт"
 msgid "Custom..."
 msgstr "Пользовательский..."
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "Вырезать"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -1200,11 +1200,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr "DV-память"
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr "Впереди опасность"
 
@@ -1212,26 +1212,26 @@ msgstr "Впереди опасность"
 msgid "Dec"
 msgstr "Десятичный"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Режим разработчика"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Режим разработчика теперь %s. Для применения изменений необходимо "
 "перезапустить CHIRP"
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "Сравнить необработанные ячейки памяти"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr "Цифровой код"
 
@@ -1240,11 +1240,11 @@ msgstr "Цифровой код"
 msgid "Digital Modes"
 msgstr "Цифровой код"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr "Отключить отправку отчётов"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr "Отключено"
 
@@ -1262,15 +1262,15 @@ msgstr "Не запрашивать снова для %s"
 msgid "Double-click to change bank name"
 msgstr "Сделайте двойной щелчок, чтобы изменить имя банка"
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr "Загрузить"
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 msgid "Download from radio"
 msgstr "Загрузить из станции"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "Загрузить из станции..."
 
@@ -1282,41 +1282,45 @@ msgstr "Инструкции по загрузке"
 msgid "Driver information"
 msgstr ""
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Редактировать сведения о ячейках памяти (%i)"
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Редактировать сведения о ячейке памяти (%i)"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Включить автоматическое редактирование"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr "Включено"
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 msgid "Enter Frequency"
 msgstr "Введите частоту"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr "Введите смещение (МГц)"
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr "Введите частоту TX (МГц)"
 
@@ -1329,7 +1333,7 @@ msgstr "Введите новое имя банка %s:"
 msgid "Enter custom port:"
 msgstr "Введите пользовательский порт:"
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, python-format
 msgid "Erased memory %s"
 msgstr "Стёрта ячейка памяти %s"
@@ -1346,19 +1350,19 @@ msgstr "Ошибка обмена данными со станцией"
 msgid "Experimental driver"
 msgstr "Экспериментальный драйвер"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr "При экспорте можно выполнять запись только в файлы CSV"
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 msgid "Export to CSV"
 msgstr "Экспорт в CSV"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 msgid "Export to CSV..."
 msgstr "Экспорт в CSV..."
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr "Дополнительно"
 
@@ -1388,13 +1392,13 @@ msgstr "Не удалось проанализировать результат"
 msgid "Features"
 msgstr "Функции"
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Файл не существует: %s"
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 msgid "Files"
 msgstr "Файлы"
 
@@ -1406,19 +1410,19 @@ msgstr "Фильтр"
 msgid "Filter results with location matching this string"
 msgstr "Фильтровать результаты с расположением, соответствующим этой строке"
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr "Найти"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr "Найти далее"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 msgid "Find..."
 msgstr "Найти..."
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Завершено задание станции %s"
@@ -1484,11 +1488,11 @@ msgstr ""
 "5 - Отключите интерфейсный кабель! Иначе с правой стороны\n"
 "    не будет звука!\n"
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1636,7 +1640,7 @@ msgstr ""
 "3 - Включите вашу станцию\n"
 "4 - Чтобы начать, нажмите «ОК»\n"
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1664,11 +1668,11 @@ msgstr ""
 "3 - Включите вашу станцию\n"
 "4 - Выполните загрузку ваших радиоданных\n"
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1696,12 +1700,12 @@ msgstr ""
 "3 - Включите вашу станцию\n"
 "4 - Выполните отправку ваших радиоданных\n"
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr "Найдено значение пустого списка для %(name)s: %(value)r"
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Частота"
 
@@ -1714,19 +1718,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Получение параметров"
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 msgid "Goto Memory"
 msgstr "Перейти к ячейке памяти"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr "Переход к ячейке памяти:"
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr "Переход..."
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Справка"
 
@@ -1738,7 +1742,7 @@ msgstr "Помощь..."
 msgid "Hex"
 msgstr "Шестнадцатеричный"
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 msgid "Hide empty memories"
 msgstr "Скрыть пустые ячейки памяти"
 
@@ -1752,9 +1756,13 @@ msgstr ""
 msgid "Import"
 msgstr "Импорт"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 msgid "Import from file..."
 msgstr "Импорт из файла..."
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 msgid "Import not recommended"
@@ -1768,11 +1776,11 @@ msgstr "Индекс"
 msgid "Info"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 msgid "Insert Row Above"
 msgstr "Вставить строку выше"
 
@@ -1780,7 +1788,7 @@ msgstr "Вставить строку выше"
 msgid "Install desktop icon?"
 msgstr "Создать значок на рабочем столе?"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Обмен данными с драйвером"
 
@@ -1789,7 +1797,7 @@ msgstr "Обмен данными с драйвером"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s — неверно (используйте десятичные градусы)"
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 msgid "Invalid Entry"
 msgstr "Некорректная запись"
 
@@ -1797,16 +1805,16 @@ msgstr "Некорректная запись"
 msgid "Invalid ZIP code"
 msgstr "Неверный почтовый индекс"
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Некорректное изменение: %s"
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr "Некорректный или неподдерживаемый файл модуля"
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, python-format
 msgid "Invalid value: %r"
 msgstr "Неверное значение: %r"
@@ -1845,7 +1853,7 @@ msgstr "Ограничение состояния"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Ограничить результаты этим расстоянием (км) от координат"
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 msgid "Load Module..."
 msgstr "Загрузить модуль..."
 
@@ -1853,11 +1861,11 @@ msgstr "Загрузить модуль..."
 msgid "Load module from issue"
 msgstr "Загрузить модуль из задачи"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 msgid "Load module from issue..."
 msgstr "Загрузить модуль из задачи..."
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1894,7 +1902,7 @@ msgstr "Долгота"
 msgid "Memories"
 msgstr "Ячейки памяти"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Ячейку памяти %i нельзя удалить"
@@ -1908,7 +1916,7 @@ msgstr "Чтобы редактировать ячейку памяти, нео�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Ячейка памяти {num} отсутствует в банке {bank}"
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 msgid "Mode"
 msgstr "Режим"
 
@@ -1920,15 +1928,15 @@ msgstr "Модель"
 msgid "Modes"
 msgstr "Режимы"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr "Модуль"
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr "Модуль загружен"
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr "Модуль успешно загружен"
 
@@ -1937,23 +1945,23 @@ msgstr "Модуль успешно загружен"
 msgid "More than one port found: %s"
 msgstr "Найдено более одного порта: %s"
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 msgid "Move Down"
 msgstr "Переместить вниз"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 msgid "Move Up"
 msgstr "Переместить вверх"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr "Новое окно"
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr "Доступна новая версия"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 msgid "No empty rows below!"
 msgstr "Ниже нет пустых строк!"
 
@@ -1974,11 +1982,11 @@ msgstr "Нет результатов"
 msgid "No results!"
 msgstr "Нет результатов!"
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr "Число"
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Смещение"
 
@@ -1998,27 +2006,27 @@ msgstr "Можно экспортировать только вкладки па
 msgid "Only working repeaters"
 msgstr "Только работающие репитеры"
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Открыть"
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 msgid "Open Recent"
 msgstr "Открыть недавние"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 msgid "Open Stock Config"
 msgstr "Открыть предустановленную конфигурацию"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Открыть файл"
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr "Открыть модуль"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Открыть журнал отладки"
 
@@ -2026,7 +2034,7 @@ msgstr "Открыть журнал отладки"
 msgid "Open in new window"
 msgstr "Открыть в новом окне"
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 msgid "Open stock config directory"
 msgstr "Открыть каталог предустановленной конфигурации"
 
@@ -2046,7 +2054,7 @@ msgstr "Опционально: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Опционально: округ, больница и т.д."
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 msgid "Overwrite memories?"
 msgstr "Перезаписать ячейки памяти?"
 
@@ -2064,31 +2072,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Анализ"
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "Вставить"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Вставленные ячейки памяти перезапишут существующие ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейку памяти %s"
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Вставленная ячейка памяти перезапишет ячейку памяти %s"
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Обязательно выйдите из программы CHIRP перед установкой новой версии!"
 
@@ -2136,7 +2144,7 @@ msgstr ""
 "4 - Затем нажмите кнопку «A» на вашей станции для начала клонирования.\n"
 "    (По завершении станция подаст звуковой сигнал.)\n"
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2149,7 +2157,7 @@ msgstr ""
 "осторожно, чтобы не навредить вашему компьютеру и вашей станции. Вы были "
 "предупреждены. Всё равно продолжить?"
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr "Подождите"
 
@@ -2161,7 +2169,7 @@ msgstr "Подключите кабель и нажмите «ОК»"
 msgid "Port"
 msgstr "Порт"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Мощность"
 
@@ -2169,7 +2177,7 @@ msgstr "Мощность"
 msgid "Press enter to set this in memory"
 msgstr "Нажмите «Ввод» для добавления в память"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr "Предпросмотр"
 
@@ -2177,24 +2185,24 @@ msgstr "Предпросмотр"
 msgid "Printing"
 msgstr "Печать"
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr "Свойства"
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr "Запрос %s"
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Запрос источника"
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Станция"
 
@@ -2228,20 +2236,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr "Требуется обновление"
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Обновлена ячейки памяти %s"
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Перезагрузить драйвер"
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Перезагрузить драйвер и файл"
 
@@ -2255,11 +2263,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Отправка отчётов включена"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2270,11 +2278,11 @@ msgstr ""
 "признательны, если вы оставите эту функцию включённой. Действительно "
 "отключить отправку отчётов?"
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr "Требуется перезапуск"
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
@@ -2282,28 +2290,28 @@ msgstr[0] "Восстановить вкладки (%i)"
 msgstr[1] "Восстановить вкладки (%i)"
 msgstr[2] "Восстановить вкладки (%i)"
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Восстановить вкладки (%i)"
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr "Полученные параметры"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr "Сохранить"
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr "Сохранить перед закрытием?"
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr "Сохранить файл"
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr "Сохранённые параметры"
 
@@ -2319,7 +2327,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr "Угроза безопасности"
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "Выбрать частотный план..."
 
@@ -2331,7 +2339,7 @@ msgstr "Выбор полос частот"
 msgid "Select Modes"
 msgstr "Выбор режимов"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr "Выбор частотного плана"
 
@@ -2343,27 +2351,27 @@ msgstr "Служба"
 msgid "Settings"
 msgstr "Параметры"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "Показать необработанную ячейку памяти"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Показать расположение журнала отладки"
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr "Показать дополнительные поля"
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 msgid "Some memories are incompatible with this radio"
 msgstr "Некоторые ячейки памяти несовместимы с этой станцией"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr "Некоторые ячейки памяти нельзя удалить"
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -2371,7 +2379,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i)"
 msgstr[1] "Упорядочить ячейки памяти (%i)"
 msgstr[2] "Упорядочить ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -2379,7 +2387,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по возра
 msgstr[1] "Упорядочить ячейки памяти (%i) по возрастанию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по возрастанию"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -2387,11 +2395,11 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по убыва
 msgstr[1] "Упорядочить ячейки памяти (%i) по убыванию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по убыванию"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr "Сортировать по столбцу:"
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 msgid "Sort memories"
 msgstr "Упорядочить ячейки памяти"
 
@@ -2407,7 +2415,7 @@ msgstr "Область"
 msgid "State/Province"
 msgstr "Область/регион"
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr "Успешно"
 
@@ -2481,7 +2489,7 @@ msgstr ""
 "текущем открытом файле на ячейки из %(file)s. Открыть этот файл для "
 "копирования/вставки ячеек памяти или продолжить импорт?"
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 msgid "This Memory"
 msgstr "Эта ячейка памяти"
 
@@ -2532,11 +2540,11 @@ msgstr ""
 "Также присылайте отчёты об ошибках и предложения по улучшению.\n"
 "Вы были предупреждены; продолжайте на свой страх и риск!"
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 msgid "This memory and shift all up"
 msgstr "Эта ячейка памяти и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 msgid "This memory and shift block up"
 msgstr "Эта ячейка памяти и сдвинуть блок вверх"
 
@@ -2571,19 +2579,19 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr "Будет выполнена загрузка модуля из задачи на веб-сайте"
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "ТонПРД"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Вид субтона"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 msgid "Tone Squelch"
 msgstr "ТонШПД"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 msgid "Tuning Step"
 msgstr "Шаг настройки"
 
@@ -2599,16 +2607,16 @@ msgstr ""
 "Не удалось определить порт для вашего кабеля. Проверьте драйверы и "
 "подключения."
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Перед редактированием ячейки памяти необходимо загрузить станцию"
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Не удалось найти предустановленную конфигурацию %r"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 msgid "Unable to open the clipboard"
 msgstr "Не удалось открыть буфер обмена"
 
@@ -2626,12 +2634,12 @@ msgstr ""
 "американская модель, но станция не является американской (или "
 "широкополосной). Выберите правильную модель и повторите попытку."
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Невозможно обнаружить %s в этой системе"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Невозможно установить %s для этой ячейки памяти"
@@ -2648,24 +2656,24 @@ msgstr "Отключите кабель (если требуется) и наж�
 msgid "Upload instructions"
 msgstr "Отправка инструкций"
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 msgid "Upload to radio"
 msgstr "Отправка на станцию"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "Отправка на станцию..."
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Отправлена ячейка памяти %s"
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr "Использовать моноширинный шрифт"
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr "Использовать более крупный шрифт"
 
@@ -2674,12 +2682,12 @@ msgstr "Использовать более крупный шрифт"
 msgid "Value does not fit in %i bits"
 msgstr "Значение не помещается в %i бит"
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Значение не должно быть меньше %.4f"
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Значение не должно превышать %.4f"
@@ -2693,7 +2701,7 @@ msgstr "Значение должно содержать десятичные ц
 msgid "Value must be zero or greater"
 msgstr "Значение должно быть больше или равно нулю"
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr "Значения"
 
@@ -2701,19 +2709,19 @@ msgstr "Значения"
 msgid "Vendor"
 msgstr "Изготовитель"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 msgid "View"
 msgstr "Вид"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr "ПРЕДУПРЕЖДЕНИЕ!"
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr "Предупреждение: %s"
@@ -2742,11 +2750,11 @@ msgstr "байт"
 msgid "bytes each"
 msgstr "байт каждый"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr "отключён"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr "включён"
 

--- a/chirp/locale/tr_TR.po
+++ b/chirp/locale/tr_TR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-16 21:38+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2024-01-20 18:51+0300\n"
 "Last-Translator: Abdullah YILMAZ (TA1AUB) <h.abdullahyilmaz@hotmail.com>\n"
 "Language-Team: TURKISH\n"
@@ -42,28 +42,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s, %(min)i ile %(max)i arasında olmalıdır"
 
-#: ../wxui/memedit.py:1593
+#: ../wxui/memedit.py:1591
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Kaydı ve hepsini yukarı kaydır"
 msgstr[1] "%i Kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:1584
+#: ../wxui/memedit.py:1582
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Kaydı"
 msgstr[1] "%i Kaydı"
 
-#: ../wxui/memedit.py:1588
+#: ../wxui/memedit.py:1586
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Kaydı ve bloğu yukarı kaydır"
 msgstr[1] "%i Kaydı ve bloğu yukarı kaydır"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s kaydedilmedi. Kapanmadan önce kaydedilsin mi?"
@@ -72,7 +72,7 @@ msgstr "%s kaydedilmedi. Kapanmadan önce kaydedilsin mi?"
 msgid "(none)"
 msgstr "(hiçbiri)"
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr "...ve %i daha"
@@ -778,7 +778,7 @@ msgstr ""
 "5. Telsizin etkin olmayan kanala ayarlandığından emin olun.\n"
 "6. İmajı cihaza yüklemek için TAMAM'a tıklayın.\n"
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -794,7 +794,7 @@ msgstr ""
 "5. Telsizin etkin olmayan kanala ayarlandığından emin olun.\n"
 "6. İmajı cihazdan indirmek için TAMAM'a tıklayın.\n"
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -962,7 +962,7 @@ msgstr ""
 "\n"
 "Kablo takılıyken telsizi açarsanız çalışmayabilir"
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -970,11 +970,11 @@ msgstr ""
 "Yeni bir CHIRP sürümü mevcut. İndirmek için lütfen en kısa zamanda web "
 "sitesini ziyaret edin!"
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "Hakkında"
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr "CHIRP Hakkında"
 
@@ -982,11 +982,11 @@ msgstr "CHIRP Hakkında"
 msgid "All"
 msgstr "Tümü"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Tüm Dosyalar"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Desteklenen tüm biçimler|"
 
@@ -994,7 +994,7 @@ msgstr "Desteklenen tüm biçimler|"
 msgid "Amateur"
 msgstr "Amatör"
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Bir hata oluştu"
 
@@ -1006,7 +1006,7 @@ msgstr "Ayarlar uygulanıyor"
 msgid "Available modules"
 msgstr "Mevcut modüller"
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr "Bant planı"
 
@@ -1034,7 +1034,7 @@ msgstr "Telsiz Tarayıcısı oluşturuluyor"
 msgid "Canada"
 msgstr "Kanada"
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
@@ -1042,36 +1042,36 @@ msgstr ""
 "Bu ayarın değiştirilmesi, imajdaki ayarların yenilenmesini gerektirir, bu "
 "işlem şimdi gerçekleşecektir."
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 "Eşdeğer TX ve RX %s'ye sahip kanallar, \"%s\" ton modu ile temsil edilir"
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Chirp İmaj Dosyaları"
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr "Seçim Gerekli"
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "%s DTCS Kodunu Seç"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr "%s Tonunu Seç"
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 msgid "Choose Cross Mode"
 msgstr "Çapraz Modu Seç"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr "Dubleks seç"
 
@@ -1104,34 +1104,34 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Klon tamamlandı, sahte baytlar kontrol ediliyor"
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Klonlanıyor"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 msgid "Cloning from radio"
 msgstr "Telsizden klonlanıyor"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 msgid "Cloning to radio"
 msgstr "Telsize klonlanıyor"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr "Kapat"
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr "Dosyayı kapat"
 
-#: ../wxui/memedit.py:1651
+#: ../wxui/memedit.py:1649
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "%i Kaydı sırala"
 msgstr[1] "%i kaydı sırala"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Yorum"
 
@@ -1155,7 +1155,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "FM'e dönüştür"
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -1164,7 +1164,7 @@ msgstr "Kopyala"
 msgid "Country"
 msgstr "Ülke"
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr "Çapraz mod"
 
@@ -1176,15 +1176,15 @@ msgstr "Özel Bağlantı Noktası"
 msgid "Custom..."
 msgstr "Özel..."
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "Kes"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 msgid "DTCS"
 msgstr "DTCS"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 msgid ""
 "DTCS\n"
 "Polarity"
@@ -1196,11 +1196,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "DTMF kod çöz"
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr "DV Kaydı"
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr "İleride Tehlike"
 
@@ -1208,25 +1208,25 @@ msgstr "İleride Tehlike"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "Sil"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Geliştirici Modu"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Geliştirici durumu artık %s. Etkili olması için CHIRP yeniden başlatılmalıdır"
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "Farklı Ham Kayıtlar"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr "Dijital Kod"
 
@@ -1234,11 +1234,11 @@ msgstr "Dijital Kod"
 msgid "Digital Modes"
 msgstr "Dijital Modlar"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr "Raporlamayı devre dışı bırak"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr "Devre dışı"
 
@@ -1256,15 +1256,15 @@ msgstr "%s için tekrar sorma"
 msgid "Double-click to change bank name"
 msgstr "Banka adını değiştirmek için çift tıklayın"
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr "İndir"
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 msgid "Download from radio"
 msgstr "Telsizden indir"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "Telsizden indir..."
 
@@ -1276,43 +1276,47 @@ msgstr "İndirme talimatları"
 msgid "Driver information"
 msgstr "Sürücü bilgileri"
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 "Analogu destekleyen çift modlu dijital tekrarlayıcılar(röleler) FM olarak "
 "gösterilecek"
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "%i kaydı için ayrıntıları düzenle"
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "%i kaydı için ayrıntıları düzenle"
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Otomatik Düzenlemeleri Etkinleştir"
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr "Etkin"
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 msgid "Enter Frequency"
 msgstr "Frekans Gir"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr "Ofset girin (MHz)"
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr "TX Frekansını girin (MHz)"
 
@@ -1325,7 +1329,7 @@ msgstr "Banka %s için yeni bir ad girin:"
 msgid "Enter custom port:"
 msgstr "Özel bağlantı noktasını girin:"
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, python-format
 msgid "Erased memory %s"
 msgstr "%s kaydı silindi"
@@ -1342,19 +1346,19 @@ msgstr "Telsizle iletişim hatası"
 msgid "Experimental driver"
 msgstr "Deneysel sürücü"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr "Dışa aktarma yalnızca CSV dosyalarını yazabilir"
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 msgid "Export to CSV"
 msgstr "CSV'ye aktar"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 msgid "Export to CSV..."
 msgstr "CSV'ye aktar..."
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -1384,13 +1388,13 @@ msgstr "Sonuç ayrıştırılamadı"
 msgid "Features"
 msgstr "Özellikler"
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Dosya mevcut değil: %s"
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 msgid "Files"
 msgstr "Dosyalar"
 
@@ -1402,19 +1406,19 @@ msgstr "Filtre"
 msgid "Filter results with location matching this string"
 msgstr "Bu dizeyle eşleşen konuma sahip sonuçları filtrele"
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr "Bul"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr "Sonraki Bul"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 msgid "Find..."
 msgstr "Bul..."
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr "%s telsiz işleri tamamlandı"
@@ -1476,11 +1480,11 @@ msgstr ""
 "4 - Telsiz > Telsizden İndir\n"
 "5 - Arayüz kablosunu çıkarın! Aksi takdirde, sağ taraf sesi olmayacaktır!\n"
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1623,7 +1627,7 @@ msgstr ""
 "3 - Telsizinizi açın (şifre korumalıysa engelini kaldırın)\n"
 "4 - Başlatmak için TAMAM'a tıklayın.\n"
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1651,11 +1655,11 @@ msgstr ""
 "3 - Telsizinizi açın\n"
 "4 - Telsiz verilerinizin indirmesini gerçekleştirin\n"
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1683,12 +1687,12 @@ msgstr ""
 "3 - Telsizinizi açın\n"
 "4 - Telsiz verilerinizin yüklemesini gerçekleştirin\n"
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr "%(name)s için boş liste değeri bulundu: %(value)r"
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Frekans"
 
@@ -1701,19 +1705,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Ayarlar alınıyor"
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 msgid "Goto Memory"
 msgstr "Kayda Git"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr "Kayda Git:"
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr "Git..."
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Yardım"
 
@@ -1725,7 +1729,7 @@ msgstr "Bana Yardım Et..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 msgid "Hide empty memories"
 msgstr "Boş kayıtları gizle"
 
@@ -1738,9 +1742,13 @@ msgstr "Ayarlanırsa, sonuçları bu koordinatlardan uzaklığa göre sırala"
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 msgid "Import from file..."
 msgstr "Dosyadan İçe Aktar..."
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 msgid "Import not recommended"
@@ -1754,11 +1762,11 @@ msgstr "Dizin"
 msgid "Info"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 msgid "Insert Row Above"
 msgstr "Yukarıya Satır Ekle"
 
@@ -1766,7 +1774,7 @@ msgstr "Yukarıya Satır Ekle"
 msgid "Install desktop icon?"
 msgstr "Masaüstü simgesi yüklensin mi?"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Sürücü ile etkileşim"
 
@@ -1775,7 +1783,7 @@ msgstr "Sürücü ile etkileşim"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Geçersiz %(value)s (ondalık basamak kullanın)"
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 msgid "Invalid Entry"
 msgstr "Geçersiz Girdi"
 
@@ -1783,16 +1791,16 @@ msgstr "Geçersiz Girdi"
 msgid "Invalid ZIP code"
 msgstr "Geçersiz Posta kodu"
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Geçersiz düzenleme: %s"
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr "Geçersiz veya desteklenmeyen modül dosyası"
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, python-format
 msgid "Invalid value: %r"
 msgstr "Geçersiz değer: %r"
@@ -1831,7 +1839,7 @@ msgstr "Durum Sınırla"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Sonuçları koordinatlardan bu mesafeye (km) sınırla"
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 msgid "Load Module..."
 msgstr "Modül Yükle..."
 
@@ -1839,11 +1847,11 @@ msgstr "Modül Yükle..."
 msgid "Load module from issue"
 msgstr "Kayıttan modül yükle"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 msgid "Load module from issue..."
 msgstr "Kayıttan modül yükle..."
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1881,7 +1889,7 @@ msgstr "Boylam"
 msgid "Memories"
 msgstr "Kayıtlar"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Kayıt %i silinemez"
@@ -1895,7 +1903,7 @@ msgstr "Hafızanın düzenlenebilmesi için bir bankada olması gerekir"
 msgid "Memory {num} not in bank {bank}"
 msgstr "{num} kaydı {bank} bankasında değil"
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 msgid "Mode"
 msgstr "Mod"
 
@@ -1907,15 +1915,15 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Modlar"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr "Modül"
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr "Modül Yüklendi"
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr "Modül başarıyla yüklendi"
 
@@ -1924,23 +1932,23 @@ msgstr "Modül başarıyla yüklendi"
 msgid "More than one port found: %s"
 msgstr "Birden fazla bağlantı noktası bulundu: %s"
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 msgid "Move Down"
 msgstr "Aşağı Taşı"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 msgid "Move Up"
 msgstr "Yukarı Taşı"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr "Yeni Pencere"
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr "Yeni sürüm mevcut"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 msgid "No empty rows below!"
 msgstr "Aşağıda boş satır yok!"
 
@@ -1961,11 +1969,11 @@ msgstr "Sonuç yok"
 msgid "No results!"
 msgstr "Sonuç yok!"
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr "Numara"
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Ofset"
 
@@ -1985,27 +1993,27 @@ msgstr "Yalnızca kayıt sekmeleri dışa aktarılabilir"
 msgid "Only working repeaters"
 msgstr "Yalnızca çalışan tekrarlayıcılar (röleler)"
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr "Aç"
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 msgid "Open Recent"
 msgstr "Son Kullanılanları Aç"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 msgid "Open Stock Config"
 msgstr "Hazır Yapılandırma Aç"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Bir dosya aç"
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr "Bir modül aç"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Hata ayıklama günlüğünü aç"
 
@@ -2013,7 +2021,7 @@ msgstr "Hata ayıklama günlüğünü aç"
 msgid "Open in new window"
 msgstr "Yeni pencerede aç"
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 msgid "Open stock config directory"
 msgstr "Hazır yapılandırma dizinini aç"
 
@@ -2033,7 +2041,7 @@ msgstr "İsteğe bağlı: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "İsteğe bağlı: bölge, Hastane vb."
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 msgid "Overwrite memories?"
 msgstr "Kayıtların üzerine yazılsın mı?"
 
@@ -2051,31 +2059,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Ayrıştırılıyor"
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Yapıştırılan kayıtlar, mevcut %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Yapıştırılan kayıtlar %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Yapıştırılan kayıtlar, %s kaydının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Yapıştırılan kayıt, %s kaydının üzerine yazacak"
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Lütfen yeni sürümü yüklemeden önce CHIRP'den çıktığınızdan emin olun!"
 
@@ -2123,7 +2131,7 @@ msgstr ""
 "4 - Ardından klonlamaya başlamak için telsizinizdeki \"A\" tuşuna basın.\n"
 "     (Sonunda telsiz bip sesi çıkaracaktır)\n"
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2136,7 +2144,7 @@ msgstr ""
 "telsizinize zarar verebilecek davranış ve işlevleri mümkün kılar. Uyarıldın! "
 "Yine de devam edilsin mi?"
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr "Lütfen bekleyin"
 
@@ -2148,7 +2156,7 @@ msgstr "Kablonuzu takın ve ardından Tamam'a tıklayın"
 msgid "Port"
 msgstr "Port"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Güç"
 
@@ -2156,7 +2164,7 @@ msgstr "Güç"
 msgid "Press enter to set this in memory"
 msgstr "Bu kayda almak için enter tuşuna basın"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr "Baskı Önizleme"
 
@@ -2164,24 +2172,24 @@ msgstr "Baskı Önizleme"
 msgid "Printing"
 msgstr "Baskı"
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr "Özellikler"
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr "%s sorgusu"
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Kaynaktan Sorgula"
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "Telsiz"
 
@@ -2219,20 +2227,20 @@ msgstr ""
 "telsiz iletişim veri sağlayıcısıdır\n"
 "<small>Premium hesap gereklidir</small>"
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr "Yeniden Başlatma Gerekli"
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Yenilenmiş %s kaydı"
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Sürücüyü Yeniden Yükle"
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Sürücüyü ve Dosyayı Yeniden Yükle"
 
@@ -2248,11 +2256,11 @@ msgstr ""
 "RepeaterBook, Amatör Telsiz için dünya çapında en kapsamlı \n"
 "ÜCRETSİZ röle rehberidir."
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Raporlama etkinleştirildi"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2263,39 +2271,39 @@ msgstr ""
 "bırakırsanız gerçekten minnettar oluruz. Raporlama gerçekten devre dışı "
 "bırakılsın mı?"
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr "Yeniden Başlatma Gerekiyor"
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "%i sekmeyi geri yükle"
 msgstr[1] "%i sekmeyi geri yükle"
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "%i sekmesini geri yükle"
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr "Alınan ayarlar"
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr "Kaydet"
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr "Kapanmadan önce kaydedilsin mi?"
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr "Dosyayı kaydet"
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr "Kaydedilmiş ayarlar"
 
@@ -2311,7 +2319,7 @@ msgstr "Karıştırıcı"
 msgid "Security Risk"
 msgstr "Güvenlik Riski"
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "Bant Planı Seç..."
 
@@ -2323,7 +2331,7 @@ msgstr "Bantları Seç"
 msgid "Select Modes"
 msgstr "Modları Seç"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr "Bir bant planı seçin"
 
@@ -2335,52 +2343,52 @@ msgstr "Servis"
 msgid "Settings"
 msgstr "Ayarlar"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "Ham Kaydı Göster"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Hata ayıklama günlüğü konumunu göster"
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr "Ekstra alanları göster"
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 msgid "Some memories are incompatible with this radio"
 msgstr "Bazı kayıtlar bu telsizle uyumlu değil"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr "Bazı anılar silinemez"
 
-#: ../wxui/memedit.py:1636
+#: ../wxui/memedit.py:1634
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "%i kaydı sırala"
 msgstr[1] "%i kaydı sırala"
 
-#: ../wxui/memedit.py:1640
+#: ../wxui/memedit.py:1638
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "%i kaydı artan şekilde sırala"
 msgstr[1] "%i kaydı artan şekilde sırala"
 
-#: ../wxui/memedit.py:1662
+#: ../wxui/memedit.py:1660
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "%i kaydı azalan şekilde sırala"
 msgstr[1] "%i kaydı azalan şekilde sırala"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr "Sütuna göre sırala:"
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 msgid "Sort memories"
 msgstr "Kayıtları sırala"
 
@@ -2396,7 +2404,7 @@ msgstr "Devlet"
 msgid "State/Province"
 msgstr "Eyalet/İl"
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr "Başarılı"
 
@@ -2470,7 +2478,7 @@ msgstr ""
 "yapıştırmak için bu dosyayı açmak mı yoksa içe aktarma işlemine devam etmek "
 "mi istiyorsunuz?"
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 msgid "This Memory"
 msgstr "Bu kaydı"
 
@@ -2530,11 +2538,11 @@ msgstr ""
 "Ayrıca lütfen hata raporu ve geliştirme istekleri gönderin!\n"
 "Uyarıldınız. Kendi sorumluluğunuzda ilerleyin!"
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 msgid "This memory and shift all up"
 msgstr "Bu kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 msgid "This memory and shift block up"
 msgstr "Bu kaydı ve bloğu yukarı kaydır"
 
@@ -2568,19 +2576,19 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr "Bu, bir web sitesi kaydından bir modül yükleyecektir"
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "Ton"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Ton Modu"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 msgid "Tone Squelch"
 msgstr "Ton Susturucu"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 msgid "Tuning Step"
 msgstr "Ayarlama Adımı"
 
@@ -2596,16 +2604,16 @@ msgstr ""
 "Kablonuz için bağlantı noktası belirlenemiyor. Sürücülerinizi ve "
 "bağlantılarınızı kontrol edin."
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Radyo yüklenmeden önce kayıt düzenlenemiyor"
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "%r stok yapılandırması bulunamadı"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 msgid "Unable to open the clipboard"
 msgstr "Pano açılamıyor"
 
@@ -2623,12 +2631,12 @@ msgstr ""
 "telsiz ABD dışı bir telsizdir (veya geniş bantlıdır). Lütfen doğru modeli "
 "seçin ve tekrar deneyin."
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "%s bu sistemde gösterilemiyor"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Bu kayıtta %s ayarlanamıyor"
@@ -2645,24 +2653,24 @@ msgstr "(gerekirse) Kablonuzu çıkarın ve ardından Tamam'ı tıklayın"
 msgid "Upload instructions"
 msgstr "Yükleme talimatları"
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 msgid "Upload to radio"
 msgstr "Telsize yükle"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "Telsize yükle..."
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Yüklenen kayıt %s"
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr "Sabit genişlikte yazı tipi kullan"
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr "Daha büyük yazı tipi kullan"
 
@@ -2671,12 +2679,12 @@ msgstr "Daha büyük yazı tipi kullan"
 msgid "Value does not fit in %i bits"
 msgstr "Değer %i bit'e sığmıyor"
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Değer en az %.4f olmalıdır"
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Değer en fazla %.4f olmalıdır"
@@ -2690,7 +2698,7 @@ msgstr "Değer tam olarak %i ondalık basamak olmalıdır"
 msgid "Value must be zero or greater"
 msgstr "Değer sıfır veya daha büyük olmalıdır"
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr "Değerler"
 
@@ -2698,19 +2706,19 @@ msgstr "Değerler"
 msgid "Vendor"
 msgstr "Tedarikçi"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 msgid "View"
 msgstr "Göster"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr "UYARI!"
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr "Uyarı"
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr "Uyarı: %s"
@@ -2739,11 +2747,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "her biri bayt"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr "devre dışı bırakıldı"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr "etkinleştirildi"
 

--- a/chirp/locale/uk_UA.po
+++ b/chirp/locale/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2015-11-30 10:36+0200\n"
 "Last-Translator: laser <student.laser@gmail.com>\n"
 "Language-Team: laser <student.laser@gmail.com>\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Видалити (та зсунути вгору)"
 msgstr[1] "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Пам'ять"
 msgstr[1] "Пам'ять"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Видалити (та зсунути вгору)"
 msgstr[1] "Видалити (та зсунути вгору)"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Файл змінено, зберегти зміни перед закриттям?"
@@ -63,7 +63,7 @@ msgstr "Файл змінено, зберегти зміни перед закр
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -506,7 +506,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -516,7 +516,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -621,17 +621,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr ""
 
@@ -639,12 +639,12 @@ msgstr ""
 msgid "All"
 msgstr "Все"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "CSV-файли"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -652,7 +652,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "Сталася помилка"
 
@@ -664,7 +664,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr ""
 
@@ -692,42 +692,42 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS код"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Кросрежим"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr ""
 
@@ -754,36 +754,36 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "Клонування"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Скопіювати з радіостанції"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "Коментар"
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 #, fuzzy
 msgid "Copy"
 msgstr "Копіювати"
@@ -816,7 +816,7 @@ msgstr "Копіювати"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 #, fuzzy
 msgid "Cross mode"
 msgstr "Кросрежим"
@@ -829,17 +829,17 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 #, fuzzy
 msgid "Cut"
 msgstr "Вирізати"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS Pol"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -850,11 +850,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr ""
 
@@ -863,27 +863,27 @@ msgstr ""
 msgid "Dec"
 msgstr "Визначити"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 #, fuzzy
 msgid "Delete"
 msgstr "Видалити"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Розробник"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 msgid "Digital Code"
 msgstr "Цифровий код"
 
@@ -892,11 +892,11 @@ msgstr "Цифровий код"
 msgid "Digital Modes"
 msgstr "Цифровий код"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Disabled"
 msgstr ""
 
@@ -914,16 +914,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 #, fuzzy
 msgid "Download from radio"
 msgstr "Скопіювати з радіостанції"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Скопіювати з радіостанції"
@@ -937,42 +937,46 @@ msgstr "Скопіювати з радіостанції"
 msgid "Driver information"
 msgstr ""
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 msgid "Enabled"
 msgstr ""
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "Частота"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -985,7 +989,7 @@ msgstr ""
 msgid "Enter custom port:"
 msgstr ""
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "Стирання пам'яті {loc}"
@@ -1003,21 +1007,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Експорт до файлу"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Експорт до файлу"
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr ""
 
@@ -1044,13 +1048,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 #, fuzzy
 msgid "Files"
 msgstr "_Файл"
@@ -1063,19 +1067,19 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 msgid "Find..."
 msgstr ""
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1118,11 +1122,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1215,7 +1219,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1233,11 +1237,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1255,12 +1259,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "Частота"
 
@@ -1273,20 +1277,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Показати Raw пам'ять"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "Довідка"
 
@@ -1298,7 +1302,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Перезаписати?"
@@ -1312,10 +1316,14 @@ msgstr ""
 msgid "Import"
 msgstr "Імпорт"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Import from file..."
 msgstr "Імпортувати з файлу"
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 #, fuzzy
@@ -1330,11 +1338,11 @@ msgstr "Зміст"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Додати рядок зверху"
@@ -1343,7 +1351,7 @@ msgstr "Додати рядок зверху"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1352,7 +1360,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Неприпустиме значення. Повинно бути цілим числом."
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Неприпустиме значення для цього поля"
@@ -1361,16 +1369,16 @@ msgstr "Неприпустиме значення для цього поля"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr ""
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "Неприпустиме значення для цього поля"
@@ -1409,7 +1417,7 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 #, fuzzy
 msgid "Load Module..."
 msgstr "Тоновий режим"
@@ -1419,12 +1427,12 @@ msgstr "Тоновий режим"
 msgid "Load module from issue"
 msgstr "Тоновий режим"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Тоновий режим"
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1456,7 +1464,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Пам'ять"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1470,7 +1478,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 #, fuzzy
 msgid "Mode"
 msgstr "Режим"
@@ -1484,15 +1492,15 @@ msgstr "Модель"
 msgid "Modes"
 msgstr "Режим"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1501,25 +1509,25 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 #, fuzzy
 msgid "Move Down"
 msgstr "Перемістити В_низ"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 #, fuzzy
 msgid "Move Up"
 msgstr "Перемістити В_гору"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Додати рядок знизу"
@@ -1541,11 +1549,11 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr ""
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "Зсув"
 
@@ -1565,29 +1573,29 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 #, fuzzy
 msgid "Open Recent"
 msgstr "Ос_танні"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Відкрити заводські конфігурації"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
@@ -1595,7 +1603,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Відкрите заводські конфігурації {name}"
@@ -1617,7 +1625,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Перезаписати?"
@@ -1633,32 +1641,32 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 #, fuzzy
 msgid "Paste"
 msgstr "Вставити"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1688,7 +1696,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1696,7 +1704,7 @@ msgid ""
 "EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr ""
 
@@ -1708,7 +1716,7 @@ msgstr ""
 msgid "Port"
 msgstr "Порт"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "Потужність"
 
@@ -1717,7 +1725,7 @@ msgstr "Потужність"
 msgid "Press enter to set this in memory"
 msgstr "Помилка настройки пам'яті"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr ""
 
@@ -1725,24 +1733,24 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr ""
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 #, fuzzy
 msgid "Radio"
 msgstr "Радіостанція"
@@ -1775,20 +1783,20 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1803,50 +1811,50 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Звіти вимкнуто"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 msgid "Restore tabs on start"
 msgstr ""
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 msgid "Saved settings"
 msgstr ""
 
@@ -1862,7 +1870,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Виберіть Стовпці"
@@ -1877,7 +1885,7 @@ msgstr "Виберіть Стовпці"
 msgid "Select Modes"
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1889,54 +1897,54 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Показати Raw пам'ять"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Вставлена пам'ять {number} несумісна із цією радіостанцією тому що:"
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 #, fuzzy
 msgid "Sort memories"
 msgstr "Перезаписати?"
@@ -1953,7 +1961,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr ""
 
@@ -2003,7 +2011,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 #, fuzzy
 msgid "This Memory"
 msgstr "Показати Raw пам'ять"
@@ -2048,12 +2056,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Видалити (та зсунути вгору)"
@@ -2079,20 +2087,20 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "Тон"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "Тоновий режим"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "ToneSql"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Крок настройки"
@@ -2107,16 +2115,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Відкрити заводські конфігурації"
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "Не вдалося виявити радіо на {port}"
@@ -2132,12 +2140,12 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Не вдається внести зміни до цієї моделі"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, fuzzy, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Не вдається внести зміни до цієї моделі"
@@ -2154,26 +2162,26 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr ""
 
@@ -2182,12 +2190,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2201,7 +2209,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr ""
 
@@ -2209,20 +2217,20 @@ msgstr ""
 msgid "Vendor"
 msgstr "Виробник"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 #, fuzzy
 msgid "View"
 msgstr "В_игляд"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2251,11 +2259,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/zh_CN.po
+++ b/chirp/locale/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-20 12:27+0100\n"
+"POT-Creation-Date: 2024-01-22 17:10-0800\n"
 "PO-Revision-Date: 2022-06-04 02:01+0800\n"
 "Last-Translator: DuckSoft, BH2UEP <realducksoft@gmail.com>\n"
 "Language: zh_CN\n"
@@ -32,25 +32,25 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1590
+#: ../wxui/memedit.py:1591
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "...并将区块上移"
 
-#: ../wxui/memedit.py:1581
+#: ../wxui/memedit.py:1582
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "存储"
 
-#: ../wxui/memedit.py:1585
+#: ../wxui/memedit.py:1586
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "...并将区块上移"
 
-#: ../wxui/main.py:1372
+#: ../wxui/main.py:1375
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "文件已更改，关闭前要保存变更吗？"
@@ -59,7 +59,7 @@ msgstr "文件已更改，关闭前要保存变更吗？"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:1922
+#: ../wxui/memedit.py:1923
 #, fuzzy, python-format
 msgid "...and %i more"
 msgstr "...并将所有存储上移"
@@ -502,7 +502,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/uvb5.py:288 ../drivers/wouxun.py:214
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -512,7 +512,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/uvb5.py:296 ../drivers/wouxun.py:222
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -617,17 +617,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1784
+#: ../wxui/main.py:1787
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:919
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1659
+#: ../wxui/main.py:1662
 msgid "About CHIRP"
 msgstr ""
 
@@ -635,12 +635,12 @@ msgstr ""
 msgid "All"
 msgstr "全选"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "全部文件"
 
-#: ../wxui/main.py:1214
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -648,7 +648,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/common.py:545 ../wxui/common.py:571
+#: ../wxui/common.py:547 ../wxui/common.py:573
 msgid "An error has occurred"
 msgstr "发生错误"
 
@@ -660,7 +660,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1727
+#: ../wxui/main.py:1730
 msgid "Bandplan"
 msgstr ""
 
@@ -688,42 +688,42 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:434
+#: ../wxui/common.py:436
 msgid ""
 "Changing this setting requires refreshing the settings from the image, which "
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1264
+#: ../wxui/memedit.py:1265
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1202
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
-#: ../wxui/memedit.py:339
+#: ../wxui/memedit.py:340
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1243
+#: ../wxui/memedit.py:1244
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS 接收代码"
 
-#: ../wxui/memedit.py:1240
+#: ../wxui/memedit.py:1241
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1274
+#: ../wxui/memedit.py:1275
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "收发使用不同亚音频"
 
-#: ../wxui/memedit.py:1304
+#: ../wxui/memedit.py:1305
 msgid "Choose duplex"
 msgstr ""
 
@@ -750,36 +750,36 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:114
+#: ../wxui/common.py:116
 msgid "Cloning"
 msgstr "正在复制"
 
-#: ../drivers/ft450d.py:508 ../drivers/ft817.py:343 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:508 ../drivers/ft817.py:343
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "从电台下载"
 
-#: ../drivers/ft450d.py:537 ../drivers/ft817.py:381 ../drivers/bj9900.py:160
+#: ../drivers/bj9900.py:160 ../drivers/ft450d.py:537 ../drivers/ft817.py:381
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "上传到电台"
 
-#: ../wxui/main.py:997
+#: ../wxui/main.py:998
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:999
 #, fuzzy
 msgid "Close file"
 msgstr "全部文件"
 
-#: ../wxui/memedit.py:1648
+#: ../wxui/memedit.py:1649
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:529
+#: ../wxui/memedit.py:530
 msgid "Comment"
 msgstr "备注"
 
@@ -802,7 +802,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1566
+#: ../wxui/memedit.py:1567
 msgid "Copy"
 msgstr "复制"
 
@@ -811,7 +811,7 @@ msgstr "复制"
 msgid "Country"
 msgstr ""
 
-#: ../wxui/memedit.py:521
+#: ../wxui/memedit.py:522
 msgid "Cross mode"
 msgstr "收发使用不同亚音频"
 
@@ -823,16 +823,16 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1562
+#: ../wxui/memedit.py:1563
 msgid "Cut"
 msgstr "剪切"
 
-#: ../wxui/memedit.py:452
+#: ../wxui/memedit.py:453
 #, fuzzy
 msgid "DTCS"
 msgstr "DTCS 策略"
 
-#: ../wxui/memedit.py:498
+#: ../wxui/memedit.py:499
 #, fuzzy
 msgid ""
 "DTCS\n"
@@ -843,12 +843,12 @@ msgstr "DTCS 策略"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2177
+#: ../wxui/memedit.py:2178
 #, fuzzy
 msgid "DV Memory"
 msgstr "该存储"
 
-#: ../wxui/main.py:1673
+#: ../wxui/main.py:1676
 msgid "Danger Ahead"
 msgstr ""
 
@@ -857,25 +857,25 @@ msgstr ""
 msgid "Dec"
 msgstr "探测"
 
-#: ../wxui/memedit.py:1575
+#: ../wxui/memedit.py:1576
 msgid "Delete"
 msgstr "删除"
 
-#: ../wxui/main.py:924
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "开发者"
 
-#: ../wxui/main.py:1679
+#: ../wxui/main.py:1682
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/developer.py:86 ../wxui/memedit.py:1684
+#: ../wxui/memedit.py:1685 ../wxui/developer.py:86
 msgid "Diff Raw Memories"
 msgstr "对比原始存储"
 
-#: ../wxui/memedit.py:2102
+#: ../wxui/memedit.py:2103
 #, fuzzy
 msgid "Digital Code"
 msgstr "数字代码"
@@ -885,11 +885,11 @@ msgstr "数字代码"
 msgid "Digital Modes"
 msgstr "数字代码"
 
-#: ../wxui/main.py:1690
+#: ../wxui/main.py:1693
 msgid "Disable reporting"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 #, fuzzy
 msgid "Disabled"
 msgstr "已启用"
@@ -908,16 +908,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1000
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1001
 #, fuzzy
 msgid "Download from radio"
 msgstr "从电台下载"
 
-#: ../wxui/main.py:831
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "从电台下载"
@@ -931,43 +931,47 @@ msgstr "显示指引"
 msgid "Driver information"
 msgstr ""
 
+#: ../wxui/main.py:542
+msgid "Driver messages"
+msgstr ""
+
 #: ../wxui/query_sources.py:333
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
-#: ../wxui/memedit.py:391
+#: ../wxui/memedit.py:392
 msgid "Duplex"
 msgstr "差频方向"
 
-#: ../wxui/memedit.py:2132
+#: ../wxui/memedit.py:2133
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2130
+#: ../wxui/memedit.py:2131
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:868
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
-#: ../wxui/memedit.py:428
+#: ../wxui/memedit.py:429
 #, fuzzy
 msgid "Enabled"
 msgstr "已启用"
 
-#: ../wxui/memedit.py:250
+#: ../wxui/memedit.py:251
 #, fuzzy
 msgid "Enter Frequency"
 msgstr "频率"
 
-#: ../wxui/memedit.py:1291
+#: ../wxui/memedit.py:1292
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1283
+#: ../wxui/memedit.py:1284
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Enter custom port:"
 msgstr ""
 
-#: ../wxui/common.py:322
+#: ../wxui/common.py:324
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "正在擦除存储 {loc}"
@@ -999,21 +1003,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "继续使用不稳定的驱动？"
 
-#: ../wxui/memedit.py:2060
+#: ../wxui/memedit.py:2061
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1357
+#: ../wxui/main.py:1360
 #, fuzzy
 msgid "Export to CSV"
 msgstr "导出到文件"
 
-#: ../wxui/main.py:711
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "导出到文件"
 
-#: ../wxui/memedit.py:2166
+#: ../wxui/memedit.py:2167
 msgid "Extra"
 msgstr ""
 
@@ -1040,13 +1044,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:546
+#: ../wxui/main.py:547
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1206 ../wxui/main.py:1287 ../wxui/main.py:1297
-#: ../wxui/main.py:1353 ../wxui/main.py:1625 ../wxui/main.py:1626
+#: ../wxui/main.py:1207 ../wxui/main.py:1288 ../wxui/main.py:1298
+#: ../wxui/main.py:1356 ../wxui/main.py:1628 ../wxui/main.py:1629
 #, fuzzy
 msgid "Files"
 msgstr "文件 (_F)"
@@ -1059,22 +1063,22 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1427
+#: ../wxui/main.py:1430
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
 
-#: ../wxui/main.py:779
+#: ../wxui/main.py:780
 #, fuzzy
 msgid "Find Next"
 msgstr "RFinder"
 
-#: ../wxui/main.py:765
+#: ../wxui/main.py:766
 #, fuzzy
 msgid "Find..."
 msgstr "RFinder"
 
-#: ../wxui/common.py:324
+#: ../wxui/common.py:326
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1117,11 +1121,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:342 ../drivers/baofeng_uv17Pro.py:437
-#: ../drivers/gmrsuv1.py:392 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/mursv1.py:342 ../drivers/uv5x3.py:418
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/btech.py:689
-#: ../drivers/gmrsv2.py:364 ../drivers/bf_t1.py:483
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:342
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:437 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1214,7 +1218,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1232,11 +1236,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/uv6r.py:348 ../drivers/baofeng_uv17Pro.py:443
-#: ../drivers/lt725uv.py:503 ../drivers/gmrsuv1.py:398
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/mursv1.py:348
-#: ../drivers/uv5x3.py:424 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/vgc.py:605 ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:348 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:443
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1254,12 +1258,12 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../wxui/memedit.py:125
+#: ../wxui/memedit.py:126
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr ""
 
-#: ../wxui/memedit.py:211
+#: ../wxui/memedit.py:212
 msgid "Frequency"
 msgstr "频率"
 
@@ -1273,21 +1277,21 @@ msgstr ""
 msgid "Getting settings"
 msgstr "正在获取 %s 信息"
 
-#: ../wxui/memedit.py:850
+#: ../wxui/memedit.py:851
 #, fuzzy
 msgid "Goto Memory"
 msgstr "该存储"
 
-#: ../wxui/memedit.py:849
+#: ../wxui/memedit.py:850
 #, fuzzy
 msgid "Goto Memory:"
 msgstr "该存储"
 
-#: ../wxui/memedit.py:818
+#: ../wxui/memedit.py:819
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:966
 msgid "Help"
 msgstr "帮助"
 
@@ -1300,7 +1304,7 @@ msgstr "在线帮助..."
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:827
+#: ../wxui/memedit.py:828
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "要覆盖吗？"
@@ -1314,10 +1318,14 @@ msgstr ""
 msgid "Import"
 msgstr "导入"
 
-#: ../wxui/main.py:705
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Import from file..."
 msgstr "导入自文件"
+
+#: ../wxui/main.py:1347
+msgid "Import messages"
+msgstr ""
 
 #: ../wxui/main.py:1341
 msgid "Import not recommended"
@@ -1331,12 +1339,12 @@ msgstr "索引"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1266
+#: ../wxui/memedit.py:1267
 #, fuzzy
 msgid "Information"
 msgstr "{information}"
 
-#: ../wxui/memedit.py:1556
+#: ../wxui/memedit.py:1557
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "上方插入一行"
@@ -1345,7 +1353,7 @@ msgstr "上方插入一行"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1354,7 +1362,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "无效值。必须为整数。"
 
-#: ../wxui/memedit.py:1411 ../wxui/query_sources.py:65
+#: ../wxui/query_sources.py:65 ../wxui/memedit.py:1412
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "设置值无效：%s"
@@ -1363,16 +1371,16 @@ msgstr "设置值无效：%s"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1410 ../wxui/memedit.py:2257
+#: ../wxui/memedit.py:1411 ../wxui/memedit.py:2258
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "设置值无效：%s"
 
-#: ../wxui/main.py:1622
+#: ../wxui/main.py:1625
 msgid "Invalid or unsupported module file"
 msgstr ""
 
-#: ../wxui/memedit.py:180 ../wxui/memedit.py:186
+#: ../wxui/memedit.py:181 ../wxui/memedit.py:187
 #, fuzzy, python-format
 msgid "Invalid value: %r"
 msgstr "%s 值无效"
@@ -1411,7 +1419,7 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:717
+#: ../wxui/main.py:718
 #, fuzzy
 msgid "Load Module..."
 msgstr "加载模块"
@@ -1421,12 +1429,12 @@ msgstr "加载模块"
 msgid "Load module from issue"
 msgstr "加载模块"
 
-#: ../wxui/main.py:956
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "加载模块"
 
-#: ../wxui/main.py:1629
+#: ../wxui/main.py:1632
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1457,7 +1465,7 @@ msgstr ""
 msgid "Memories"
 msgstr "存储"
 
-#: ../wxui/memedit.py:1450
+#: ../wxui/memedit.py:1451
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1471,7 +1479,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/memedit.py:507 ../wxui/query_sources.py:524
+#: ../wxui/query_sources.py:524 ../wxui/memedit.py:508
 #, fuzzy
 msgid "Mode"
 msgstr "制式"
@@ -1485,17 +1493,17 @@ msgstr "型号"
 msgid "Modes"
 msgstr "制式"
 
-#: ../wxui/main.py:1626
+#: ../wxui/main.py:1629
 #, fuzzy
 msgid "Module"
 msgstr "模块"
 
-#: ../wxui/main.py:1598
+#: ../wxui/main.py:1601
 #, fuzzy
 msgid "Module Loaded"
 msgstr "模块"
 
-#: ../wxui/main.py:1713
+#: ../wxui/main.py:1716
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1504,26 +1512,26 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:814
+#: ../wxui/memedit.py:815
 #, fuzzy
 msgid "Move Down"
 msgstr "下移 (_N)"
 
-#: ../wxui/memedit.py:804
+#: ../wxui/memedit.py:805
 #, fuzzy
 msgid "Move Up"
 msgstr "上移 (_U)"
 
-#: ../wxui/main.py:651
+#: ../wxui/main.py:652
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1786
+#: ../wxui/main.py:1789
 #, fuzzy
 msgid "New version available"
 msgstr "CHIRP 新版本可用：{ver}。"
 
-#: ../wxui/memedit.py:1721
+#: ../wxui/memedit.py:1722
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "下方插入一行"
@@ -1545,11 +1553,11 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/memedit.py:849 ../wxui/query_sources.py:40
+#: ../wxui/query_sources.py:40 ../wxui/memedit.py:850
 msgid "Number"
 msgstr ""
 
-#: ../wxui/memedit.py:209
+#: ../wxui/memedit.py:210
 msgid "Offset"
 msgstr "频差"
 
@@ -1569,29 +1577,29 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:993 ../wxui/main.py:1343
+#: ../wxui/main.py:994 ../wxui/main.py:1343
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:692
+#: ../wxui/main.py:693
 #, fuzzy
 msgid "Open Recent"
 msgstr "打开最近 (_R)"
 
-#: ../wxui/main.py:662
+#: ../wxui/main.py:663
 msgid "Open Stock Config"
 msgstr "打开库存配置"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1217
+#: ../wxui/main.py:995 ../wxui/main.py:1218
 #, fuzzy
 msgid "Open a file"
 msgstr "打开最近的文件"
 
-#: ../wxui/main.py:1644
+#: ../wxui/main.py:1647
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
@@ -1599,7 +1607,7 @@ msgstr ""
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:609
+#: ../wxui/main.py:610
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "打开库存配置 {name}"
@@ -1621,7 +1629,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1853
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "要覆盖吗？"
@@ -1637,31 +1645,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1570
+#: ../wxui/memedit.py:1571
 msgid "Paste"
 msgstr "粘贴"
 
-#: ../wxui/memedit.py:1847
+#: ../wxui/memedit.py:1848
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1850
+#: ../wxui/memedit.py:1851
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1845
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1841
+#: ../wxui/memedit.py:1842
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1790
+#: ../wxui/main.py:1793
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1691,7 +1699,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1667
+#: ../wxui/main.py:1670
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1699,7 +1707,7 @@ msgid ""
 "EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:187
+#: ../wxui/common.py:189
 msgid "Please wait"
 msgstr ""
 
@@ -1711,7 +1719,7 @@ msgstr ""
 msgid "Port"
 msgstr "端口"
 
-#: ../wxui/memedit.py:271
+#: ../wxui/memedit.py:272
 msgid "Power"
 msgstr "功率"
 
@@ -1720,7 +1728,7 @@ msgstr "功率"
 msgid "Press enter to set this in memory"
 msgstr "设置存储时出错"
 
-#: ../wxui/main.py:728
+#: ../wxui/main.py:729
 msgid "Print Preview"
 msgstr ""
 
@@ -1728,26 +1736,26 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1549
+#: ../wxui/memedit.py:1550
 msgid "Properties"
 msgstr "属性"
 
-#: ../wxui/main.py:1741
+#: ../wxui/main.py:1744
 #, fuzzy, python-format
 msgid "Query %s"
 msgstr "查询失败"
 
-#: ../wxui/main.py:845
+#: ../wxui/main.py:846
 #, fuzzy
 msgid "Query Source"
 msgstr "查询数据源"
 
-#: ../wxui/memedit.py:454
+#: ../wxui/memedit.py:455
 #, fuzzy
 msgid "RX DTCS"
 msgstr "DTCS 接收代码"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:965
 msgid "Radio"
 msgstr "电台"
 
@@ -1779,21 +1787,21 @@ msgid ""
 "<small>Premium account required</small>"
 msgstr ""
 
-#: ../wxui/common.py:436
+#: ../wxui/common.py:438
 #, fuzzy
 msgid "Refresh required"
 msgstr "刷新"
 
-#: ../wxui/common.py:314
+#: ../wxui/common.py:316
 #, fuzzy, python-format
 msgid "Refreshed memory %s"
 msgstr "这些存储"
 
-#: ../wxui/main.py:885
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:894
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1807,49 +1815,49 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:933
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "报告已禁用"
 
-#: ../wxui/main.py:1686
+#: ../wxui/main.py:1689
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1684
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:672
+#: ../wxui/main.py:673
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 
-#: ../wxui/main.py:815
+#: ../wxui/main.py:816
 msgid "Restore tabs on start"
 msgstr ""
 
-#: ../wxui/common.py:318
+#: ../wxui/common.py:320
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:995
+#: ../wxui/main.py:996
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1374
+#: ../wxui/main.py:1377
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:996 ../wxui/main.py:1301
+#: ../wxui/main.py:997 ../wxui/main.py:1302
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:320
+#: ../wxui/common.py:322
 #, fuzzy
 msgid "Saved settings"
 msgstr "设置"
@@ -1866,7 +1874,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:875
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "全选"
@@ -1881,7 +1889,7 @@ msgstr "选择列"
 msgid "Select Modes"
 msgstr "选择列"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1729
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1893,50 +1901,50 @@ msgstr ""
 msgid "Settings"
 msgstr "设置"
 
-#: ../wxui/developer.py:89 ../wxui/memedit.py:1677
+#: ../wxui/memedit.py:1678 ../wxui/developer.py:89
 msgid "Show Raw Memory"
 msgstr "显示原始存储"
 
-#: ../wxui/main.py:951
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:823
+#: ../wxui/memedit.py:824
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/memedit.py:1926
+#: ../wxui/memedit.py:1927
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "粘贴的存储 {number} 与此电台不兼容，原因："
 
-#: ../wxui/memedit.py:1794
+#: ../wxui/memedit.py:1795
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1633
+#: ../wxui/memedit.py:1634
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1637
+#: ../wxui/memedit.py:1638
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1659
+#: ../wxui/memedit.py:1660
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1526
+#: ../wxui/memedit.py:1527
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1525
+#: ../wxui/memedit.py:1526
 #, fuzzy
 msgid "Sort memories"
 msgstr "要覆盖吗？"
@@ -1954,7 +1962,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1714
+#: ../wxui/main.py:1717
 msgid "Success"
 msgstr ""
 
@@ -2004,7 +2012,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1595
+#: ../wxui/memedit.py:1596
 #, fuzzy
 msgid "This Memory"
 msgstr "该存储"
@@ -2049,12 +2057,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1599
+#: ../wxui/memedit.py:1600
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "...并将区块上移"
 
-#: ../wxui/memedit.py:1597
+#: ../wxui/memedit.py:1598
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "...并将区块上移"
@@ -2080,20 +2088,20 @@ msgstr ""
 msgid "This will load a module from a website issue"
 msgstr ""
 
-#: ../wxui/memedit.py:357
+#: ../wxui/memedit.py:358
 msgid "Tone"
 msgstr "亚音频"
 
-#: ../wxui/memedit.py:884
+#: ../wxui/memedit.py:885
 msgid "Tone Mode"
 msgstr "亚音频制式"
 
-#: ../wxui/memedit.py:359
+#: ../wxui/memedit.py:360
 #, fuzzy
 msgid "Tone Squelch"
 msgstr "接收亚音频"
 
-#: ../wxui/memedit.py:301 ../wxui/memedit.py:898
+#: ../wxui/memedit.py:302 ../wxui/memedit.py:899
 #, fuzzy
 msgid "Tuning Step"
 msgstr "调谐间隔"
@@ -2108,16 +2116,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1331
+#: ../wxui/memedit.py:1332
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1259
+#: ../wxui/main.py:1260
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/common.py:220
+#: ../wxui/common.py:222
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "无法打开此镜像：型号不支持"
@@ -2133,12 +2141,12 @@ msgid ""
 "model and try again."
 msgstr ""
 
-#: ../wxui/common.py:621
+#: ../wxui/common.py:623
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "无法变更此型号电台"
 
-#: ../wxui/memedit.py:161
+#: ../wxui/memedit.py:162
 #, fuzzy, python-format
 msgid "Unable to set %s on this memory"
 msgstr "无法变更此型号电台"
@@ -2156,26 +2164,26 @@ msgstr ""
 msgid "Upload instructions"
 msgstr "{instructions}"
 
-#: ../wxui/main.py:1002
+#: ../wxui/main.py:1003
 #, fuzzy
 msgid "Upload to radio"
 msgstr "上传到电台"
 
-#: ../wxui/main.py:839
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "上传到电台"
 
-#: ../wxui/common.py:316
+#: ../wxui/common.py:318
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:800
+#: ../wxui/main.py:801
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:808
+#: ../wxui/main.py:809
 msgid "Use larger font"
 msgstr ""
 
@@ -2184,12 +2192,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:468
+#: ../wxui/common.py:470
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:472
+#: ../wxui/common.py:474
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2203,7 +2211,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2157
+#: ../wxui/memedit.py:2158
 msgid "Values"
 msgstr ""
 
@@ -2211,20 +2219,20 @@ msgstr ""
 msgid "Vendor"
 msgstr "厂商"
 
-#: ../wxui/main.py:963
+#: ../wxui/main.py:964
 #, fuzzy
 msgid "View"
 msgstr "查看 (_V)"
 
-#: ../wxui/common.py:420
+#: ../wxui/common.py:422
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1417
+#: ../wxui/memedit.py:1418
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1416
+#: ../wxui/memedit.py:1417
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2253,12 +2261,12 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 #, fuzzy
 msgid "disabled"
 msgstr "已启用"
 
-#: ../wxui/main.py:1664
+#: ../wxui/main.py:1667
 #, fuzzy
 msgid "enabled"
 msgstr "已启用"

--- a/chirp/logger.py
+++ b/chirp/logger.py
@@ -21,6 +21,7 @@ it checks the CHIRP_DEBUG, CHIRP_LOG, and CHIRP_LOG_LEVEL environment
 variables.
 """
 
+import contextlib
 import os
 import sys
 import logging
@@ -189,3 +190,27 @@ def handle_options(options):
 
     if logger.early_level > logging.DEBUG:
         logger.LOG.debug(version_string())
+
+
+class LookbackHandler(logging.Handler):
+    def __init__(self):
+        super().__init__()
+        self._history = []
+
+    def emit(self, record):
+        self._history.append(record)
+
+    def get_history(self):
+        return self._history
+
+
+@contextlib.contextmanager
+def log_history(level, root=None):
+    root = logging.getLogger(root)
+    handler = LookbackHandler()
+    handler.setLevel(level)
+    try:
+        root.addHandler(handler)
+        yield handler
+    finally:
+        root.removeHandler(handler)

--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import atexit
+import contextlib
 import functools
 import logging
 import os
@@ -27,6 +28,7 @@ import wx
 from chirp import chirp_common
 from chirp.drivers import generic_csv
 from chirp import errors
+from chirp import logger
 from chirp import platform as chirp_platform
 from chirp import settings
 from chirp.wxui import config
@@ -642,3 +644,18 @@ def temporary_debug_log():
     delete_atexit(dst)
     shutil.copy(src, dst)
     return dst
+
+
+@contextlib.contextmanager
+def expose_logs(level, root, label):
+    with logger.log_history(level, root) as history:
+        try:
+            yield
+        finally:
+            if history.get_history():
+                msg = os.linesep.join(x.getMessage()
+                                      for x in history.get_history())
+                d = wx.MessageDialog(
+                    None, str(msg), label,
+                    style=wx.OK | wx.ICON_INFORMATION)
+                d.ShowModal()

--- a/tests/test_detect.py
+++ b/tests/test_detect.py
@@ -5,12 +5,17 @@ from unittest import mock
 import pytest
 
 from chirp import directory
+from chirp import logger
 from tests import base
 
 
 class TestCaseDetect(base.DriverTest):
     def test_detect(self):
-        radio = directory.get_radio_by_image(self.TEST_IMAGE)
+        with logger.log_history(logging.WARNING, 'chirp.drivers') as history:
+            radio = directory.get_radio_by_image(self.TEST_IMAGE)
+            self.assertEqual([], history.get_history(),
+                             'Drivers should not log warnings/errors for '
+                             'good images')
         if hasattr(radio, '_orig_rclass'):
             radio = radio._orig_rclass(self.TEST_IMAGE)
         if isinstance(self.radio, radio.__class__):

--- a/tests/unit/test_logger.py
+++ b/tests/unit/test_logger.py
@@ -1,0 +1,38 @@
+import logging
+
+from chirp import logger
+from tests.unit import base
+
+
+class TestLogger(base.BaseTest):
+    def test_log_history(self):
+        drv_log = logging.getLogger('chirp.drivers.foo')
+        ui_log = logging.getLogger('chirp.wxui.foo')
+        root_log = logging.getLogger()
+
+        root_log.setLevel(logging.DEBUG)
+
+        def log_all():
+            for log in (drv_log, ui_log, root_log):
+                log.debug('debug')
+                log.warning('warning')
+                log.error('error')
+
+        # Log to everything
+        log_all()
+
+        with logger.log_history(logging.WARNING, 'chirp.drivers') as h:
+            log_all()
+            history = h.get_history()
+
+        # We should only have the error,warning messages from drivers
+        # since we started the capture, not before
+        self.assertEqual(2, len(history))
+
+        with logger.log_history(logging.WARNING, 'chirp.drivers') as h:
+            log_all()
+            history = h.get_history()
+
+        # Make sure we only have the captured logs, not any leftover from
+        # the previous run
+        self.assertEqual(2, len(history))


### PR DESCRIPTION
This makes us capture and display any warning or error log messages
that the driver emits while we're loading it (but no other times).
While this is sort of a hack, it provides a conduit for the driver's
sanity-checking routines to communicate concerns to the UI user, such
as un-parse-able CSV lines, etc. Actual failures to parse the image
should of course still raise an exception to stop the process.

Fixes: #11093
