### PR TITLE
Initial support for Icom IC-7400

### DIFF
--- a/chirp/drivers/icomciv.py
+++ b/chirp/drivers/icomciv.py
@@ -142,6 +142,40 @@ bbcd ctone_tx[2];             // 15-17 tone rx squelch setting
 char name[10];             // 18-27 Callsign
 """
 
+MEM_IC7400_FORMAT = """
+bbcd number[2];
+u8   unknown1;
+lbcd freq[5];
+u8   mode;
+u8   filter;
+u8   unknown2:7,
+     dig:1;
+u8   unknown3:2,
+     duplex:2,
+     unknown4:1,
+     tmode:3;
+bbcd rtone[3];
+bbcd ctone[3];
+u8   dtcs_polarity;
+bbcd dtcs[2];
+// As with IC-7300 it seems the following are duplicated parameters save for
+// `dig` which seem to be zeroed in unknown5
+lbcd freq_tx[5];
+u8   mode_tx;
+u8   filter_tx;
+u8 unknown5;
+u8   unknown6:2,
+     duplex_tx:2,
+     unknown7:1,
+     tmode_tx:3;
+bbcd rtone_tx[3];
+bbcd ctone_tx[3];
+u8   dtcs_polarity_tx;
+bbcd dtcs_tx[2];
+// End TX duplicate block
+char name[8];
+"""
+
 MEM_IC7610_FORMAT = """
 bbcd number[2];            // 1,2
 u8   spl:4,                // 3 split and select memory settings
@@ -297,6 +331,12 @@ class DupToneMemFrame(MemFrame):
     def get_obj(self):
         self._data = MemoryMapBytes(bytes(self._data))
         return bitwise.parse(mem_duptone_format, self._data)
+
+
+class IC7400MemFrame(MemFrame):
+    def get_obj(self):
+        self._data = MemoryMapBytes(bytes(self._data))
+        return bitwise.parse(MEM_IC7400_FORMAT, self._data)
 
 
 class IC7300MemFrame(MemFrame):
@@ -897,6 +937,44 @@ class Icom746Radio(IcomCIVRadio):
         self._rf.valid_skips = []
         self._rf.valid_name_length = 9
         self._rf.valid_characters = chirp_common.CHARSET_ASCII
+        self._rf.memory_bounds = (1, 99)
+
+
+@directory.register
+class Icom7400Radio(IcomCIVRadio):
+    """Icom IC-7400"""
+    MODEL = "IC-7400"
+    BAUD_RATE = 9600
+    _model = "\x66"
+    _template = 102
+
+    _num_banks = 1		# Banks not supported
+
+    def _initialize(self):
+        self._classes["mem"] = IC7400MemFrame
+        self._rf.has_bank = False
+        self._rf.has_dtcs_polarity = True
+        self._rf.has_dtcs = True
+        self._rf.has_ctone = True
+        self._rf.has_offset = False
+        self._rf.has_name = True
+        self._rf.has_tuning_step = False
+        self._rf.valid_modes = [
+            "LSB", "USB", "AM", "CW", "RTTY", "FM", "USB", "CWR", "RTTYR"
+        ]
+        self._rf.valid_tmodes = ["", "Tone", "TSQL", "DTCS"]
+        self._rf.valid_duplexes = ["", "-", "+"]
+        self._rf.valid_bands = [(30000, 174000000)]
+        self._rf.valid_tuning_steps = []
+        self._rf.valid_skips = []
+        self._rf.valid_name_length = 8
+        self._rf.valid_characters = " !#$%&'()*+,-./" \
+            "0123456789" \
+            ":;<=>?" \
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
+            "[\\]^_" \
+            "abcdefghijklmnopqrstuvwxyz" \
+            "{|}~"
         self._rf.memory_bounds = (1, 99)
 
 

--- a/tests/Python3_Driver_Testing.md
+++ b/tests/Python3_Driver_Testing.md
@@ -114,6 +114,7 @@
 | <a name="Icom_IC-7100"></a> Icom_IC-7100 | Mike W | 16-Feb-2023 | Yes | 0.06% |
 | <a name="Icom_IC-7200"></a> Icom_IC-7200 | [@kk7ds](https://github.com/kk7ds) | 22-Oct-2022 | Yes |  |
 | <a name="Icom_IC-7300"></a> Icom_IC-7300 | [@kk7ds](https://github.com/kk7ds) | 22-Oct-2022 | Yes | 0.03% |
+| <a name="Icom_IC-7400"></a> Icom_IC-7400 |  |  | Yes |  |
 | <a name="Icom_IC-746"></a> Icom_IC-746 | [Reported working](https://chirp.danplanet.com/issues/10346) | 3-Feb-2023 | Yes |  |
 | <a name="Icom_IC-7610"></a> Icom_IC-7610 | [@kk7ds](https://github.com/kk7ds) | 24-Oct-2022 | Yes | 0.00% |
 | <a name="Icom_IC-910"></a> Icom_IC-910 | [@mfncooper](https://github.com/mfncooper) | 1-Oct-2021 | Yes | 0.00% |
@@ -453,11 +454,11 @@
 | <a name="Zastone_ZT-X6"></a> Zastone_ZT-X6 | [Implied by Retevis_RT22](#user-content-Retevis_RT22) | 9-Dec-2022 | Yes | 0.11% |
 ## Stats
 
-**Drivers:** 450
+**Drivers:** 451
 
-**Tested:** 88% (396/54) (93% of usage stats)
+**Tested:** 87% (396/55) (93% of usage stats)
 
-**Byte clean:** 91% (411/39)
+**Byte clean:** 91% (412/39)
 
 ## Meaning of this testing
 


### PR DESCRIPTION
This should also work seamlessly for IC-746PRO, as it is using the same address for the CI-V protocol.

As with other existing icomciv.py based implementations, I did not add general radio settings: this implementation only allows for setting memories.

(Probably) related to #2157
I meant to mention WA1RKT for possibly trying out this on the IC-746PRO, but I'm not able to find him on GH. If this PR lands decently I can drop him an email.

# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues). Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
