### PR TITLE
Fixes issue #11221

### DIFF
--- a/chirp/drivers/baofeng_uv17.py
+++ b/chirp/drivers/baofeng_uv17.py
@@ -290,9 +290,15 @@ class UV17(baofeng_uv17Pro.UV17Pro):
     } vfo;
 
     #seekto 0x4000;
-    struct {
+    struct channelname {
       char name[11];
-    } names[999];
+    };
+
+    struct channelname names1[372];
+    #seek 0x4;
+    struct channelname names2[372];
+    #seek 0x4;
+    struct channelname names3[255];
 
     #seekto 0x8000;
     struct {
@@ -408,9 +414,20 @@ class UV17(baofeng_uv17Pro.UV17Pro):
         _mem = self._memobj.mem1.mem[number]
         return _mem
 
+    def get_channel_name(self, number):
+        number = number - 1
+        if number >= 744:
+            _name = self._memobj.names3[number - 744]
+            return _name
+        if number >= 372:
+            _name = self._memobj.names2[number - 372]
+            return _name
+        _name = self._memobj.names1[number]
+        return _name
+
     def get_memory(self, number):
         _mem = self.get_raw_memory(number)
-        _nam = self._memobj.names[number - 1]
+        _nam = self.get_channel_name(number)
 
         mem = chirp_common.Memory()
         mem.number = number
@@ -441,7 +458,7 @@ class UV17(baofeng_uv17Pro.UV17Pro):
 
     def set_memory(self, mem):
         _mem = self.get_raw_memory(mem.number)
-        _nam = self._memobj.names[mem.number - 1]
+        _nam = self.get_channel_name(mem.number)
 
         if mem.empty:
             _mem.set_raw(b"\xff" * 16)


### PR DESCRIPTION
UV13Pro and UV17: channel names were displayed wrong above channel 372

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues). Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
