### PR TITLE
Fix duplex=off tests and a BUNCH of drivers

### DIFF
--- a/chirp/bitwise.py
+++ b/chirp/bitwise.py
@@ -306,6 +306,12 @@ class arrayDataElement(DataElement):
         raw = [item.get_raw(asbytes=True) for item in self.__items]
         return self._compat_bytes(bytes(b''.join(raw)), asbytes)
 
+    def set_raw(self, data):
+        item_size = self.__items[0].size() // 8
+        assert len(data) / item_size == len(self), 'Invalid raw data length'
+        for i in range(len(self)):
+            self[i].set_raw(data[i * item_size:(i + 1) * item_size])
+
     def __setitem__(self, index, val):
         self.__items[index].set_value(val)
 

--- a/chirp/drivers/anytone_ht.py
+++ b/chirp/drivers/anytone_ht.py
@@ -498,7 +498,7 @@ class AnyToneTERMN8RRadio(chirp_common.CloneModeRadio,
         mem.duplex = DUPLEXES[_mem.duplex]
         mem.mode = MODES[_mem.channel_width]
 
-        if _mem.tx_off is True:
+        if bool(_mem.tx_off):
             mem.duplex = "off"
             mem.offset = 0
 

--- a/chirp/drivers/kyd.py
+++ b/chirp/drivers/kyd.py
@@ -312,7 +312,7 @@ class NC630aRadio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
@@ -320,6 +320,8 @@ class NC630aRadio(chirp_common.CloneModeRadio):
         if int(_mem.rxfreq) == int(_mem.txfreq):
             mem.duplex = ""
             mem.offset = 0
+        elif _mem.txfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
+            mem.duplex = "off"
         else:
             mem.duplex = int(_mem.rxfreq) > int(_mem.txfreq) and "-" or "+"
             mem.offset = abs(int(_mem.rxfreq) - int(_mem.txfreq)) * 10
@@ -390,16 +392,15 @@ class NC630aRadio(chirp_common.CloneModeRadio):
         _skp = self._memobj.skipflags[bytepos]
 
         if mem.empty:
-            _mem.set_raw("\xFF" * 16)
+            _mem.fill_raw(b"\xFF")
             return
 
-        _mem.set_raw("\x00" * 14 + "\xFF" * 2)
+        _mem.set_raw(b"\x00" * 14 + b"\xFF" * 2)
 
         _mem.rxfreq = mem.freq / 10
 
         if mem.duplex == "off":
-            for i in range(0, 4):
-                _mem.txfreq[i].set_raw("\xFF")
+            _mem.txfreq.fill_raw(b"\xFF")
         elif mem.duplex == "split":
             _mem.txfreq = mem.offset / 10
         elif mem.duplex == "+":

--- a/chirp/drivers/mml_jc8810.py
+++ b/chirp/drivers/mml_jc8810.py
@@ -517,7 +517,7 @@ class JC8810base(chirp_common.CloneModeRadio):
         # Freq and offset
         mem.freq = int(_mem.rxfreq) * 10
         # tx freq can be blank
-        if _mem.get_raw()[:4] == b"\xFF\xFF\xFF\xFF":
+        if _mem.txfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
             # TX freq not set
             mem.offset = 0
             mem.duplex = "off"
@@ -646,8 +646,7 @@ class JC8810base(chirp_common.CloneModeRadio):
         _mem.rxfreq = mem.freq / 10
 
         if mem.duplex == "off":
-            for i in range(0, 4):
-                _mem.txfreq[i].set_raw("\xFF")
+            _mem.txfreq.fill_raw(b"\xFF")
         elif mem.duplex == "split":
             _mem.txfreq = mem.offset / 10
         elif mem.duplex == "+":

--- a/chirp/drivers/retevis_rb15.py
+++ b/chirp/drivers/retevis_rb15.py
@@ -471,19 +471,19 @@ class RB15RadioBase(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
 
-        if _mem.get_raw(asbytes=False) == ("\xFF" * 16):
+        if _mem.get_raw() == (b"\xFF" * 16):
             LOG.debug("Initializing empty memory")
-            _mem.set_raw("\x00" * 16)
+            _mem.set_raw(b"\x00" * 16)
 
         # Freq and offset
         mem.freq = int(_mem.rxfreq) * 10
         # tx freq can be blank
-        if _mem.get_raw(asbytes=False)[4] == "\xFF":
+        if _mem.txfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
             # TX freq not set
             mem.offset = 0
             mem.duplex = "off"
@@ -545,8 +545,7 @@ class RB15RadioBase(chirp_common.CloneModeRadio):
         _mem.rxfreq = mem.freq / 10
 
         if mem.duplex == "off":
-            for i in range(0, 4):
-                _mem.txfreq[i].set_raw("\xFF")
+            _mem.txfreq.fill_raw(b"\xFF")
         elif mem.duplex == "split":
             _mem.txfreq = mem.offset / 10
         elif mem.duplex == "+":

--- a/chirp/drivers/retevis_rt1.py
+++ b/chirp/drivers/retevis_rt1.py
@@ -426,7 +426,7 @@ class RT1Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
@@ -434,6 +434,8 @@ class RT1Radio(chirp_common.CloneModeRadio):
         if int(_mem.rxfreq) == int(_mem.txfreq):
             mem.duplex = ""
             mem.offset = 0
+        elif _mem.txfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
+            mem.duplex = "off"
         else:
             mem.duplex = int(_mem.rxfreq) > int(_mem.txfreq) and "-" or "+"
             mem.offset = abs(int(_mem.rxfreq) - int(_mem.txfreq)) * 10
@@ -480,8 +482,7 @@ class RT1Radio(chirp_common.CloneModeRadio):
         _mem.rxfreq = mem.freq / 10
 
         if mem.duplex == "off":
-            for i in range(0, 4):
-                _mem.txfreq[i].set_raw("\xFF")
+            _mem.txfreq.fill_raw(b"\xFF")
         elif mem.duplex == "split":
             _mem.txfreq = mem.offset / 10
         elif mem.duplex == "+":

--- a/chirp/drivers/retevis_rt21.py
+++ b/chirp/drivers/retevis_rt21.py
@@ -910,7 +910,7 @@ class RT21Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
@@ -918,6 +918,8 @@ class RT21Radio(chirp_common.CloneModeRadio):
         if int(_mem.rxfreq) == int(_mem.txfreq):
             mem.duplex = ""
             mem.offset = 0
+        elif _mem.txfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
+            mem.duplex = "off"
         else:
             mem.duplex = int(_mem.rxfreq) > int(_mem.txfreq) and "-" or "+"
             mem.offset = abs(int(_mem.rxfreq) - int(_mem.txfreq)) * 10
@@ -1214,8 +1216,7 @@ class RT21Radio(chirp_common.CloneModeRadio):
         _mem.rxfreq = mem.freq / 10
 
         if mem.duplex == "off":
-            for i in range(0, 4):
-                _mem.txfreq[i].set_raw("\xFF")
+            _mem.txfreq.fill_raw(b"\xFF")
         elif mem.duplex == "split":
             _mem.txfreq = mem.offset / 10
         elif mem.duplex == "+":

--- a/chirp/drivers/retevis_rt22.py
+++ b/chirp/drivers/retevis_rt22.py
@@ -470,6 +470,8 @@ class RT22Radio(chirp_common.CloneModeRadio):
         if int(_mem.rxfreq) == int(_mem.txfreq):
             mem.duplex = ""
             mem.offset = 0
+        elif _mem.txfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
+            mem.duplex = "off"
         else:
             mem.duplex = int(_mem.rxfreq) > int(_mem.txfreq) and "-" or "+"
             mem.offset = abs(int(_mem.rxfreq) - int(_mem.txfreq)) * 10
@@ -550,8 +552,7 @@ class RT22Radio(chirp_common.CloneModeRadio):
         _mem.rxfreq = mem.freq / 10
 
         if mem.duplex == "off":
-            for i in range(0, 4):
-                _mem.txfreq[i].set_raw("\xFF")
+            _mem.txfreq.fill_raw(b"\xFF")
         elif mem.duplex == "split":
             _mem.txfreq = mem.offset / 10
         elif mem.duplex == "+":

--- a/chirp/drivers/retevis_rt26.py
+++ b/chirp/drivers/retevis_rt26.py
@@ -438,7 +438,7 @@ class RT26Radio(chirp_common.CloneModeRadio):
             mem.empty = True
             return mem
 
-        if _mem.rxfreq.get_raw(asbytes=False) == "\xFF\xFF\xFF\xFF":
+        if _mem.rxfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
             mem.freq = 0
             mem.empty = True
             return mem
@@ -446,6 +446,8 @@ class RT26Radio(chirp_common.CloneModeRadio):
         if int(_mem.rxfreq) == int(_mem.txfreq):
             mem.duplex = ""
             mem.offset = 0
+        elif _mem.txfreq.get_raw() == b"\xFF\xFF\xFF\xFF":
+            mem.duplex = "off"
         else:
             mem.duplex = int(_mem.rxfreq) > int(_mem.txfreq) and "-" or "+"
             mem.offset = abs(int(_mem.rxfreq) - int(_mem.txfreq)) * 10
@@ -490,8 +492,7 @@ class RT26Radio(chirp_common.CloneModeRadio):
         _mem.rxfreq = mem.freq / 10
 
         if mem.duplex == "off":
-            for i in range(0, 4):
-                _mem.txfreq[i].set_raw("\xFF")
+            _mem.txfreq.fill_raw(b"\xFF")
         elif mem.duplex == "split":
             _mem.txfreq = mem.offset / 10
         elif mem.duplex == "+":

--- a/chirp/drivers/tk3140.py
+++ b/chirp/drivers/tk3140.py
@@ -557,7 +557,7 @@ class KenwoodTKx140Radio(chirp_common.CloneModeRadio):
         elif mem.duplex == 'split':
             _mem.tx_freq = mem.offset // 10
         elif mem.duplex == 'off':
-            _mem.tx_freq = 0xFFFFFFFF
+            _mem.tx_freq.fill_raw(b'\xFF')
         elif mem.duplex == '-':
             _mem.tx_freq = (mem.freq - mem.offset) // 10
         elif mem.duplex == '+':

--- a/tests/test_brute_force.py
+++ b/tests/test_brute_force.py
@@ -91,7 +91,7 @@ class TestCaseBruteForce(base.DriverTest):
         if 'duplex' in m.immutable:
             self.skipTest('Test memory has immutable duplex')
         for duplex in self.rf.valid_duplexes:
-            if duplex not in ["", "-", "+", "split"]:
+            if duplex not in ["", "-", "+", "split", "off"]:
                 continue
             if duplex == 'split':
                 self.assertTrue(self.rf.can_odd_split,

--- a/tests/unit/test_bitwise.py
+++ b/tests/unit/test_bitwise.py
@@ -98,6 +98,26 @@ class TestBitwiseBaseIntTypes(BaseTest):
             obj.foo[i] = i * 2
         self.assertEqual(b'\x00\x02\x04\x06', data.get_packed())
 
+    def test_int_array_set_raw(self):
+        data = memmap.MemoryMapBytes(bytes(b'\x00\x01\x02\x03'))
+        obj = bitwise.parse('u8 foo[4];', data)
+        obj.foo.set_raw(b'\x09\x08\x07\x06')
+        self.assertEqual(9, obj.foo[0])
+        self.assertEqual(8, obj.foo[1])
+        self.assertEqual(7, obj.foo[2])
+        self.assertEqual(6, obj.foo[3])
+
+        obj = bitwise.parse('u16 foo[2];', data)
+        obj.foo.set_raw(b'\x00\x01\x00\x02')
+        self.assertEqual(1, obj.foo[0])
+        self.assertEqual(2, obj.foo[1])
+
+        with self.assertRaises(AssertionError):
+            obj.foo.set_raw(b'123')
+
+        with self.assertRaises(AssertionError):
+            obj.foo.set_raw(b'12345')
+
 
 class TestBitfieldTypes(BaseTest):
     def test_bitfield_u8(self):


### PR DESCRIPTION
- rt470: Fix duplex=off detection
- bitwise: Fix set_raw() on arrayDataElement
- tk3140: Fix duplex=ff
- retevis_rt26: Fix duplex=off
- retevis_rt22: Fix duplex=off
- retevis_rt21: Fix duplex=off
- retevis_r1: Fix duplex=off
- retevis_rb15: Fix duplex=off
- kyd: Fix duplex=off
- kyd_IP620: Fix duplex=off
- anytone_ht: Fix duplex=off
- Enable duplex=off in test_duplex
