### PR TITLE
Make the MessageBoxes stay on top of their parent Dialog

### DIFF
--- a/chirp/wxui/clone.py
+++ b/chirp/wxui/clone.py
@@ -375,14 +375,14 @@ class ChirpCloneDialog(wx.Dialog):
         r = wx.MessageBox(
             _('Unplug your cable (if needed) and then click OK'),
             _('USB Port Finder'),
-            style=wx.OK | wx.CANCEL | wx.OK_DEFAULT)
+            style=wx.OK | wx.CANCEL | wx.OK_DEFAULT, parent=self)
         if r == wx.CANCEL:
             return
         before = list_ports.comports()
         r = wx.MessageBox(
             _('Plug in your cable and then click OK'),
             _('USB Port Finder'),
-            style=wx.OK | wx.CANCEL | wx.OK_DEFAULT)
+            style=wx.OK | wx.CANCEL | wx.OK_DEFAULT, parent=self)
         if r == wx.CANCEL:
             return
         after = list_ports.comports()
@@ -392,7 +392,7 @@ class ChirpCloneDialog(wx.Dialog):
             wx.MessageBox(
                 _('Unable to determine port for your cable. '
                   'Check your drivers and connections.'),
-                _('USB Port Finder'))
+                _('USB Port Finder'), parent=self)
             self.set_ports(after)
             return
         elif len(changed) == 1:
@@ -400,11 +400,11 @@ class ChirpCloneDialog(wx.Dialog):
             wx.MessageBox(
                 '%s\n%s' % (_('Your cable appears to be on port:'),
                             port_label(found)),
-                _('USB Port Finder'))
+                _('USB Port Finder'), parent=self)
         else:
             wx.MessageBox(
                 _('More than one port found: %s') % ', '.join(changed),
-                _('USB Port Finder'))
+                _('USB Port Finder'), parent=self)
             self.set_ports(after)
             return
         self.set_ports(after, select=found.device)
@@ -480,7 +480,7 @@ class ChirpCloneDialog(wx.Dialog):
         def safe_fail():
             wx.MessageBox(message,
                           _('Error communicating with radio'),
-                          wx.ICON_ERROR)
+                          wx.ICON_ERROR, parent=self)
             self.cancel_action()
         wx.CallAfter(safe_fail)
 

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -2255,7 +2255,7 @@ class ChirpMemPropDialog(wx.Dialog):
             msgs = self._radio.validate_memory(mem)
             if msgs:
                 wx.MessageBox(_('Invalid edit: %s') % '; '.join(msgs),
-                              'Invalid Entry')
+                              'Invalid Entry', parent=self)
                 raise errors.InvalidValueError()
 
     def _button(self, event):


### PR DESCRIPTION
This PR avoids an issue (at least on Linux Gtk) when:

- a dialog is open (ChirpMemPropDialog or ChirpCloneDialog)
- an error message or an information message is displayed in a MessageBox (such as for an invalid entry or a communication error)
- the user clicks on the main window or on the dialog causing the MessageBox to get hidden behind the dialog:

![image](https://github.com/kk7ds/chirp/assets/1055635/72d119b2-db70-4dc9-83b2-626433bd6bbe)
