### PR TITLE
Fix/ft1d

### DIFF
--- a/chirp/drivers/ft1d.py
+++ b/chirp/drivers/ft1d.py
@@ -986,7 +986,7 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
                     num += len(x[1])
                     # num -= len(x[1])
             if array is None:
-                raise IndexError("Unknown special %s", memref)
+                raise IndexError("Unknown special %s" % memref)
             num += ndx
             # num -= ndx
         elif memref > self.MAX_MEM_SLOT:         # numbered special
@@ -1000,7 +1000,7 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
                     break
                 ndx -= len(x[1])
             if array is None:
-                raise IndexError("Unknown memref number %s", memref)
+                raise IndexError("Unknown memref number %s" % memref)
         else:
             array = "memory"
             ndx = memref - 1

--- a/chirp/drivers/ft1d.py
+++ b/chirp/drivers/ft1d.py
@@ -828,9 +828,6 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
     _VFO_SCAN_MODE = ("BAND", "ALL")
     _MEMORY_SCAN_MODE = ("BAND", "ALL")
 
-    _SG_RE = re.compile(r"(?P<sign>[-+NESW]?)(?P<d>[\d]+)[\s\.,]*"
-                        "(?P<m>[\d]*)[\s\']*(?P<s>[\d]*)")
-
     _RX_BAUD = ("off", "1200 baud", "9600 baud")
     _TX_DELAY = ("100ms", "150ms", "200ms", "250ms", "300ms",
                  "400ms", "500ms", "750ms", "1000ms")

--- a/chirp/drivers/ft1d.py
+++ b/chirp/drivers/ft1d.py
@@ -878,7 +878,7 @@ class FT1Radio(yaesu_clone.YaesuCloneModeRadio):
     _SQUELCH = ["%d" % x for x in range(0, 16)]
     _VOLUME = ["%d" % x for x in range(0, 33)]
     _DG_ID = ["%d" % x for x in range(0, 100)]
-    _GM_RING = ("OFF", "IN RING", "AlWAYS")
+    _GM_RING = ("OFF", "IN RING", "ALWAYS")
     _GM_INTERVAL = ("LONG", "NORMAL", "OFF")
 
     _MYCALL_CHR_SET = list(string.ascii_uppercase) + \


### PR DESCRIPTION
This PR:

- reorders some structs in the memory map
- removes a duplicated assignment that cause a warning to be  printed when installing the Debian package of chirp version 1:20240122-2
- fixes a small typo

A `#seekto` directive was useful because an "invalid negative seek" warning pointed a previously unknown field that was instead partially known and so could be deleted to fix the offset.
