### PR TITLE
KG-UV980P freq limit fix

### DIFF
--- a/chirp/drivers/kguv980p.py
+++ b/chirp/drivers/kguv980p.py
@@ -53,7 +53,7 @@ DIR_FROM = 0x00
 config_map = (          # map address, write size, write count
     # (0x0, 64, 512),     # 0 to 8000 - full write use only
     (0x4c,  12, 1),    # Mode PSW --  Display name
-    (0x60,  44, 1),    # Freq Limits
+    (0x60,  16, 3),    # Freq Limits
     (0x740,  40, 1),    # FM chan 1-20
     (0x830,  16, 13),    # General settings
     (0x900, 8, 1),       # General settings


### PR DESCRIPTION
Fixes: #11096
Update config map to send 3 blocks of 16 bytes to allow radio to accept the last sets of freq limits.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues). Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
