### PR TITLE
Fix duplicate definitions of bitfields

### DIFF
--- a/chirp/drivers/kyd_IP620.py
+++ b/chirp/drivers/kyd_IP620.py
@@ -41,7 +41,7 @@ struct {           // Channel memory structure
      n_a:2;        // n-a
   u8 unknown_2:1,  // n-a
      scan_add:1,   // Scan add
-     n_a:1,        // n-a
+     n_a2:1,       // n-a
      w_n:1,        // Narrow-0 Wide-1
      lout:1,       // LOCKOUT OFF-0 ON-1
      n_a_:1,       // n-a
@@ -67,7 +67,7 @@ struct {           // Settings memory structure ( A-Frequency mode )
   n_a:2;
   u8 unknown_1_6:3,
   freq_a_w_n:1,
-  n_a:1,
+  n_a2:1,
   na:1,
   freq_a_power:2;
   u8 unknown_1_7;

--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -129,13 +129,13 @@ struct {
             // calls it tdrch. Since this is a minor difference, it will
             // be referred to by the wrong name for the UV-82HP.
   u8 displayab:1,
-     unknown1:2,
+     unknown7:2,
      fmradio:1,
      alarm:1,
-     unknown2:1,
+     unknown8:1,
      reset:1,
      menu:1;
-  u8 unknown1:6,
+  u8 unknown9:6,
      singleptt:1,
      vfomrlock:1;
   u8 workmode;


### PR DESCRIPTION
This PR renames the duplicated struct members, all were unused.