### PR TITLE
puxing_px888k: fix bitwise errors

### DIFF
--- a/chirp/drivers/puxing_px888k.py
+++ b/chirp/drivers/puxing_px888k.py
@@ -344,7 +344,7 @@ struct {
         u8 rxtx_stun_code_length;
         u8 cancel_rxtx_stun_code_length;
         u8 cancel_rxtx_stun_code[4];
-        u8 _unknown_0D4E[2];
+        u8 _unknown_0D5E[2];
 
 // 0x0d60
         struct {
@@ -1327,7 +1327,7 @@ class Puxing_PX888K_Radio(chirp_common.CloneModeRadio):
                              _data.ptt_id_edge,
                              PTT_ID_EDGES),
                 list_setting("Optional signal before/after transmission, " +
-                             "this setting overrides the PTT ID setting.",
+                             "this setting overrides the PTT ID setting",
                              "Opt Signal",
                              _data.opt_signal,
                              OPTSIGN_MODES))


### PR DESCRIPTION
There also seems to be a bug introduced to CHIRP-next build 20230531 that causes the '.' (period) at the end of the string at line 1330 to be used to split the value at this point to create an extra value. This causes loading of the puxing_px888.img test image to fail. This should probably be fixed, but removing the '.' from the string resolves the issue for now.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues). Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
