### PR TITLE
5RM: Fix paste/import of AM frequencies

### DIFF
--- a/chirp/drivers/baofeng_uv17Pro.py
+++ b/chirp/drivers/baofeng_uv17Pro.py
@@ -1316,3 +1316,19 @@ class BF5RM(UV17Pro):
     SCODE_LIST = ["%s" % x for x in range(1, 16)]
     LIST_PW_SAVEMODE = ["Off", "1:1", "1:2", "1:4"]
     _has_workmode_support = True
+
+    def check_set_memory_immutable_policy(self, existing, new):
+        if (self._airband[0] <= new.freq <= self._airband[1] and
+                new.mode == 'AM'):
+            # This is valid, so mark mode as immutable so it doesn't get
+            # blocked, and let the radio override it during set.
+            new.immutable.append('mode')
+            existing.immutable = []
+        elif existing.mode == 'AM' and new.mode in self.MODES:
+            # If we're going from a forced-AM channel to some valid one,
+            # clear immutable so we allow the change.
+            try:
+                existing.immutable.remove('mode')
+            except ValueError:
+                pass
+        super().check_set_memory_immutable_policy(existing, new)

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -764,6 +764,7 @@ class TestOverrideRules(base.BaseTest):
         'Radioddity_DB25-G',
         'Retevis_RB17P',
         'Baofeng_UV-17ProGPS',
+        'Baofeng_5RM',
     ]
 
     def _test_radio_override_immutable_policy(self, rclass):


### PR DESCRIPTION
This radio behaves like the 17ProGPS with regards to supporting airband
frequencies, so apply the same immutable override to make it work.

Fixes #11185
