### PR TITLE
radioreference: fix utf-8 encoding issue with SUDS

### DIFF
--- a/chirp/sources/radioreference.py
+++ b/chirp/sources/radioreference.py
@@ -26,6 +26,7 @@ CONF = config.get()
 try:
     from suds.client import Client
     from suds import WebFault
+    from suds.plugin import MessagePlugin
     HAVE_SUDS = True
 except ImportError:
     HAVE_SUDS = False
@@ -85,8 +86,14 @@ class RadioReferenceRadio(base.NetworkResultRadio):
                 "Suds library required for RadioReference.com import.\n" +
                 "Try installing your distribution's python-suds package.")
 
+        class UnicodeFilter(MessagePlugin):
+            def received(self, context):
+                decoded = context.reply.decode('latin1')
+                reencoded = decoded.encode('utf-8')
+                context.reply = reencoded
+
         self._auth = {"appKey": self.APPKEY, "username": "", "password": ""}
-        self._client = Client(self.URL)
+        self._client = Client(self.URL, plugins=[UnicodeFilter()])
         self._freqs = []
         self._modes = None
         self._zipcounty = None


### PR DESCRIPTION
# CHIRP PR Checklist

The following must be true before PRs can be merged:

* All tests must be passing.
* Commits should be squashed into logical units.
* Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
* Commits in a single PR should be related.
* Major new features or bug fixes should reference a [CHIRP issue](https://chirp.danplanet.com/projects/chirp/issues). Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
* New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already).
* All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).

Please also follow these guidelines:

* Keep cleanups in separate commits from functional changes.
* Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc).
* The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
* Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
* All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`.
* New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.

---

## Problem:
Current importer fails to handle "invalid tokens" which I believe are most likely caused by non-ascii accents frequently found in the Quebec region:

<img width="83" alt="image" src="https://github.com/kk7ds/chirp/assets/494354/b0a0c139-b6c2-494b-a47d-bcfdeb68cd3d">


## Solution:
The PR attempts to fix that by adding a MessagePlugin to decode the input (while ignoring errors) and then re-encode it as utf-8. 


I tested it locally and was able to import the QC/Montreal region with no "invalid token" errors.
