### PR TITLE
Make 'reveal backup location' create folder if it doesn't exist

### DIFF
--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1772,6 +1772,15 @@ class ChirpMain(wx.Frame):
     @common.error_proof()
     def _menu_backup_loc(self, event):
         backup_dir = chirp_platform.get_platform().config_file('backups')
+
+        # Backup directory may not exist if no backup has been made
+        try:
+            os.makedirs(backup_dir, exist_ok=True)
+        except Exception as e:
+            LOG.warning('Failed to create backup directory %s: %s' %
+                        (backup_dir, e))
+            return
+
         common.reveal_location(backup_dir)
 
     @common.error_proof()


### PR DESCRIPTION
If you run "Help/Show image backup location" before having made a backup, the action fails silently (with an error on the console), because the backup folder doesn't exist.

This MR includes a fix that attempts to create the directory before "revealing" it.