### PR TITLE
bitwise: Fix logging a warning for incomplete bitfields

### DIFF
--- a/chirp/bitwise.py
+++ b/chirp/bitwise.py
@@ -935,7 +935,7 @@ class Processor:
 
         if bitsleft:
             LOG.warn("WARNING: %i trailing bits unaccounted for in %s" %
-                     (bitsleft, bitfield))
+                     (bitsleft, name))
 
         return bytes
 


### PR DESCRIPTION
Fixes RecursionError exception triggered by line 937 in chirp/bitwise.py.

After this change, the following script
```
#! /usr/bin/env python3
from chirp import bitwise

defn ="""
struct {
u8 onebit:1;
} memory;
"""

data = bytearray(b"\x00")
tree = bitwise.parse(defn, data)
print(tree)
```

prints:
```
WARNING: 7 trailing bits unaccounted for in onebit
struct {
           memory: struct {
           onebit: 0x00 (.......0b)
} memory (0 bytes at 0x0000)

} (anonymous) (0 bytes at 0x0000)
```

before it would trigger a `RecursionError` exception and would not reach the `print()`.