### PR TITLE
vx8: Remove invalid NFM option

### DIFF
--- a/chirp/drivers/vx8.py
+++ b/chirp/drivers/vx8.py
@@ -151,7 +151,7 @@ struct {
 #seekto 0x328A;
 struct {
   u8 unknown1a:2,
-     half_deviation:1,
+     half_deviation:1, // This is not really right, maybe auto?
      unknown1b:5;
   u8 mode:2,
      duplex:2,
@@ -337,7 +337,7 @@ u8 checksum;
 
 TMODES = ["", "Tone", "TSQL", "DTCS"]
 DUPLEX = ["", "-", "+", "split"]
-MODES = ["FM", "AM", "WFM", "NFM"]
+MODES = ["FM", "AM", "WFM"]
 STEPS = [5.0, 6.25, 8.33, 9.0, 10.0, 12.5, 15.0, 20.0, 25.0, 50.0,
          100.0, 200.0]
 SKIPS = ["", "S", "P"]
@@ -656,10 +656,7 @@ class VX8Radio(yaesu_clone.YaesuCloneModeRadio):
         mem.duplex = DUPLEX[_mem.duplex]
         if mem.duplex == "split":
             mem.offset = chirp_common.fix_rounded_step(mem.offset)
-        if _mem.mode == "FM" and _mem.half_deviation == 1:
-            mem.mode = "NFM"
-        else:
-            mem.mode = MODES[_mem.mode]
+        mem.mode = MODES[_mem.mode]
         mem.dtcs = chirp_common.DTCS_CODES[_mem.dcs]
         mem.tuning_step = STEPS[_mem.tune_step]
         mem.power = POWER_LEVELS[3 - _mem.power]
@@ -705,12 +702,8 @@ class VX8Radio(yaesu_clone.YaesuCloneModeRadio):
         _mem.tone = chirp_common.TONES.index(mem.rtone)
         _mem.tone_mode = TMODES.index(mem.tmode)
         _mem.duplex = DUPLEX.index(mem.duplex)
-        if mem.mode == "NFM":
-            _mem.mode = 0            # Yaesu's NFM, i.e. regular FM
-            _mem.half_deviation = 1  # but half bandwidth
-        else:
-            _mem.mode = MODES.index(mem.mode)
-            _mem.half_deviation = 0
+        _mem.mode = MODES.index(mem.mode)
+        _mem.half_deviation = 0
         _mem.mode = MODES.index(mem.mode)
         _mem.dcs = chirp_common.DTCS_CODES.index(mem.dtcs)
         _mem.tune_step = STEPS.index(mem.tuning_step)


### PR DESCRIPTION
It has been reported (and confirmed locally and in the manual) that
the radio's "half deviation" setting is global for the entire radio
and not per-memory like the current mapping suggests. I think the
recording of that was actually a mistake, confused by the yaesu-esque
"auto" mode option.

So, this removes NFM from the supported modes since the radio can't
actually do it per-memory.

Fixes: #11275
