### PR TITLE
baofeng_common.py: gracefully handle bcd coding errors - fixes #11183

### DIFF
--- a/chirp/drivers/uv5x3.py
+++ b/chirp/drivers/uv5x3.py
@@ -23,7 +23,7 @@ from chirp.settings import RadioSettingGroup, RadioSetting, \
     RadioSettingValueBoolean, RadioSettingValueList, \
     RadioSettingValueString, RadioSettingValueInteger, \
     RadioSettingValueFloat, RadioSettings, \
-    InvalidValueError
+    InvalidValueError, InternalError
 
 LOG = logging.getLogger(__name__)
 
@@ -136,7 +136,7 @@ class UV5X3(bfc.BaofengCommonHT):
     SCODE_LIST = LIST_SCODE
 
     MEM_FORMAT = """
-    #seekto 0x0000;
+    // #seekto 0x0000;
     struct {
       lbcd rxfreq[4];
       lbcd txfreq[4];
@@ -855,54 +855,66 @@ class UV5X3(bfc.BaofengCommonHT):
         rs.set_apply_callback(apply_freq, _mem.vfo.b)
         work.append(rs)
 
-        val = bfc.bcd_decode_freq(_mem.subvfoa.vhf.freq)
-        if int(float(val)) == 0:
-            val = str(int(_mem.limits.vhf.lower)) + ".000000"
+        try:
+            val = bfc.bcd_decode_freq(_mem.subvfoa.vhf.freq)
+        except InternalError:
+            LOG.debug('Failed to decode VFO A VHF (Saved)')
+            val = "000.000000"
         val1a = RadioSettingValueString(0, 10, val)
         val1a.set_validate_callback(my_vhf_validate)
         rs = RadioSetting("subvfoa.vhf.freq", "VFO A VHF (Saved)", val1a)
         rs.set_apply_callback(apply_freq, _mem.subvfoa.vhf)
         work.append(rs)
 
-        val = bfc.bcd_decode_freq(_mem.subvfob.vhf.freq)
-        if int(float(val)) == 0:
-            val = str(int(_mem.limits.vhf.lower)) + ".000000"
+        try:
+            val = bfc.bcd_decode_freq(_mem.subvfob.vhf.freq)
+        except InternalError:
+            LOG.debug('Failed to decode VFO B VHF (Saved)')
+            val = "000.000000"
         val1b = RadioSettingValueString(0, 10, val)
         val1b.set_validate_callback(my_vhf_validate)
         rs = RadioSetting("subvfob.vhf.freq", "VFO B VHF (Saved)", val1b)
         rs.set_apply_callback(apply_freq, _mem.subvfob.vhf)
         work.append(rs)
 
-        val = bfc.bcd_decode_freq(_mem.subvfoa.vhf2.freq)
-        if int(float(val)) == 0:
-            val = str(int(_mem.limits.vhf2.lower)) + ".000000"
+        try:
+            val = bfc.bcd_decode_freq(_mem.subvfoa.vhf2.freq)
+        except InternalError:
+            LOG.debug('Failed to decode VFO A VHF2 (Saved)')
+            val = "000.000000"
         val1a = RadioSettingValueString(0, 10, val)
         val1a.set_validate_callback(my_vhf2_validate)
         rs = RadioSetting("subvfoa.vhf2.freq", "VFO A VHF2 (Saved)", val1a)
         rs.set_apply_callback(apply_freq, _mem.subvfoa.vhf2)
         work.append(rs)
 
-        val = bfc.bcd_decode_freq(_mem.subvfob.vhf2.freq)
-        if int(float(val)) == 0:
-            val = str(int(_mem.limits.vhf2.lower)) + ".000000"
+        try:
+            val = bfc.bcd_decode_freq(_mem.subvfob.vhf2.freq)
+        except settings.InternalError:
+            LOG.debug('Failed to decode VFO B VHF2 (Saved)')
+            val = "000.000000"
         val1b = RadioSettingValueString(0, 10, val)
         val1b.set_validate_callback(my_vhf2_validate)
         rs = RadioSetting("subvfob.vhf2.freq", "VFO B VHF2 (Saved)", val1b)
         rs.set_apply_callback(apply_freq, _mem.subvfob.vhf2)
         work.append(rs)
 
-        val = bfc.bcd_decode_freq(_mem.subvfoa.uhf.freq)
-        if int(float(val)) == 0:
-            val = str(int(_mem.limits.uhf.lower)) + ".000000"
+        try:
+            val = bfc.bcd_decode_freq(_mem.subvfoa.uhf.freq)
+        except InternalError:
+            LOG.debug('Failed to decode VFO A UHF (Saved)')
+            val = "000.000000"
         val1a = RadioSettingValueString(0, 10, val)
         val1a.set_validate_callback(my_uhf_validate)
         rs = RadioSetting("subvfoa.uhf.freq", "VFO A UHF (Saved)", val1a)
         rs.set_apply_callback(apply_freq, _mem.subvfoa.uhf)
         work.append(rs)
 
-        val = bfc.bcd_decode_freq(_mem.subvfob.uhf.freq)
-        if int(float(val)) == 0:
-            val = str(int(_mem.limits.uhf.lower)) + ".000000"
+        try:
+            val = bfc.bcd_decode_freq(_mem.subvfob.uhf.freq)
+        except InternalError:
+            LOG.debug('Failed to decode VFO B UHF (Saved)')
+            val = "000.000000"
         val1b = RadioSettingValueString(0, 10, val)
         val1b.set_validate_callback(my_uhf_validate)
         rs = RadioSetting("subvfob.uhf.freq", "VFO B UHF (Saved)", val1b)


### PR DESCRIPTION
The BTech UV-5X3 do not ship from the factory with valid values for all of the subvfo settings. This causes the Settings tabs to not display.

This patch allows the tabs to display and highlights the settings that need a valid value.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues). Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
