### PR TITLE
type cleanups

### DIFF
--- a/.github/actions/py3-tox/action.yaml
+++ b/.github/actions/py3-tox/action.yaml
@@ -4,6 +4,10 @@ inputs:
   tox_target:
     required: true
     type: string
+  py_version:
+    required: false
+    type: string
+    default: '3'
 
 runs:
   using: "composite"
@@ -13,7 +17,7 @@ runs:
       run: |
         sudo apt-get update
         sudo apt-get install python3-pip python3-wxgtk4.0
-        sudo python3 -mpip install tox
+        sudo python${{ inputs.py_version }} -mpip install tox
     - name: Run tox
       shell: bash
       run: |

--- a/.github/workflows/py3-test.yaml
+++ b/.github/workflows/py3-test.yaml
@@ -30,22 +30,6 @@ jobs:
           path: unit_report.html
 
   driver:
-    name: Driver tests (Python 3.8)
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Run tox
-        uses: ./.github/actions/py3-tox
-        with:
-          tox_target: fast-driver
-      - name: Archive results
-        uses: actions/upload-artifact@v3
-        with:
-          name: driver_report
-          path: driver_report.html
-
-  driver-py:
     name: Driver tests (Python 3.10)
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/py3-test.yaml
+++ b/.github/workflows/py3-test.yaml
@@ -40,6 +40,25 @@ jobs:
         with:
           tox_target: fast-driver
 
+  driver-next:
+    name: Driver tests (Python 3.12)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install python 3.12
+        uses: actions/setup-python@v5
+        id: pyinst
+        with:
+          python-version: '3.12'
+      - run: "sudo ln -s ${{ steps.pyinst.outputs.python-path }} /usr/local/bin/python3.12"
+      - run: "echo $PATH; ls -l /usr/local/bin"
+      - name: Run tox
+        uses: ./.github/actions/py3-tox
+        with:
+          tox_target: fast-driver
+          py_version: '3.12'
+
   matrix:
     name: Create support matrix
     runs-on: ubuntu-22.04

--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -243,7 +243,7 @@ def parse_power(powerstr):
     return AutoNamedPowerLevel(watts)
 
 
-def parse_freq(freqstr):
+def parse_freq(freqstr: str) -> int:
     """Parse a frequency string and return the value in integral Hz"""
     freqstr = freqstr.strip()
     if freqstr == "":
@@ -254,14 +254,14 @@ def parse_freq(freqstr):
         return int(freqstr.split(" ")[0]) * 1000
 
     if "." in freqstr:
-        mhz, khz = freqstr.split(".")
-        if mhz == "":
-            mhz = 0
-        khz = khz.ljust(6, "0")
-        if len(khz) > 6:
-            raise ValueError("Invalid kHz value: %s", khz)
-        mhz = int(mhz) * 1000000
-        khz = int(khz)
+        _mhz, _khz = freqstr.split(".")
+        if _mhz == "":
+            _mhz = "0"
+        _khz = _khz.ljust(6, "0")
+        if len(_khz) > 6:
+            raise ValueError("Invalid kHz value: %s", _khz)
+        mhz = int(_mhz) * 1000000
+        khz = int(_khz)
     else:
         mhz = int(freqstr) * 1000000
         khz = 0
@@ -269,7 +269,7 @@ def parse_freq(freqstr):
     return mhz + khz
 
 
-def format_freq(freq):
+def format_freq(freq: int) -> str:
     """Format a frequency given in Hz as a string"""
 
     return "%i.%06i" % (freq / 1000000, freq % 1000000)
@@ -281,30 +281,30 @@ class ImmutableValueError(ValueError):
 
 class Memory:
     """Base class for a single radio memory"""
-    freq = 0
-    number = 0
-    extd_number = ""
-    name = ""
-    vfo = 0
-    rtone = 88.5
-    ctone = 88.5
-    dtcs = 23
-    rx_dtcs = 23
-    tmode = ""
-    cross_mode = "Tone->Tone"
-    dtcs_polarity = "NN"
-    skip = ""
-    power = None
-    duplex = ""
-    offset = 600000
-    mode = "FM"
-    tuning_step = 5.0
+    freq: int = 0
+    number: int = 0
+    extd_number: str = ""
+    name: str = ""
+    vfo: int = 0
+    rtone: float = 88.5
+    ctone: float = 88.5
+    dtcs: int = 23
+    rx_dtcs: int = 23
+    tmode: str = ""
+    cross_mode: str = "Tone->Tone"
+    dtcs_polarity: str = "NN"
+    skip: str = ""
+    power: PowerLevel | None = None
+    duplex: str = ""
+    offset: int = 600000
+    mode: str = "FM"
+    tuning_step: float = 5.0
 
