### PR TITLE
Fix displaying choice settings

### DIFF
--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -545,6 +545,7 @@ class ChirpSettingGrid(wx.Panel):
             e.SetValue(choices.index(str(value)))
         else:
             e.SetValueToUnspecified()
+        return e
 
     def _get_editor_bool(self, setting, value):
         prop = wx.propgrid.BoolProperty(setting.get_shortname(),


### PR DESCRIPTION
In commit f9e5b870535012d6fb6b22a357c3624652ca83eb the refactor for
late eval of choice setting values omitted a return of the editor
which prevented them from showing up in the UI.
