### PR TITLE
TIDRADIO: Enforce usedflags at read time to prevent untouched memorie…

### DIFF
--- a/chirp/drivers/tdh8.py
+++ b/chirp/drivers/tdh8.py
@@ -1081,7 +1081,10 @@ class TDH8(chirp_common.CloneModeRadio):
 
         if _mem.get_raw(asbytes=False)[0] == "\xff":
             mem.empty = True
+            self.set_usedFlag(mem)
             return mem
+
+        self.set_usedFlag(mem)
 
         # receiving frequency
         mem.freq = int(_mem.rxfreq) * 10
@@ -1254,20 +1257,7 @@ class TDH8(chirp_common.CloneModeRadio):
 
         return ([x_list, y_list])
 
-    def set_memory(self, mem):
-        _mem = self._get_mem(mem.number)
-        _nam = self._get_nam(mem.number)
-
-        if mem.empty:
-            _mem.set_raw("\xff" * 16)
-            if self.MODEL in H8_LIST:
-                _nam.set_raw("\xff" * 16)
-            else:
-                _nam.set_raw("\xff" * 8)
-            return
-
-        _mem.set_raw("\x00" * 16)
-
+    def set_usedFlag(self, mem):
         # When the channel is empty, you need to set "usedflags" to 0,
         # which means it is empty.When the channel has a value,
         # you need to set "usedflags" to 0,
@@ -1314,6 +1304,22 @@ class TDH8(chirp_common.CloneModeRadio):
                 _usedflags.block7 = 0
             elif block_xy[1] == 8:
                 _usedflags.block8 = 0
+
+    def set_memory(self, mem):
+        _mem = self._get_mem(mem.number)
+        _nam = self._get_nam(mem.number)
+
+        if mem.empty:
+            _mem.set_raw("\xff" * 16)
+            if self.MODEL in H8_LIST:
+                _nam.set_raw("\xff" * 16)
+            else:
+                _nam.set_raw("\xff" * 8)
+            return
+
+        _mem.set_raw("\x00" * 16)
+
+        self.set_usedFlag(mem)
 
         if mem.duplex == "":
             _mem.rxfreq = _mem.txfreq = mem.freq / 10


### PR DESCRIPTION
…s from appearing full

Fixes #11185

Absolutely untested. This pc is still on suicide watch. trying to see if it passes tests at least.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues). Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
