### PR TITLE
Fix "no section" error on fresh install

### DIFF
--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1038,7 +1038,8 @@ class ChirpMain(wx.Frame):
                 CONF.set('recent%i' % i, recent[i], 'state')
             except IndexError:
                 # Clean higher-order entries if they exist
-                CONF.remove_option('recent%i' % i, 'state')
+                if CONF.is_defined('recent%i' % i, 'state'):
+                    CONF.remove_option('recent%i' % i, 'state')
         config._CONFIG.save()
 
         # Clear the menu


### PR DESCRIPTION
This was an oversight in the refactoring of the recent file handling
which breaks for new users.

Related to #11194
