### PR TITLE
K5 Plus: Register new model -> child of 5RM driver

### DIFF
--- a/chirp/drivers/baofeng_uv17Pro.py
+++ b/chirp/drivers/baofeng_uv17Pro.py
@@ -1332,3 +1332,9 @@ class BF5RM(UV17Pro):
             except ValueError:
                 pass
         super().check_set_memory_immutable_policy(existing, new)
+
+
+@directory.register
+class BFK5Plus(BF5RM):
+    VENDOR = "Baofeng"
+    MODEL = "K5-Plus"

--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -62,6 +62,7 @@
 | <a name="Baofeng_F-11"></a> Baofeng_F-11 | [Implied by Baofeng_UV-5R](#user-content-Baofeng_UV-5R) | 18-Nov-2022 | Yes | 0.12% |
 | <a name="Baofeng_GT-3WP"></a> Baofeng_GT-3WP | [@KC9HI](https://github.com/KC9HI) | 3-Dec-2022 | Yes | 0.43% |
 | <a name="Baofeng_GT-5R"></a> Baofeng_GT-5R | [@KC9HI](https://github.com/KC9HI) | 18-Nov-2022 | Yes | 0.68% |
+| <a name="Baofeng_K5-Plus"></a> Baofeng_K5-Plus |  |  | Yes |  |
 | <a name="Baofeng_UV-13Pro"></a> Baofeng_UV-13Pro | [@vdwel](https://github.com/vdwel) | 21-Feb-2024 | Yes |  |
 | <a name="Baofeng_UV-17"></a> Baofeng_UV-17 | [@vdwel](https://github.com/vdwel) | 27-Nov-2023 | Yes |  |
 | <a name="Baofeng_UV-17Pro"></a> Baofeng_UV-17Pro | [@vdwel](https://github.com/vdwel) | 27-Nov-2023 | Yes |  |
@@ -452,11 +453,11 @@
 | <a name="Zastone_ZT-X6"></a> Zastone_ZT-X6 | [Implied by Retevis_RT22](#user-content-Retevis_RT22) | 9-Dec-2022 | Yes | 0.11% |
 ## Stats
 
-**Drivers:** 449
+**Drivers:** 450
 
-**Tested:** 87% (395/54) (93% of usage stats)
+**Tested:** 87% (395/55) (93% of usage stats)
 
-**Byte clean:** 91% (410/39)
+**Byte clean:** 91% (411/39)
 
 ## Meaning of this testing
 

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -765,6 +765,7 @@ class TestOverrideRules(base.BaseTest):
         'Retevis_RB17P',
         'Baofeng_UV-17ProGPS',
         'Baofeng_5RM',
+        'Baofeng_K5-Plus',
     ]
 
     def _test_radio_override_immutable_policy(self, rclass):


### PR DESCRIPTION
Fixes: #11119

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues). Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
