### PR TITLE
Use older SetTable interface for compatibility

### DIFF
--- a/chirp/share/model_alias_map.yaml
+++ b/chirp/share/model_alias_map.yaml
@@ -123,6 +123,8 @@ Baofeng/Pofung:
   model: UV-5RE, UV-5RE+
 - alt: UV-5R
   model: UV-5RG, RK, RQ, RS, RT, RU
+- alt: Baofeng 5RM
+  model: UV-5RH Pro Max
 - alt: BF-F8HP
   model: UV-5RHP
 - alt: Radioddity UV-5RX3

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -729,8 +729,10 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
 
         self._grid = ChirpMemoryGrid(self)
         self._table = ChirpGridTable(self._features, len(self._col_defs))
-        self._grid.AssignTable(self._table)
-        self._grid.SetSelectionMode(wx.grid.Grid.SelectRows)
+        # AssignTable added in wxPython 4.1, so use the older interface for
+        # earlier version support (i.e. Ubuntu Jammy)
+        self._grid.SetTable(self._table, takeOwnership=True,
+                            selmode=wx.grid.Grid.SelectRows)
         self._grid.DisableDragRowSize()
         self._grid.EnableDragCell()
         self._grid.SetFocus()


### PR DESCRIPTION
Jammy and contemporaries are still stuck on wxPython 4.0.x and lack
the AssignTable interface that was added in 4.1. This makes us use
SetTable() instead to maintain compatibility with those older versions
for a bit longer.

Fixes #11352
