### PR TITLE
radioddity_r2.py: Support Retevis RT24 with no ack - fixes #11297

### DIFF
--- a/chirp/drivers/radioddity_r2.py
+++ b/chirp/drivers/radioddity_r2.py
@@ -180,13 +180,19 @@ def _r2_enter_programming_mode(radio):
         raise errors.RadioError("Radio is password protected")
     try:
         serial.write(CMD_ACK)
-        ack = serial.read(6)
+        ack = serial.read(1)
 
     except:
         _r2_exit_programming_mode(radio)
         raise errors.RadioError("Error communicating with radio 2")
 
-    if ack != CMD_ACK:
+    # The latest Retevis RT24 (and likely the RT24V and H777S) models no
+    # longer acknowlege the CMD_ACK above so the 'ack' will be empty and
+    # fail the check causing cloning to fail.
+    #
+    # The factory CPS continues with or without an ack so CHIRP will
+    # behave the same way.
+    if ack and ack != CMD_ACK:
         _r2_exit_programming_mode(radio)
         raise errors.RadioError("Radio refused to enter programming mode 2")
 


### PR DESCRIPTION
The latest Retevis RT24 (and likely the RT24V and H777S) models no longer acknowlege the CMD_ACK following the password check so the 'ack' will be empty and fail the check for an ack causing cloning to fail.

The factory CPS continues with or without an ack so CHIRP will now behave the same way.

# CHIRP PR Guidelines

The following must be true before PRs can be merged:

1. All tests must be passing. The "PR Checks" job is speculative and failure doesn't always indicate a critial problem, but generally it needs to pass as well.
1. Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
1. Commits in a single PR should be related. Squash intermediate commits into logical units (i.e. "fix tests" commits need not survive on their own). Keep cleanup commits separate from functional changes.
1. Major new features or bug fixes should reference a [CHIRP issue](https://chirpmyradio.com/projects/chirp/issues) _in the commit message_. Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
1. Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc). The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
1. New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already). All new drivers should set `NEEDS_COMPAT_SERIAL=False` and use `MemoryMapBytes`. New drivers and radio models will affect the Python3 test matrix. You should regenerate this file with `tox -emakesupported` and include it in your commit.
1. All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).
1. Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