-    comment = ""
+    comment: str = ""
 
-    empty = False
+    empty: bool = False
 
-    immutable = []
+    immutable: list[str] = []
 
     # A RadioSettingGroup of additional settings supported by the radio,
     # or an empty list if none
@@ -597,10 +597,10 @@ class Memory:
 
 class DVMemory(Memory):
     """A Memory with D-STAR attributes"""
-    dv_urcall = "CQCQCQ"
-    dv_rpt1call = ""
-    dv_rpt2call = ""
-    dv_code = 0
+    dv_urcall: str = "CQCQCQ"
+    dv_rpt1call: str = ""
+    dv_rpt2call: str = ""
+    dv_code: int = 0
 
     def __str__(self):
         string = Memory.__str__(self)
@@ -1179,7 +1179,7 @@ class Radio(Alias):
     WANTS_RTS = True
     ALIASES = []
     NEEDS_COMPAT_SERIAL = True
-    FORMATS = []
+    FORMATS: list[str] = []
 
     def status_fn(self, status):
         """Deliver @status to the UI"""
@@ -1189,25 +1189,25 @@ class Radio(Alias):
         self.errors = []
         self.pipe = pipe
 
-    def get_features(self):
+    def get_features(self) -> RadioFeatures:
         """Return a RadioFeatures object for this radio"""
         return RadioFeatures()
 
     @classmethod
-    def get_name(cls):
+    def get_name(cls) -> str:
         """Return a printable name for this radio"""
         return "%s %s" % (cls.VENDOR, cls.MODEL)
 
     @classmethod
-    def get_prompts(cls):
+    def get_prompts(cls) -> RadioPrompts:
         """Return a set of strings for use in prompts"""
         return RadioPrompts()
 
-    def set_pipe(self, pipe):
+    def set_pipe(self, pipe) -> None:
         """Set the serial object to be used for communications"""
         self.pipe = pipe
 
-    def get_memory(self, number):
+    def get_memory(self, number: int | str) -> Memory:
         """Return a Memory object for the memory at location @number
 
         Constructs and returns a generic Memory object for the given location
@@ -1219,12 +1219,15 @@ class Radio(Alias):
         NB: No changes to the radio's memory should occur as a result of
         calling get_memory().
         """
-        pass
+        raise NotImplementedError()
 
-    def erase_memory(self, number):
+    def erase_memory(self, number: int | str) -> None:
         """Erase memory at location @number"""
         mem = Memory()
-        mem.number = number
+        if isinstance(number, str):
+            mem.extd_number = number
+        else:
+            mem.number = number
         mem.empty = True
         self.set_memory(mem)
 
@@ -1232,7 +1235,7 @@ class Radio(Alias):
         """Get all the memories between @lo and @hi"""
         pass
 
-    def set_memory(self, memory):
+    def set_memory(self, memory: Memory) -> None:
         """Set the memory object @memory
 
         This method should copy generic attributes from @memory to the
@@ -1243,7 +1246,7 @@ class Radio(Alias):
         substitution will be made, or ValidationError if truly incompatible.
         In the latter case, set_memory() will not be called.
         """
-        pass
+        raise NotImplementedError()
 
     def get_mapping_models(self):
         """Returns a list of MappingModel objects (or an empty list)"""
@@ -1254,11 +1257,11 @@ class Radio(Alias):
                 return [bank_model]
         return []
 
-    def get_raw_memory(self, number):
+    def get_raw_memory(self, number: int | str) -> str:
         """Return a raw string describing the memory at @number"""
-        pass
+        return 'Memory<%r>' % number
 
-    def filter_name(self, name):
+    def filter_name(self, name: str) -> str:
         """Filter @name to just the length and characters supported"""
         rf = self.get_features()
         if rf.valid_characters == rf.valid_characters.upper():
@@ -1267,12 +1270,12 @@ class Radio(Alias):
         return "".join([x for x in name[:rf.valid_name_length]
                         if x in rf.valid_characters])
 
-    def get_sub_devices(self):
+    def get_sub_devices(self) -> list[Alias]:
         """Return a list of sub-device Radio objects, if
         RadioFeatures.has_sub_devices is True"""
         return []
 
-    def validate_memory(self, mem):
+    def validate_memory(self, mem: Memory) -> list[ValidationMessage]:
         """Return a list of warnings and errors that will be encountered
         if trying to set @mem on the current radio"""
         rf = self.get_features()
@@ -1295,7 +1298,7 @@ class Radio(Alias):
         pass
 
     @classmethod
-    def supports_format(cls, fmt):
+    def supports_format(cls, fmt: str) -> bool:
         """Returns true if file format @fmt is supported by this radio.
 
         This really should not be overridden by implementations
@@ -1303,7 +1306,7 @@ class Radio(Alias):
         """
         return fmt in cls.FORMATS
 
-    def check_set_memory_immutable_policy(self, existing, new):
+    def check_set_memory_immutable_policy(self, existing: Memory, new: Memory):
         """Checks whether or not a new memory will violate policy.
 
         Some radios have complex requirements for which fields of which

--- a/chirp/drivers/ft4.py
+++ b/chirp/drivers/ft4.py
@@ -562,7 +562,7 @@ TONE_DICT = {}          # encode sql_type.
 CROSS_DICT = {}         # encode sql_type.
 
 for sql_type in reversed(range(0, len(RADIO_TMODES))):
-    sql_type_row = RADIO_TMODES[sql_type]
+    sql_type_row: list = RADIO_TMODES[sql_type]
     for decode_row in sql_type_row[0]:
         suppress = None
         if len(decode_row) == 3:

--- a/chirp/drivers/ft857.py
+++ b/chirp/drivers/ft857.py
@@ -34,7 +34,7 @@ class FT857Radio(ft817.FT817Radio):
     MODEL = "FT-857/897"
     _model = ""
 
-    TMODES = {
+    TMODES: dict[int, str] = {
         0x04: "Tone",
         0x05: "TSQL",
         # 0x08 : "DTCS Enc", not supported in UI yet

--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -243,7 +243,6 @@ class CSVRadio(chirp_common.FileBackedRadio):
             good += 1
 
         if not good:
-            LOG.error(self.errors)
             raise errors.InvalidDataError("No channels found")
 
     def save(self, filename=None):

--- a/chirp/drivers/ic2730.py
+++ b/chirp/drivers/ic2730.py
@@ -18,6 +18,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import typing
+
 from chirp.drivers import icf
 from chirp import chirp_common, directory, bitwise
 from chirp.settings import RadioSettingGroup, RadioSetting, \
@@ -285,7 +287,7 @@ class IC2730Radio(icf.IcomCloneModeRadio):
     _raw_frames = True
     _highbit_flip = True
 
-    _icf_data = {
+    _icf_data: dict[str, typing.Any] = {
         'MapRev': 1,
         'EtcData': 0,  # This might be wrong
         'Comment': '',
@@ -1316,7 +1318,6 @@ class IC2730Radio(icf.IcomCloneModeRadio):
 
     def set_settings(self, settings):
         _settings = self._memobj.settings
-        _mem = self._memobj
         for element in settings:
             if not isinstance(element, RadioSetting):
                 self.set_settings(element)

--- a/chirp/drivers/kenwood_d7.py
+++ b/chirp/drivers/kenwood_d7.py
@@ -1985,7 +1985,9 @@ class THD7GRadio(KenwoodD7Family):
         "DSPA": {'type': 'list',
                  'values': ("Entire Display", "One Line")},
         "ICO": {'type': 'map',
-                'map': (KenwoodD7Family._COMMON_SETTINGS["ICO"]["map"] +
+                'map': (
+                    KenwoodD7Family.
+                        _COMMON_SETTINGS["ICO"]["map"] +  # type: ignore
                         _APRS_EXTRA)}}
 
     _SETTINGS_MENUS = (
@@ -2125,7 +2127,8 @@ class TMD700Radio(KenwoodD7Family):
         "FUNC": {'type': 'map',
                  'map': (("Mode 1", "1"), ("Mode 2", "2"), ("Mode 3", "3"))},
         "ICO": {'type': 'map',
-                'map': (KenwoodD7Family._COMMON_SETTINGS["ICO"]["map"] +
+                'map': (KenwoodD7Family.
+                        _COMMON_SETTINGS["ICO"]["map"] +  # type: ignore
                         (('Digipeater', '0,F'),) +
                         THD7GRadio._APRS_EXTRA)},
         "MCL 0": _BOOL,

--- a/chirp/drivers/tdh8.py
+++ b/chirp/drivers/tdh8.py
@@ -2219,8 +2219,10 @@ class TDH8_GMRS(TDH8):
     ident_mode = b'P31184\xff\xff'
     _gmrs = True
     _txbands = [(136000000, 175000000), (400000000, 521000000)]
-    _tx_power = [chirp_common.PowerLevel("Low",  watts=1.00),
-                 None,  # No mid power
+    _tx_power = [chirp_common.PowerLevel("Low", watts=1.00),
+                 # This index should not be used on this radio, but if we
+                 # find it, just treat it like "low"
+                 chirp_common.PowerLevel("Low", watts=1.00),
                  chirp_common.PowerLevel("High", watts=8.00)]
 
     def validate_memory(self, mem):

--- a/chirp/sources/radioreference.py
+++ b/chirp/sources/radioreference.py
@@ -157,9 +157,14 @@ class RadioReferenceRadio(base.NetworkResultRadio):
                                                              self._auth)
                 self._freqs += result
                 status_cur += 1
-                status.send_status(
-                    'Fetching %s:%s' % (cat.cName, subcat.scName),
-                    status_cur / status_max * 100)
+                try:
+                    status.send_status(
+                        'Fetching %s:%s' % (cat.cName, subcat.scName),
+                        status_cur / status_max * 100)
+                except AttributeError:
+                    LOG.debug('Category %r subcat %r has no name',
+                              cat.cName, subcat.scid)
+                    pass
 
         for agency in county.agencyList:
             agency = self._client.service.getAgencyInfo(agency.aid, self._auth)

--- a/chirp/wxui/__init__.py
+++ b/chirp/wxui/__init__.py
@@ -1,13 +1,9 @@
 import argparse
 import builtins
+from importlib import resources
 import logging
 import os
 import sys
-
-if sys.version_info < (3, 10):
-    import importlib_resources
-else:
-    import importlib.resources as importlib_resources
 
 from chirp import CHIRP_VERSION
 from chirp import directory
@@ -33,14 +29,13 @@ def maybe_install_desktop(args):
     local = os.path.join(os.path.expanduser('~'), '.local')
     desktop_path = os.path.join(local, 'share',
                                 'applications', 'chirp.desktop')
-    with importlib_resources.as_file(
-            importlib_resources.files('chirp.share')
-            .joinpath('chirp.desktop')) as desktop_src:
+    with resources.as_file(
+            resources.files('chirp.share').joinpath('chirp.desktop')
+    ) as desktop_src:
         with open(desktop_src) as f:
             desktop_content = f.readlines()
-    with importlib_resources.as_file(
-            importlib_resources.files('chirp.share')
-            .joinpath('chirp.ico')) as p:
+    with resources.as_file(
+            resources.files('chirp.share').joinpath('chirp.ico')) as p:
         icon_path = str(p)
 
     # If asked not to do this, always bail
@@ -168,8 +163,7 @@ def chirpmain():
     else:
         lang = wx.Locale.GetSystemLanguage()
 
-    localedir = str(os.path.join(importlib_resources.files('chirp'),
-                                 'locale'))
+    localedir = str(os.path.join(resources.files('chirp'), 'locale'))
     app._lc = wx.Locale()
     if localedir and os.path.isdir(localedir):
         wx.Locale.AddCatalogLookupPathPrefix(localedir)

--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -22,6 +22,7 @@ import os
 import platform
 import shutil
 import tempfile
+import textwrap
 import threading
 
 import wx
@@ -711,7 +712,7 @@ def temporary_debug_log():
 
 
 @contextlib.contextmanager
-def expose_logs(level, root, label):
+def expose_logs(level, root, label, maxlen=128):
     if not isinstance(root, tuple):
         root = (root,)
 
@@ -724,7 +725,8 @@ def expose_logs(level, root, label):
             lines = list(itertools.chain.from_iterable(x.get_history()
                                                        for x in histories))
             if lines:
-                msg = os.linesep.join(x.getMessage() for x in lines)
+                msg = os.linesep.join(textwrap.shorten(x.getMessage(), maxlen)
+                                      for x in lines)
                 d = wx.MessageDialog(
                     None, str(msg), label,
                     style=wx.OK | wx.ICON_INFORMATION)

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -16,6 +16,7 @@
 import datetime
 import functools
 import hashlib
+from importlib import resources
 import logging
 import os
 import pickle
@@ -25,10 +26,6 @@ import time
 import typing
 import webbrowser
 
-if sys.version_info < (3, 10):
-    import importlib_resources
-else:
-    import importlib.resources as importlib_resources
 
 import wx
 import wx.aui
@@ -374,9 +371,8 @@ class ChirpWelcomePanel(wx.Panel):
 
         vbox = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(vbox)
-        with importlib_resources.as_file(
-            importlib_resources.files('chirp.share')
-            .joinpath('welcome_screen.png')
+        with resources.as_file(
+            resources.files('chirp.share').joinpath('welcome_screen.png')
         ) as welcome:
             bmp = wx.Bitmap(str(welcome))
         width, height = self.GetSize()
@@ -453,9 +449,8 @@ class ChirpMain(wx.Frame):
         self.add_tab_panel = wx.Panel(self, pos=(0, 0), size=(600, 600))
         self.add_tab_panel.Hide()
 
-        with importlib_resources.as_file(
-            importlib_resources.files('chirp.share')
-            .joinpath('plus-icon.png')
+        with resources.as_file(
+            resources.files('chirp.share').joinpath('plus-icon.png')
         ) as icon:
             self.add_tab_bm = wx.Bitmap(str(icon), wx.BITMAP_TYPE_ANY)
 
@@ -525,9 +520,8 @@ class ChirpMain(wx.Frame):
             icon = 'chirp.ico'
         else:
             icon = 'chirp.png'
-        with importlib_resources.as_file(
-            importlib_resources.files('chirp.share')
-            .joinpath(icon)
+        with resources.as_file(
+            resources.files('chirp.share').joinpath(icon)
         ) as path:
             self.SetIcon(wx.Icon(str(path)))
 
@@ -588,7 +582,7 @@ class ChirpMain(wx.Frame):
         dist_stock_confs = sorted(
             [
                 (conf.name, hashlib.md5(conf.read_bytes())) for conf
-                in importlib_resources.files('chirp.stock_configs').iterdir()
+                in resources.files('chirp.stock_configs').iterdir()
                 if conf.is_file()
             ]
         )
@@ -1233,9 +1227,8 @@ class ChirpMain(wx.Frame):
 
         user_stock_dir = get_stock_configs()
         user_stock_conf = os.path.join(user_stock_dir, fn)
-        with importlib_resources.as_file(
-            importlib_resources.files('chirp.stock_configs')
-            .joinpath(fn)
+        with resources.as_file(
+            resources.files('chirp.stock_configs').joinpath(fn)
         ) as path:
             dist_stock_conf = str(path)
         if os.path.exists(user_stock_conf):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ pyserial
 requests
 pywin32; platform_system=="Windows"
 suds
-importlib-resources;python_version<"3.10"
 yattag

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,10 @@ setup(name='chirp',
       include_package_data=True,
       version=0,
       url='https://chirp.danplanet.com',
-      python_requires=">=3.7,<4",
+      python_requires=">=3.10,<4",
       install_requires=[
           'pyserial',
           'requests',
-          'importlib-resources;python_version<"3.10"',
           'yattag',
       ],
       extras_require={

--- a/tools/cpep8.manifest
+++ b/tools/cpep8.manifest
@@ -23,7 +23,6 @@
 ./chirp/drivers/generic_csv.py
 ./chirp/drivers/gmrsv2.py
 ./chirp/drivers/h777.py
-./chirp/drivers/ic2730.py
 ./chirp/drivers/icf.py
 ./chirp/drivers/icomciv.py
 ./chirp/drivers/iradio_uv_5118.py

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps =
     mypy
 commands =
     python ./tools/cpep8.py {posargs}
-    mypy --config-file .mypy.ini chirp --exclude='/drivers/*' --exclude='chirp/share/*'
+    mypy --config-file .mypy.ini chirp --exclude='chirp/share/*'
 
 [textenv:py3clean]
 commands =


### PR DESCRIPTION
- Limit driver message line length
- csv: Avoid duplicating import error messages
- Fix several mypy warnings in chirp.drivers
- Add some type hints to chirp_common for IDEs
