### PR TITLE
Display error dialog if python3-suds is not installed when querying RR

### DIFF
--- a/chirp/locale/de.po
+++ b/chirp/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2012-10-02 22:11+0100\n"
 "Last-Translator: Benjamin, HB9EUK <hb9euk@hb9d.org>\n"
 "Language-Team: German\n"
@@ -35,28 +35,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Löschen (und nach oben verschieben)"
 msgstr[1] "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Speicher"
 msgstr[1] "Speicher"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Löschen (und nach oben verschieben)"
 msgstr[1] "Löschen (und nach oben verschieben)"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Datei wurde geändert, speichern Sie die Änderungen vor dem Schliessen?"
@@ -65,7 +65,7 @@ msgstr "Datei wurde geändert, speichern Sie die Änderungen vor dem Schliessen?
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -623,17 +623,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr ""
 
@@ -641,12 +641,12 @@ msgstr ""
 msgid "All"
 msgstr "Alle"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "CSV Datei"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -662,7 +662,7 @@ msgstr "Ein Fehler ist aufgetreten"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Automatischer Repeater-Offset"
@@ -671,7 +671,7 @@ msgstr "Automatischer Repeater-Offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr ""
 
@@ -679,7 +679,7 @@ msgstr ""
 msgid "Bands"
 msgstr ""
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Bank"
 
@@ -687,7 +687,7 @@ msgstr "Bank"
 msgid "Bin"
 msgstr ""
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
@@ -709,13 +709,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -723,22 +723,22 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross Mode"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -769,25 +769,25 @@ msgstr ""
 msgid "Cloning"
 msgstr "Klonen"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Download vom Gerät"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Upload zum Gerät"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -823,7 +823,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -845,7 +845,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Ausschneiden"
 
@@ -865,11 +865,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr ""
 
@@ -878,25 +878,25 @@ msgstr ""
 msgid "Dec"
 msgstr "Erkennung"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Entwickler"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Digital Code"
 
@@ -905,7 +905,7 @@ msgstr "Digital Code"
 msgid "Digital Modes"
 msgstr "Digital Code"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr ""
 
@@ -932,16 +932,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download vom Gerät"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download vom Gerät"
@@ -959,7 +959,7 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -971,17 +971,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -995,11 +995,11 @@ msgstr "Aktiviert"
 msgid "Enter Frequency"
 msgstr "Frequenz"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1031,21 +1031,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Weiter mit dem experimentellen Treiber?"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 #, fuzzy
 msgid "Export to CSV"
 msgstr "In Datei exportieren"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "In Datei exportieren"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1072,13 +1072,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 #, fuzzy
 msgid "Files"
 msgstr "_Datei"
@@ -1091,17 +1091,17 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 #, fuzzy
 msgid "Find Next"
 msgstr "RFinder"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 #, fuzzy
 msgid "Find..."
 msgstr "RFinder"
@@ -1149,11 +1149,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1219,7 +1219,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1246,7 +1246,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1264,11 +1264,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1308,20 +1308,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Zeige RAW Speicher"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Hilfe"
 
@@ -1333,7 +1333,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Überschreiben?"
@@ -1347,20 +1347,20 @@ msgstr ""
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Importieren"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importieren von Datei"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr ""
 
@@ -1368,15 +1368,15 @@ msgstr ""
 msgid "Index"
 msgstr "Index"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Zeile oben einfügen"
@@ -1385,7 +1385,7 @@ msgstr "Zeile oben einfügen"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1399,7 +1399,7 @@ msgstr "Interner Fehler"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ungültiger Wert. Muss eine ganze Zahl sein."
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ungültiger Wert für dieses Feld"
@@ -1408,12 +1408,12 @@ msgstr "Ungültiger Wert für dieses Feld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1426,11 +1426,11 @@ msgstr "Ungültiger Wert für dieses Feld"
 msgid "Issue number:"
 msgstr ""
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 #, fuzzy
 msgid "Language"
 msgstr "Sprache wählen"
@@ -1461,12 +1461,12 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "Gerät"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 #, fuzzy
 msgid "Load Module..."
 msgstr "Module laden"
@@ -1476,18 +1476,18 @@ msgstr "Module laden"
 msgid "Load module from issue"
 msgstr "Module laden"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Module laden"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1514,11 +1514,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Speicher"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1550,17 +1550,17 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Mode"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 #, fuzzy
 msgid "Module"
 msgstr "Module laden"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Module laden"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1569,30 +1569,30 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Nach _Unten"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Nach _Oben"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 #, fuzzy
 msgid "New version available"
 msgstr "Eine neue Version von CHIRP ist verfügbar:"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Zeile unten einfügen"
@@ -1614,7 +1614,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr ""
 
@@ -1630,7 +1630,7 @@ msgstr ""
 msgid "Only certain modes"
 msgstr ""
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr ""
 
@@ -1638,37 +1638,37 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Aktuell"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Speichervorgaben öffnen"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Vorgaben öffnen {name}"
@@ -1690,7 +1690,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Überschreiben?"
@@ -1706,31 +1706,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1760,7 +1760,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1789,7 +1789,7 @@ msgstr "Leistung"
 msgid "Press enter to set this in memory"
 msgstr "Fehler beim Setzen der Speicher"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr ""
 
@@ -1797,16 +1797,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 #, fuzzy
 msgid "Query Source"
 msgstr "Datenquelle abfragen"
@@ -1815,11 +1815,11 @@ msgstr "Datenquelle abfragen"
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Gerät"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr ""
@@ -1865,11 +1865,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1884,30 +1884,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Report ist deaktiviert"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1915,15 +1915,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1948,7 +1948,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Spalten auswählen"
@@ -1958,7 +1958,7 @@ msgstr "Spalten auswählen"
 msgid "Select Bands"
 msgstr "Spalten auswählen"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "Spalten auswählen"
@@ -1968,7 +1968,7 @@ msgstr "Spalten auswählen"
 msgid "Select Modes"
 msgstr "Spalten auswählen"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1976,7 +1976,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "Einstellungen"
 
@@ -1984,58 +1984,58 @@ msgstr "Einstellungen"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr "Zeige RAW Speicher"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "Eingefügter Speicher {number} ist nicht mit diesem Gerät kompatibel weil:"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Überschreiben?"
@@ -2053,7 +2053,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr ""
 
@@ -2097,7 +2097,11 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2107,7 +2111,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Zeige RAW Speicher"
@@ -2132,13 +2136,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2173,12 +2177,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Löschen (und nach oben verschieben)"
@@ -2216,7 +2220,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Tone"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Tone Mode"
 
@@ -2254,7 +2258,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Abstimmungsschritt"
@@ -2269,16 +2273,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Speichervorgaben öffnen"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Kann Gerät auf {port} nicht erkennen"
@@ -2309,7 +2313,7 @@ msgstr "Keine Änderungen bei diesem Modell möglich"
 msgid "Unable to set %s on this memory"
 msgstr "Keine Änderungen bei diesem Modell möglich"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Keine Änderungen bei diesem Modell möglich"
@@ -2331,12 +2335,12 @@ msgstr "Nicht unterstuetzter Dateityp"
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Upload zum Gerät"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Upload zum Gerät"
@@ -2346,11 +2350,11 @@ msgstr "Upload zum Gerät"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr ""
 
@@ -2378,7 +2382,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2386,7 +2390,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Hersteller"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 #, fuzzy
 msgid "View"
 msgstr "_Ansicht"
@@ -2395,16 +2399,16 @@ msgstr "_Ansicht"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr ""
 
@@ -2428,12 +2432,12 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 #, fuzzy
 msgid "disabled"
 msgstr "Aktiviert"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 #, fuzzy
 msgid "enabled"
 msgstr "Aktiviert"

--- a/chirp/locale/el.po
+++ b/chirp/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2023-02-11 15:12+0200\n"
 "Last-Translator: Sokratis Alichanidis <sv2hzs@posteo.net>\n"
 "Language-Team: Greek\n"
@@ -37,28 +37,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 msgstr[1] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Μνήμες"
 msgstr[1] "Μνήμες"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
 msgstr[1] "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr ""
@@ -67,7 +67,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(καμία)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -625,7 +625,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -633,11 +633,11 @@ msgstr ""
 "Μία νέα έκδοση του CHIRP είναι διαθέσιμη. Παρακαλούμε επισκεφθείτε την "
 "ιστοσελίδα το συντομότερο δυνατό για να την κατεβάσετε!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "Σχετικά"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr "Σχετικά με το CHIRP"
 
@@ -645,11 +645,11 @@ msgstr "Σχετικά με το CHIRP"
 msgid "All"
 msgstr "Όλες"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Όλα τα αρχεία"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Όλοι οι τύποι αρχείων|"
 
@@ -665,7 +665,7 @@ msgstr "Παρουσιάστηκε ένα σφάλμα"
 msgid "Applying settings"
 msgstr "Εφαρμογή ρυθμίσεων"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 msgid "Automatic from system"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr "Χάρτης συχνοτήτων"
 
@@ -681,7 +681,7 @@ msgstr "Χάρτης συχνοτήτων"
 msgid "Bands"
 msgstr "Μπάντες"
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Ομάδες μνημών"
 
@@ -689,7 +689,7 @@ msgstr "Ομάδες μνημών"
 msgid "Bin"
 msgstr "Bin"
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr "Περιηγητής"
 
@@ -697,7 +697,7 @@ msgstr "Περιηγητής"
 msgid "Building Radio Browser"
 msgstr "Δημιουργία Περιηγητή Πομποδεκτών"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
@@ -711,13 +711,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Αρχεία ειδώλου CHIRP"
 
@@ -725,21 +725,21 @@ msgstr "Αρχεία ειδώλου CHIRP"
 msgid "Choice Required"
 msgstr "Απαιτείται επιλογή"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Επιλέξτε κωδικό DTCS %s"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Επιλέξτε τόνο %s"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 #, fuzzy
 msgid "Choose duplex"
 msgstr "Επιλογή duplex"
@@ -771,23 +771,23 @@ msgstr ""
 msgid "Cloning"
 msgstr "Αντιγραφή"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 msgid "Cloning from radio"
 msgstr "Λήψη από πομποδέκτη"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 msgid "Cloning to radio"
 msgstr "Αποστολή σε πομποδέκτη"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr "Κλείσιμο"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr "Κλείσιμο αρχείου"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -822,7 +822,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr "Εισάγετε προσαρμοσμένη θύρα:"
 msgid "Custom..."
 msgstr "Προσαρμοσμένη..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 #, fuzzy
 msgid "Cut"
 msgstr "Χώρα"
@@ -866,11 +866,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "Μνήμη DV"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr ""
 
@@ -878,24 +878,24 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Λειτουργία προγραμματιστή"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 #, fuzzy
 msgid "Digital Code"
 msgstr "Ψηφιακός Κωδικός"
@@ -905,7 +905,7 @@ msgstr "Ψηφιακός Κωδικός"
 msgid "Digital Modes"
 msgstr "Ψηφιακός Κωδικός"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 #, fuzzy
 msgid "Disable reporting"
 msgstr "Αναφορές απενεργοποιημένες"
@@ -932,15 +932,15 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr "Κάντε διπλό κλικ για μετονομασία της ομάδας μνημών"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr "Λήψη"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 msgid "Download from radio"
 msgstr "Λήψη Από Πομποδέκτη"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Λήψη Από Πομποδέκτη"
@@ -958,7 +958,7 @@ msgstr "Επαναφόρτωση Οδηγού"
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -970,17 +970,17 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Επεξεργασία λεπτομερειών για %i μνήμες"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Επεξεργασία λεπτομερειών για τη μνήμη %i"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 #, fuzzy
 msgid "Enable Automatic Edits"
 msgstr "Ενεργοποίηση αυτόματης επεξεργασίας"
@@ -993,11 +993,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Εισάγετε συχνότητα"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "Εισάγετε συχνότητα εκπομπής (MHz)"
 
@@ -1027,20 +1027,20 @@ msgstr "Σφάλμα επικοινωνίας με τον πομποδέκτη"
 msgid "Experimental driver"
 msgstr "Πειραματικός οδηγός"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "Η εξαγωγή είναι δυνατή μόνο σε αρχεία CSV"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 msgid "Export to CSV"
 msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Περισσότερα"
 
@@ -1068,13 +1068,13 @@ msgstr "Αδυναμία φόρτωσης περιηγητή πομποδεκτ�
 msgid "Features"
 msgstr "Δυνατότητες"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Το αρχείο δεν υπάρχει: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 msgid "Files"
 msgstr "Αρχεία"
 
@@ -1086,15 +1086,15 @@ msgstr "Φίλτρο"
 msgid "Filter results with location matching this string"
 msgstr "Φιλτράρισμα αποτελεσμάτων με τοποθεσία σύμφωνη με αυτό το λεκτικό"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr "Εύρεση"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr "Εύρεση επόμενου"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 #, fuzzy
 msgid "Find..."
 msgstr "Εύρεση"
@@ -1142,11 +1142,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1212,7 +1212,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1239,7 +1239,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1257,11 +1257,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1301,20 +1301,20 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Λήψη ρυθμίσεων"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Μετάβαση σε Μνήμη"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Μετάβαση σε Μνήμη:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 #, fuzzy
 msgid "Goto..."
 msgstr "Μετάβαση σε"
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr ""
 
@@ -1326,7 +1326,7 @@ msgstr "Βοήθεια..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Αντικατάσταση μνημών;"
@@ -1340,19 +1340,19 @@ msgstr ""
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr ""
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 msgid "Import from file..."
 msgstr ""
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr ""
 
@@ -1360,15 +1360,15 @@ msgstr ""
 msgid "Index"
 msgstr ""
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Εισαγωγή γραμμής επάνω"
 
@@ -1376,7 +1376,7 @@ msgstr "Εισαγωγή γραμμής επάνω"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 #, fuzzy
 msgid "Interact with driver"
 msgstr "Αλληλεπίδραση με οδηγό"
@@ -1391,7 +1391,7 @@ msgstr "Αλληλεπίδραση με οδηγό"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Μη έγκυρη τιμή: %s"
@@ -1400,12 +1400,12 @@ msgstr "Μη έγκυρη τιμή: %s"
 msgid "Invalid ZIP code"
 msgstr "Μη έγκυρος ΤΚ"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Μη έγκυρη τιμή: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1418,12 +1418,12 @@ msgstr "Μη έγκυρη τιμή: %r"
 msgid "Issue number:"
 msgstr ""
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 #, fuzzy
 msgid "LIVE"
 msgstr "LIVE"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 msgid "Language"
 msgstr ""
 
@@ -1454,12 +1454,12 @@ msgstr "Περιορισμός Μπαντών"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "Πομποδέκτης"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 #, fuzzy
 msgid "Load Module..."
 msgstr "Φόρτωση Module"
@@ -1469,18 +1469,18 @@ msgstr "Φόρτωση Module"
 msgid "Load module from issue"
 msgstr "Φόρτωση Module"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Φόρτωση Module"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1507,11 +1507,11 @@ msgstr ""
 msgid "Longitude"
 msgstr "Γεωγραφικό μήκος"
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Μνήμες"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Η μνήμη %i δεν μπορεί να διαγραφεί"
@@ -1529,7 +1529,7 @@ msgstr "Η μνήμη πρέπει να βρίσκεται σε ομάδα γι�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Η μνήμη {num} δεν βρίσκεται στην ομάδα μνημών {bank}"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 #, fuzzy
 msgid "Mode"
 msgstr "Λειτουργία"
@@ -1542,16 +1542,16 @@ msgstr "Μοντέλο"
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr "Module"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Module"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1560,27 +1560,27 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr "Βρέθηκαν περισσότερες από μία θύρες: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr ""
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr ""
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr "Διαθέσιμη νέα έκδοση"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "Καμία κενή σειρά από κάτω!"
 
@@ -1602,7 +1602,7 @@ msgstr "Κανένα αποτέλεσμα!"
 msgid "No results!"
 msgstr "Κανένα αποτέλεσμα!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr "Αριθμός"
 
@@ -1618,7 +1618,7 @@ msgstr "Μόνο ορισμένες μπάντες"
 msgid "Only certain modes"
 msgstr ""
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr "Μόνο οι καρτέλες μνημών μπορούν να εξαχθούν"
 
@@ -1626,35 +1626,35 @@ msgstr "Μόνο οι καρτέλες μνημών μπορούν να εξαχ
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr "Άνοιγμα"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 msgid "Open Recent"
 msgstr "Άνοιγμα πρόσφατου"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 msgid "Open Stock Config"
 msgstr "Άνοιγμα προεπιλεγμένων ρυθμίσεων"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Άνοιγμα αρχείου"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr "Άνοιγμα αρθρώματος"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Άνοιγμα αρχείου καταγραφής αποσφαλμάτωσης"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Άνοιγμα προεπιλεγμένων ρυθμίσεων"
@@ -1676,7 +1676,7 @@ msgstr "Προαιρετικό: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Προαιρετικό: Επαρχία, Νοσοκομείο κλπ"
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "Αντικατάσταση μνημών;"
 
@@ -1691,31 +1691,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr ""
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 "Παρακαλούμε βεβαιωθείτε ότι έχετε κλείσει το CHIRP πριν εγκαταστήσετε την "
@@ -1747,7 +1747,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1775,7 +1775,7 @@ msgstr "Ισχύς"
 msgid "Press enter to set this in memory"
 msgstr "Πατήστε enter για καταχώρηση στη μνήμη"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr "Προεπισκόπηση εκτύπωσης"
 
@@ -1783,16 +1783,16 @@ msgstr "Προεπισκόπηση εκτύπωσης"
 msgid "Printing"
 msgstr "Εκτύπωση"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Ιδιότητες"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr "Ερώτημα %s"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Ερώτημα Πηγής"
 
@@ -1800,11 +1800,11 @@ msgstr "Ερώτημα Πηγής"
 msgid "RX DTCS"
 msgstr "DTCS Λήψης"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Πομποδέκτης"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr "Ο πομποδέκτης δεν επιβεβαίωσε το μπλοκ %i"
@@ -1850,11 +1850,11 @@ msgstr "Απαιτείται επανεκκίνηση"
 msgid "Refreshed memory %s"
 msgstr "Ανανεώθηκε η μνήμη %s"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Επαναφόρτωση Οδηγού"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Επαναφόρτωση Οδηγού και Αρχείου"
 
@@ -1868,30 +1868,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Αναφορές ενεργοποιημένες"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr "Απαιτείται επανεκκίνηση"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Επαναφορά %i καρτελών"
 msgstr[1] "Επαναφορά %i καρτελών"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Επαναφορά %i καρτελών"
@@ -1900,15 +1900,15 @@ msgstr "Επαναφορά %i καρτελών"
 msgid "Retrieved settings"
 msgstr "Ρυθμίσεις ανακτήθηκαν"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr "Αποθήκευση πριν το κλείσιμο;"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Αποθήκευση αρχείου"
 
@@ -1932,7 +1932,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Επιλογή χάρτη συχνοτήτων"
@@ -1941,7 +1941,7 @@ msgstr "Επιλογή χάρτη συχνοτήτων"
 msgid "Select Bands"
 msgstr "Επιλογή Μπαντών"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "Επιλογή Μπαντών"
@@ -1950,7 +1950,7 @@ msgstr "Επιλογή Μπαντών"
 msgid "Select Modes"
 msgstr ""
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr "Επιλογή χάρτη συνοτήτων"
 
@@ -1958,7 +1958,7 @@ msgstr "Επιλογή χάρτη συνοτήτων"
 msgid "Service"
 msgstr "Υπηρεσία"
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "Ρυθμίσεις"
 
@@ -1966,57 +1966,57 @@ msgstr "Ρυθμίσεις"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr ""
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Εμφάνιση τοποθεσίας αρχείου καταγραφής αποσφαλμάτωσης"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Show image backup location"
 msgstr "Εμφάνιση τοποθεσίας αρχείου καταγραφής αποσφαλμάτωσης"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Κάποιες μνήμες δεν είναι συμβατές με αυτόν τον πομποδέκτη"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Κάποιες μνήμες δεν είναι δυνατόν να διαγραφούν"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Αντικατάσταση μνημών;"
@@ -2034,7 +2034,7 @@ msgstr "Πολιτεία"
 msgid "State/Province"
 msgstr "Πολιτεία / Επαρχία"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr ""
 
@@ -2078,7 +2078,11 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2088,7 +2092,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Μνήμη DV"
@@ -2113,13 +2117,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2161,12 +2165,12 @@ msgstr ""
 "δυνατοτήτων!\n"
 "Σας προειδοποιήσαμε. Προχωράτε με δική σας ευθύνη!"
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
@@ -2204,7 +2208,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Τόνος"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Τύπος τόνου"
 
@@ -2241,7 +2245,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Βήμα συντονισμού"
 
@@ -2255,16 +2259,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Αδυναμία ανοίγματος του πρόχειρου"
@@ -2294,7 +2298,7 @@ msgstr ""
 msgid "Unable to set %s on this memory"
 msgstr "Πατήστε enter για καταχώρηση στη μνήμη"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Πατήστε enter για καταχώρηση στη μνήμη"
@@ -2316,11 +2320,11 @@ msgstr ""
 msgid "Upload instructions"
 msgstr "Οδηγίες αποστολής"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 msgid "Upload to radio"
 msgstr "Αποστολή Σε Πομποδέκτη"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Αποστολή Σε Πομποδέκτη"
@@ -2330,11 +2334,11 @@ msgstr "Αποστολή Σε Πομποδέκτη"
 msgid "Uploaded memory %s"
 msgstr "Απεστάλη η μνήμη %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr "Χρήση γραμματοσειράς σταθερού πλάτους"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr "Χρήση μεγαλύτερης γραμματοσειράς"
 
@@ -2362,7 +2366,7 @@ msgstr "Η τιμή πρέπει να έιναι ακριβώς %i δεκαδι�
 msgid "Value must be zero or greater"
 msgstr "Η τιμή πρέπει να είναι μηδέν ή μεγαλύτερη"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2370,7 +2374,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Προμηθευτής"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 msgid "View"
 msgstr "Εμφάνιση"
 
@@ -2378,16 +2382,16 @@ msgstr "Εμφάνιση"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr "Προειδοποίηση"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Προειδοποίηση: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr "Καλωσήρθατε"
 
@@ -2411,11 +2415,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "bytes το καθένα"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/en_US.po
+++ b/chirp/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2011-11-29 16:07-0800\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "_Delete"
 msgstr[1] "_Delete"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "_Delete"
 msgstr[1] "_Delete"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "File is modified, save changes before closing?"
@@ -63,7 +63,7 @@ msgstr "File is modified, save changes before closing?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -621,17 +621,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr ""
 
@@ -639,12 +639,12 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "CSV Files"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -660,7 +660,7 @@ msgstr ""
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Automatic Repeater Offset"
@@ -669,7 +669,7 @@ msgstr "Automatic Repeater Offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr ""
 
@@ -677,7 +677,7 @@ msgstr ""
 msgid "Bands"
 msgstr ""
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Bin"
 msgstr ""
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr ""
 
@@ -693,7 +693,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
@@ -707,13 +707,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -721,21 +721,21 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -766,25 +766,25 @@ msgstr ""
 msgid "Cloning"
 msgstr ""
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Download From Radio"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Upload To Radio"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -819,7 +819,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 #, fuzzy
 msgid "Copy"
 msgstr "_Copy"
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 #, fuzzy
 msgid "Cut"
 msgstr "_Cut"
@@ -860,11 +860,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr ""
 
@@ -872,27 +872,27 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 #, fuzzy
 msgid "Delete"
 msgstr "_Delete"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Developer"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr ""
 
@@ -900,7 +900,7 @@ msgstr ""
 msgid "Digital Modes"
 msgstr ""
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr ""
 
@@ -926,16 +926,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download From Radio"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download From Radio"
@@ -953,7 +953,7 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -965,17 +965,17 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -987,11 +987,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr ""
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1021,21 +1021,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Import from RFinder"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Import from RFinder"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1062,13 +1062,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 #, fuzzy
 msgid "Files"
 msgstr "_File"
@@ -1081,15 +1081,15 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 msgid "Find..."
 msgstr ""
 
@@ -1136,11 +1136,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1206,7 +1206,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1233,7 +1233,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1251,11 +1251,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1295,20 +1295,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Show raw memory"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Help"
 
@@ -1320,7 +1320,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Diff raw memories"
@@ -1334,20 +1334,20 @@ msgstr ""
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Import"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 #, fuzzy
 msgid "Import from file..."
 msgstr "Import from RFinder"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Import from RFinder"
@@ -1356,15 +1356,15 @@ msgstr "Import from RFinder"
 msgid "Index"
 msgstr ""
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr ""
 
@@ -1372,7 +1372,7 @@ msgstr ""
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1385,7 +1385,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1393,12 +1393,12 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1411,11 +1411,11 @@ msgstr ""
 msgid "Issue number:"
 msgstr ""
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 msgid "Language"
 msgstr ""
 
@@ -1445,12 +1445,12 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "_Radio"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 msgid "Load Module..."
 msgstr ""
 
@@ -1458,17 +1458,17 @@ msgstr ""
 msgid "Load module from issue"
 msgstr ""
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1495,12 +1495,12 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 #, fuzzy
 msgid "Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 msgid "Mode"
 msgstr ""
 
@@ -1530,15 +1530,15 @@ msgstr ""
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1547,29 +1547,29 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Move D_n"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Move _Up"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr ""
 
@@ -1590,7 +1590,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr ""
 
@@ -1606,7 +1606,7 @@ msgstr ""
 msgid "Only certain modes"
 msgstr ""
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr ""
 
@@ -1614,36 +1614,36 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Recent"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 msgid "Open Stock Config"
 msgstr ""
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 msgid "Open stock config directory"
 msgstr ""
 
@@ -1663,7 +1663,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Diff raw memories"
@@ -1679,32 +1679,32 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 #, fuzzy
 msgid "Paste"
 msgstr "_Paste"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1734,7 +1734,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1762,7 +1762,7 @@ msgstr ""
 msgid "Press enter to set this in memory"
 msgstr ""
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr ""
 
@@ -1770,16 +1770,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr ""
 
@@ -1787,12 +1787,12 @@ msgstr ""
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 #, fuzzy
 msgid "Radio"
 msgstr "_Radio"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr ""
@@ -1836,11 +1836,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1854,30 +1854,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Reporting is disabled"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1885,15 +1885,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1917,7 +1917,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Select Columns"
@@ -1927,7 +1927,7 @@ msgstr "Select Columns"
 msgid "Select Bands"
 msgstr "Select Columns"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "Select Columns"
@@ -1937,7 +1937,7 @@ msgstr "Select Columns"
 msgid "Select Modes"
 msgstr "Select Columns"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1945,7 +1945,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr ""
 
@@ -1953,57 +1953,57 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Show raw memory"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Diff raw memories"
@@ -2020,7 +2020,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr ""
 
@@ -2064,7 +2064,11 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2074,7 +2078,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Show raw memory"
@@ -2099,13 +2103,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2140,12 +2144,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "_Delete"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "_Delete"
@@ -2183,7 +2187,7 @@ msgstr ""
 msgid "Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr ""
 
@@ -2219,7 +2223,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr ""
 
@@ -2233,16 +2237,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 msgid "Unable to import while the view is sorted"
 msgstr ""
 
@@ -2271,7 +2275,7 @@ msgstr ""
 msgid "Unable to set %s on this memory"
 msgstr ""
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 msgid "Unable to upload this file"
 msgstr ""
 
@@ -2292,12 +2296,12 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Upload To Radio"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Upload To Radio"
@@ -2307,11 +2311,11 @@ msgstr "Upload To Radio"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr ""
 
@@ -2339,7 +2343,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2347,7 +2351,7 @@ msgstr ""
 msgid "Vendor"
 msgstr ""
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 #, fuzzy
 msgid "View"
 msgstr "_View"
@@ -2356,16 +2360,16 @@ msgstr "_View"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr ""
 
@@ -2389,11 +2393,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/es.po
+++ b/chirp/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2024-05-20 23:31-0400\n"
 "Last-Translator: MELERIX\n"
 "Language-Team: \n"
@@ -43,28 +43,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s debe estar entre %(min)i y %(max)i"
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Memoria y desplazar todo hacia arriba"
 msgstr[1] "%i Memorias y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Memoria"
 msgstr[1] "%i Memorias"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Memoria y desplazar bloque hacia arriba"
 msgstr[1] "%i Memorias y desplazar bloque hacia arriba"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s no ha sido guardado. ¿Guardar antes de cerrar?"
@@ -73,7 +73,7 @@ msgstr "%s no ha sido guardado. ¿Guardar antes de cerrar?"
 msgid "(none)"
 msgstr "(nada)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr "...y %i más"
@@ -994,7 +994,7 @@ msgstr ""
 "\n"
 "Esto podría no funcionar si enciendes la radio con el cable ya conectado"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -1002,11 +1002,11 @@ msgstr ""
 "Una nueva versión de CHIRP está disponible, ¡Por favor visita el sitio web "
 "tan pronto como sea posible para descargarla!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "Acerca de"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr "Acerca de CHIRP"
 
@@ -1014,11 +1014,11 @@ msgstr "Acerca de CHIRP"
 msgid "All"
 msgstr "Todo"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Todos los archivos"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Todos los formatos soportados|"
 
@@ -1034,7 +1034,7 @@ msgstr "Ha ocurrido un error"
 msgid "Applying settings"
 msgstr "Aplicando ajustes"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 msgid "Automatic from system"
 msgstr "Automático del sistema"
 
@@ -1042,7 +1042,7 @@ msgstr "Automático del sistema"
 msgid "Available modules"
 msgstr "Módulos disponibles"
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr "Plan de banda"
 
@@ -1050,7 +1050,7 @@ msgstr "Plan de banda"
 msgid "Bands"
 msgstr "Bandas"
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Bancos"
 
@@ -1058,7 +1058,7 @@ msgstr "Bancos"
 msgid "Bin"
 msgstr "Binario"
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr "Navegador"
 
@@ -1066,7 +1066,7 @@ msgstr "Navegador"
 msgid "Building Radio Browser"
 msgstr "Construyendo navegador de radio"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr "CHIRP debe ser reiniciado para que la nueva selección tome efecto"
 
@@ -1082,7 +1082,7 @@ msgstr ""
 "Cambiar este ajuste requiere actualizar los ajustes desde la imagen, lo cual "
 "ocurrirá ahora."
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
@@ -1090,7 +1090,7 @@ msgstr ""
 "Canales con TX y RX equivalentes %s son representados por modo de tono de "
 "\"%s\""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Archivos de imagen Chirp"
 
@@ -1098,21 +1098,21 @@ msgstr "Archivos de imagen Chirp"
 msgid "Choice Required"
 msgstr "Elección requerida"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Elegir %s código DTCS"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Elegir %s tono"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "Elegir modo cruzado"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr "Elegir Dúplex"
 
@@ -1150,23 +1150,23 @@ msgstr "Clonado completado, comprobando por bytes espurios"
 msgid "Cloning"
 msgstr "Clonando"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 msgid "Cloning from radio"
 msgstr "Clonando desde radio"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 msgid "Cloning to radio"
 msgstr "Clonando a radio"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr "Cerrar"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr "Cerrar archivo"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Convertir a FM"
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Copiar"
 
@@ -1226,7 +1226,7 @@ msgstr "Puerto personalizado"
 msgid "Custom..."
 msgstr "Personalizado..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Cortar"
 
@@ -1246,11 +1246,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Decodificación DTMF"
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "Memoria DV"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr "Peligro adelante"
 
@@ -1258,26 +1258,26 @@ msgstr "Peligro adelante"
 msgid "Dec"
 msgstr "Decimal"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Modo desarrollador"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Estado de desarrollador ahora está %s. CHIRP debe ser reiniciado para que "
 "tome efecto"
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr "Diferenciar memorias en bruto"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Código digital"
 
@@ -1285,7 +1285,7 @@ msgstr "Código digital"
 msgid "Digital Modes"
 msgstr "Modos digitales"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr "Deshabilitar reportes"
 
@@ -1311,15 +1311,15 @@ msgstr "¿Aceptas el riesgo?"
 msgid "Double-click to change bank name"
 msgstr "Doble clic para cambiar nombre de banco"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr "Descargar"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 msgid "Download from radio"
 msgstr "Descargar desde radio"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "Descargar desde radio..."
 
@@ -1335,7 +1335,7 @@ msgstr "Controlador"
 msgid "Driver information"
 msgstr "Información del controlador"
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr "Mensajes del controlador"
 
@@ -1349,17 +1349,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Dúplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Editar detalles para %i memorias"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editar detalles para memoria %i"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Habilitar ediciones automáticas"
 
@@ -1371,11 +1371,11 @@ msgstr "Habilitado"
 msgid "Enter Frequency"
 msgstr "Ingresar frecuencia"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr "Ingresar desplazamiento (MHz)"
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "Ingresar frecuencia TX (MHz)"
 
@@ -1405,19 +1405,19 @@ msgstr "Error comunicándose con la radio"
 msgid "Experimental driver"
 msgstr "Controlador experimental"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "Exportar solo puede escribir archivos CSV"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 msgid "Export to CSV"
 msgstr "Exportar a CSV"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 msgid "Export to CSV..."
 msgstr "Exportar a CSV..."
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Extra"
 
@@ -1447,13 +1447,13 @@ msgstr "Fallo al analizar el resultado"
 msgid "Features"
 msgstr "Caracteristicas"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr "El archivo no existe: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 msgid "Files"
 msgstr "Archivos"
 
@@ -1465,15 +1465,15 @@ msgstr "Filtrar"
 msgid "Filter results with location matching this string"
 msgstr "Filtrar resultados con ubicación coincidiendo esta cadena"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr "Buscar"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr "Buscar siguiente"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 msgid "Find..."
 msgstr "Buscar..."
 
@@ -1542,11 +1542,11 @@ msgstr ""
 "5 - ¡Desconecta el cable de interfaz! ¡De lo contrario no habrá\n"
 "    audio del lado derecho!\n"
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1650,7 +1650,7 @@ msgstr ""
 "    audio del lado derecho!\n"
 "6 - Apaga y enciende la radio para salir del modo de clonación\n"
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1692,7 +1692,7 @@ msgstr ""
 "3 - Enciende tu radio\n"
 "4 - Cliquea Aceptar para iniciar\n"
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1720,11 +1720,11 @@ msgstr ""
 "3 - Enciende tu radio\n"
 "4 - Haz la descarga de tus datos de radio\n"
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1774,19 +1774,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Obteniendo ajustes"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Ir a memoria"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Ir a memoria:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "Ir a..."
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Ayuda"
 
@@ -1798,7 +1798,7 @@ msgstr "Ayúdame..."
 msgid "Hex"
 msgstr "Hexadecimal"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "Ocultar memorias vacías"
 
@@ -1812,19 +1812,19 @@ msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Si se establece, ordenar los resultados por distancia desde estas coordenadas"
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Importar"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 msgid "Import from file..."
 msgstr "Importar desde archivo..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr "Importar mensajes"
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr "Importación no recomendada"
 
@@ -1832,15 +1832,15 @@ msgstr "Importación no recomendada"
 msgid "Index"
 msgstr "Índice"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Insertar fila arriba"
 
@@ -1848,7 +1848,7 @@ msgstr "Insertar fila arriba"
 msgid "Install desktop icon?"
 msgstr "¿Instalar icono de escritorio?"
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Interactuar con controlador"
 
@@ -1861,7 +1861,7 @@ msgstr "Error interno del controlador"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s inválido (usa grados decimales)"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 msgid "Invalid Entry"
 msgstr "Entrada inválida"
 
@@ -1869,12 +1869,12 @@ msgstr "Entrada inválida"
 msgid "Invalid ZIP code"
 msgstr "Código postal inválido"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Edición inválida: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr "Archivo de módulo inválido o no soportado"
 
@@ -1887,11 +1887,11 @@ msgstr "Valor inválido: %r"
 msgid "Issue number:"
 msgstr "Número de problema:"
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr "EN VIVO"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 msgid "Language"
 msgstr "Lenguaje"
 
@@ -1921,11 +1921,11 @@ msgstr "Estado límite"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Limitar resultados a esta distancia (km) desde coordenadas"
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 msgid "Live Radio"
 msgstr "Radio en vivo"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 msgid "Load Module..."
 msgstr "Cargar módulo..."
 
@@ -1933,11 +1933,11 @@ msgstr "Cargar módulo..."
 msgid "Load module from issue"
 msgstr "Cargar módulo desde problema"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 msgid "Load module from issue..."
 msgstr "Cargar módulo desde problema..."
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
@@ -1946,7 +1946,7 @@ msgstr ""
 "que se indique lo contrario) cerrar todas las pestañas antes de cargar un "
 "módulo."
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1979,11 +1979,11 @@ msgstr "Cadena del logotipo 2 (12 caracteres)"
 msgid "Longitude"
 msgstr "Longitud"
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Memorias"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoria %i no es borrable"
@@ -2001,7 +2001,7 @@ msgstr "La memoria debe estar en un banco para ser editada"
 msgid "Memory {num} not in bank {bank}"
 msgstr "La memoria {num} no está en banco {bank}"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 msgid "Mode"
 msgstr "Modo"
 
@@ -2013,15 +2013,15 @@ msgstr "Modelo"
 msgid "Modes"
 msgstr "Modos"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr "Módulo"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr "Módulo cargado"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr "Módulo cargado exitosamente"
 
@@ -2030,29 +2030,29 @@ msgstr "Módulo cargado exitosamente"
 msgid "More than one port found: %s"
 msgstr "Más de un puerto encontrado: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "Mover abajo"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "Mover arriba"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 "Las operaciones de movimiento están deshabilitadas mientras la vista es "
 "ordenada"
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr "Nueva versión disponible"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "¡No hay filas vacías debajo!"
 
@@ -2073,7 +2073,7 @@ msgstr "No hay resultados"
 msgid "No results!"
 msgstr "¡No hay resultados!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr "Numero"
 
@@ -2089,7 +2089,7 @@ msgstr "Solo ciertas bandas"
 msgid "Only certain modes"
 msgstr "Solo ciertos modos"
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr "Solo pestañas de memorias pueden ser exportadas"
 
@@ -2097,35 +2097,35 @@ msgstr "Solo pestañas de memorias pueden ser exportadas"
 msgid "Only working repeaters"
 msgstr "Sólo repetidores funcionando"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr "Abrir"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 msgid "Open Recent"
 msgstr "Abrir reciente"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 msgid "Open Stock Config"
 msgstr "Abrir configuración original"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Abrir un archivo"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr "Abrir un módulo"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Abrir registro de depuración"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr "Abrir en nueva ventana"
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 msgid "Open stock config directory"
 msgstr "Abrir directorio de configuración original"
 
@@ -2145,7 +2145,7 @@ msgstr "Opcional: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcional: Condado, Hospital, etc."
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "¿Sobrescribir memorias?"
 
@@ -2163,31 +2163,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Analizando"
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Las memorias pegadas sobrescribirán %s memorias existentes"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Las memorias pegadas sobrescribirán memorias %s"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Las memorias pegadas sobrescribirán la memoria %s"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria pegada sobrescribirá la memoria %s"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 "¡Por favor asegúrate de salir de CHIRP antes de instalar la nueva versión!"
@@ -2236,7 +2236,7 @@ msgstr ""
 "4 - Entonces presiona el botón \"A\" en tu radio para iniciar la clonación.\n"
 "    (Al final la radio emitirá un pitido)\n"
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2269,7 +2269,7 @@ msgstr "Potencia"
 msgid "Press enter to set this in memory"
 msgstr "Presiona enter para configurar esto en memoria"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr "Previsualización de impresión"
 
@@ -2277,16 +2277,16 @@ msgstr "Previsualización de impresión"
 msgid "Printing"
 msgstr "Imprimiendo"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr "Consulta %s"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Consultar fuente"
 
@@ -2294,11 +2294,11 @@ msgstr "Consultar fuente"
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Radio"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr "La radio no reconoció el bloque %i"
@@ -2350,11 +2350,11 @@ msgstr "Actualización requerida"
 msgid "Refreshed memory %s"
 msgstr "Memoria actualizada %s"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Recargar controlador"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Recargar controlador y archivo"
 
@@ -2370,11 +2370,11 @@ msgstr ""
 "RepeaterBook es el directorio GRATUITO de repetidores,\n"
 "mundial, de Radio Aficionados más completo."
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Reportes habilitados"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2384,18 +2384,18 @@ msgstr ""
 "plataformas de SO gastar nuestros limitados esfuerzos. Apreciamos mucho si "
 "lo dejas habilitado. ¿Realmente deshabilitar reportes?"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr "Reinicio requerido"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Restaurar %i pestaña"
 msgstr[1] "Restaurar %i pestañas"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr "Restaurar pestañas al iniciar"
 
@@ -2403,15 +2403,15 @@ msgstr "Restaurar pestañas al iniciar"
 msgid "Retrieved settings"
 msgstr "Ajustes recuperados"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr "Guardar"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr "¿Guardar antes de cerrar?"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Guardar archivo"
 
@@ -2435,7 +2435,7 @@ msgstr "Codificador"
 msgid "Security Risk"
 msgstr "Riesgo de seguridad"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "Seleccionar plan de banda..."
 
@@ -2443,7 +2443,7 @@ msgstr "Seleccionar plan de banda..."
 msgid "Select Bands"
 msgstr "Seleccionar bandas"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 msgid "Select Language"
 msgstr "Seleccionar lenguaje"
 
@@ -2451,7 +2451,7 @@ msgstr "Seleccionar lenguaje"
 msgid "Select Modes"
 msgstr "Seleccionar modos"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr "Seleccionar plan de banda"
 
@@ -2459,7 +2459,7 @@ msgstr "Seleccionar plan de banda"
 msgid "Service"
 msgstr "Servicio"
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "Ajustes"
 
@@ -2469,56 +2469,56 @@ msgstr ""
 "Cantidad de desplazamiento (o frecuencia de transmisión) controlada por "
 "dúplex"
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr "Mostrar memoria en bruto"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Mostrar ubicación del registro de depuración"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "Mostrar campos adicionales"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr "Mostrar ubicación de la copia de respaldo de la imagen"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Algunas memorias son incompatibles con esta radio"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Algunas memorias no son borrables"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Ordenar %i memoria"
 msgstr[1] "Ordenar %i memorias"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Ordenar %i memoria de forma ascendente"
 msgstr[1] "Ordenar %i memorias de forma ascendente"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Ordenar %i memoria de forma descendente"
 msgstr[1] "Ordenar %i memorias de forma descendente"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "Ordenar por columna:"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "Ordenar memorias"
 
@@ -2534,7 +2534,7 @@ msgstr "Estado"
 msgid "State/Province"
 msgstr "Estado/Provincia"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr "Éxito"
 
@@ -2600,7 +2600,11 @@ msgstr ""
 "recomienda que no cargues este módulo ya que podría poner un riesgo de "
 "seguridad. ¿Proceder de todos modos?"
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2616,7 +2620,7 @@ msgstr ""
 "abrir este archivo para copiar/pegar memorias a través de este, o proceder "
 "con la importación?"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "Esta memoria"
 
@@ -2649,7 +2653,7 @@ msgstr ""
 "descargues una imagen nueva de tu radio y utilizarla en adelante para la "
 "mejor seguridad y compatibilidad."
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
@@ -2657,7 +2661,7 @@ msgstr ""
 "Este es un modo de radio en vivo, lo que significa que los cambios son "
 "enviados a la radio en tiempo real cuando los haces. ¡Cargar no es necesario!"
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2710,11 +2714,11 @@ msgstr ""
 "¡También por favor envía en solicitudes de errores y mejoras!\n"
 "Has sido advertido. ¡Procede bajo tu propio riesgo!"
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "Esta memoria y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "Esta memoria y desplazar bloque hacia arriba"
 
@@ -2766,7 +2770,7 @@ msgstr "Esto va a cargar un módulo desde un problema del sitio web"
 msgid "Tone"
 msgstr "Tono"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Modo de tono"
 
@@ -2806,7 +2810,7 @@ msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 "Tono de transmisión/recepción para el modo TSQL, sino, tono de recepción"
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Paso de sintonización"
 
@@ -2822,16 +2826,16 @@ msgstr ""
 "No se puede determinar puerto para tu cable. Comprueba tus controladores y "
 "conexiones."
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr "No se puede editar memoria antes de que la radio este cargada"
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "No se puede buscar la configuración original %r"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 msgid "Unable to import while the view is sorted"
 msgstr "No se puede importar mientras la vista es ordenada"
 
@@ -2863,7 +2867,7 @@ msgstr "No se puede revelar %s en este sistema"
 msgid "Unable to set %s on this memory"
 msgstr "No se puede establecer %s en esta memoria"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 msgid "Unable to upload this file"
 msgstr "No se puede cargar este archivo"
 
@@ -2884,11 +2888,11 @@ msgstr "Modelo no soportado %r"
 msgid "Upload instructions"
 msgstr "Cargar instrucciones"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 msgid "Upload to radio"
 msgstr "Cargar a radio"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "Cargar a radio..."
 
@@ -2897,11 +2901,11 @@ msgstr "Cargar a radio..."
 msgid "Uploaded memory %s"
 msgstr "Memoria cargada %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr "Usar fuente de ancho fijo"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr "Usar fuente más grande"
 
@@ -2929,7 +2933,7 @@ msgstr "Valor debe ser exactamente %i dígitos decimales"
 msgid "Value must be zero or greater"
 msgstr "Valor debe ser cero o superior"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "Valores"
 
@@ -2937,7 +2941,7 @@ msgstr "Valores"
 msgid "Vendor"
 msgstr "Vendedor"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 msgid "View"
 msgstr "Ver"
 
@@ -2945,16 +2949,16 @@ msgstr "Ver"
 msgid "WARNING!"
 msgstr "¡ADVERTENCIA!"
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Advertencia: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr "Bienvenido"
 
@@ -2978,11 +2982,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "bytes cada"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr "habilitado"
 

--- a/chirp/locale/fr.po
+++ b/chirp/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-22 16:01-0400\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2024-05-22 16:39-0400\n"
 "Last-Translator: Alexandre J. Raymond <alexandre.j.raymond@gmail.com>\n"
 "Language-Team: French\n"
@@ -62,7 +62,7 @@ msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Mémoire et décaler le bloc vers le haut"
 msgstr[1] "%i Mémoires et décaler le bloc vers le haut"
 
-#: ../wxui/main.py:1369
+#: ../wxui/main.py:1374
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s n'a pas été enregistré. Enregistrer avant de fermer ?"
@@ -994,7 +994,7 @@ msgstr ""
 "Cela peut ne pas fonctionner si vous allumez la radio avec le câble déjà "
 "branché"
 
-#: ../wxui/main.py:1859
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -1002,11 +1002,11 @@ msgstr ""
 "Une nouvelle version de CHIRP est disponible. Visitez le site internet dès "
 "que possible pour la télécharger!"
 
-#: ../wxui/main.py:915
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "À propos"
 
-#: ../wxui/main.py:1718
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr "À propos de CHIRP"
 
@@ -1014,11 +1014,11 @@ msgstr "À propos de CHIRP"
 msgid "All"
 msgstr "Tout"
 
-#: ../wxui/main.py:1199
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Tous les fichiers"
 
-#: ../wxui/main.py:1210
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Tous les formats supportés|"
 
@@ -1034,7 +1034,7 @@ msgstr "Une erreur s'est produite"
 msgid "Applying settings"
 msgstr "Application des préférences"
 
-#: ../wxui/main.py:1465
+#: ../wxui/main.py:1470
 msgid "Automatic from system"
 msgstr "Selon le système"
 
@@ -1042,7 +1042,7 @@ msgstr "Selon le système"
 msgid "Available modules"
 msgstr "Modules disponibles"
 
-#: ../wxui/main.py:1802
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr "Plan de fréquences"
 
@@ -1050,7 +1050,7 @@ msgstr "Plan de fréquences"
 msgid "Bands"
 msgstr "Bandes"
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Banques"
 
@@ -1058,7 +1058,7 @@ msgstr "Banques"
 msgid "Bin"
 msgstr "Corbeille"
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr "Navigateur"
 
@@ -1066,7 +1066,7 @@ msgstr "Navigateur"
 msgid "Building Radio Browser"
 msgstr "Établissement navigateur radio"
 
-#: ../wxui/main.py:1494
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 "CHIRP doit être redémarré pour que la nouvelle sélection soit prise en compte"
@@ -1091,7 +1091,7 @@ msgstr ""
 "Les canaux avec TX et RX équivalents %s sont représentés par le mode de "
 "tonalité de \"%s\""
 
-#: ../wxui/main.py:1198
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Fichiers image Chirp"
 
@@ -1158,11 +1158,11 @@ msgstr "Téléchargement depuis la radio - Lire"
 msgid "Cloning to radio"
 msgstr "Téléchargement vers la radio - Écrire"
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr "Fermer"
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr "Fermer fichier"
 
@@ -1250,7 +1250,7 @@ msgstr "Décodage DTMF"
 msgid "DV Memory"
 msgstr "Mémoire DV"
 
-#: ../wxui/main.py:1732
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr "Danger"
 
@@ -1262,11 +1262,11 @@ msgstr "Dec"
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../wxui/main.py:920
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Mode développeur"
 
-#: ../wxui/main.py:1738
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
@@ -1285,7 +1285,7 @@ msgstr "Code numérique"
 msgid "Digital Modes"
 msgstr "Modes numériques"
 
-#: ../wxui/main.py:1750
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr "Désactiver le rapport d'utilisation"
 
@@ -1311,15 +1311,15 @@ msgstr "Acceptez-vous les risques?"
 msgid "Double-click to change bank name"
 msgstr "Double-cliquer pour modifier le nom de la banque"
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr "Télécharger"
 
-#: ../wxui/main.py:1001
+#: ../wxui/main.py:1006
 msgid "Download from radio"
 msgstr "Télécharger depuis la radio"
 
-#: ../wxui/main.py:827
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "Télécharger depuis la radio..."
 
@@ -1335,7 +1335,7 @@ msgstr "Pilote"
 msgid "Driver information"
 msgstr "Informations sur les pilotes"
 
-#: ../wxui/main.py:544
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr "Messages du pilote"
 
@@ -1359,7 +1359,7 @@ msgstr "Éditer les details pour %i mémoires"
 msgid "Edit details for memory %i"
 msgstr "Editer les details pour la mémoire %i"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Activer l'édition automatique"
 
@@ -1409,11 +1409,11 @@ msgstr "Pilote expérimental"
 msgid "Export can only write CSV files"
 msgstr "L'exportation ne peut écrire que des fichiers CSV"
 
-#: ../wxui/main.py:1354
+#: ../wxui/main.py:1359
 msgid "Export to CSV"
 msgstr "Exporter vers un fichier CSV"
 
-#: ../wxui/main.py:702
+#: ../wxui/main.py:707
 msgid "Export to CSV..."
 msgstr "Exporter vers un fichier CSV..."
 
@@ -1447,13 +1447,13 @@ msgstr "Échec d'analyse des résultats"
 msgid "Features"
 msgstr "Caracteristiques"
 
-#: ../wxui/main.py:549
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Fichier inexistant: %s"
 
-#: ../wxui/main.py:1202 ../wxui/main.py:1282 ../wxui/main.py:1292
-#: ../wxui/main.py:1350 ../wxui/main.py:1684 ../wxui/main.py:1685
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 msgid "Files"
 msgstr "Fichiers"
 
@@ -1467,15 +1467,15 @@ msgstr ""
 "Filtrer les résultats avec emplacement correspondant a cette chaine de "
 "caractères"
 
-#: ../wxui/main.py:1424
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr "Rechercher"
 
-#: ../wxui/main.py:770
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr "Rechercher le suivant"
 
-#: ../wxui/main.py:756
+#: ../wxui/main.py:761
 msgid "Find..."
 msgstr "Rechercher..."
 
@@ -1548,7 +1548,7 @@ msgstr ""
 #: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
 #: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1653,7 +1653,7 @@ msgstr ""
 "    pas d'audio du côté droit!\n"
 "6 - Éteignez puis rallumez votre radio pour sortir du mode de clonage\n"
 
-#: ../drivers/bf_t1.py:489 ../drivers/btech.py:694
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1790,7 +1790,7 @@ msgstr "Aller à la mémoire:"
 msgid "Goto..."
 msgstr "Aller..."
 
-#: ../wxui/main.py:966
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Aide"
 
@@ -1816,19 +1816,19 @@ msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Si sélectionné, trier les résultats selon la distance depuis ces coordonnées"
 
-#: ../wxui/main.py:1337
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Importer"
 
-#: ../wxui/main.py:696
+#: ../wxui/main.py:701
 msgid "Import from file..."
 msgstr "Importer depuis un fichier..."
 
-#: ../wxui/main.py:1341
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr "Importer les messages"
 
-#: ../wxui/main.py:1335
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr "Import non recommandé"
 
@@ -1836,7 +1836,7 @@ msgstr "Import non recommandé"
 msgid "Index"
 msgstr "Index"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr "Info"
 
@@ -1852,7 +1852,7 @@ msgstr "Insérer une ligne avant"
 msgid "Install desktop icon?"
 msgstr "Installer une icône sur le bureau?"
 
-#: ../wxui/main.py:904
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Intéragir avec le pilote"
 
@@ -1878,7 +1878,7 @@ msgstr "Code postal invalide"
 msgid "Invalid edit: %s"
 msgstr "Édition invalide: %s"
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr "Fichier module invalide ou pas supporté"
 
@@ -1891,11 +1891,11 @@ msgstr "Valeur invalide: %r"
 msgid "Issue number:"
 msgstr "Problème numero:"
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr "LIVE"
 
-#: ../wxui/main.py:813 ../wxui/main.py:1479
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 msgid "Language"
 msgstr "Changer la langue"
 
@@ -1925,11 +1925,11 @@ msgstr "Limiter les états"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Limiter les résultats à cette distance (km) depuis les coordonnées"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1567
 msgid "Live Radio"
 msgstr "Radio en direct"
 
-#: ../wxui/main.py:708
+#: ../wxui/main.py:713
 msgid "Load Module..."
 msgstr "Chargement module..."
 
@@ -1937,11 +1937,11 @@ msgstr "Chargement module..."
 msgid "Load module from issue"
 msgstr "Chargement module pour un problème"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:962
 msgid "Load module from issue..."
 msgstr "Chargement module pour un problème..."
 
-#: ../wxui/main.py:1777
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
@@ -1950,7 +1950,7 @@ msgstr ""
 "(sauf instructions contraires) de fermer tous les onglets avant de charger "
 "un module."
 
-#: ../wxui/main.py:1688
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1983,7 +1983,7 @@ msgstr "Texte logo 2 (12 caractères)"
 msgid "Longitude"
 msgstr "Longitude"
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Mémoires"
 
@@ -2017,15 +2017,15 @@ msgstr "Modèle"
 msgid "Modes"
 msgstr "Modes"
 
-#: ../wxui/main.py:1685
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr "Module"
 
-#: ../wxui/main.py:1657
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr "Module chargé"
 
-#: ../wxui/main.py:1788
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr "Module chargé avec succès"
 
@@ -2046,11 +2046,11 @@ msgstr "Monter"
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Les déplacements sont désactivés lorsque la vue est triée"
 
-#: ../wxui/main.py:654
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
-#: ../wxui/main.py:1861
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr "Nouvelle version disponible"
 
@@ -2091,7 +2091,7 @@ msgstr "Seulement certaines bandes"
 msgid "Only certain modes"
 msgstr "Seulement certains modes"
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr "Seuls les onglets des mémoires peuvent être exportés"
 
@@ -2099,35 +2099,35 @@ msgstr "Seuls les onglets des mémoires peuvent être exportés"
 msgid "Only working repeaters"
 msgstr "Uniquement les répéteurs en fonctionnement"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1337
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr "Ouvrir"
 
-#: ../wxui/main.py:683
+#: ../wxui/main.py:688
 msgid "Open Recent"
 msgstr "Ouvrir récent"
 
-#: ../wxui/main.py:665
+#: ../wxui/main.py:670
 msgid "Open Stock Config"
 msgstr "Ouvrir base de données"
 
-#: ../wxui/main.py:995 ../wxui/main.py:1213
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Ouvrir un fichier"
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr "Ouvrir un module"
 
-#: ../wxui/main.py:941
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Ouvrir le fichier de débogage"
 
-#: ../wxui/main.py:519
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr "Ouvrir dans une nouvelle fenêtre"
 
-#: ../wxui/main.py:612
+#: ../wxui/main.py:617
 msgid "Open stock config directory"
 msgstr "Ouvrir le repertoire de base de données"
 
@@ -2189,7 +2189,7 @@ msgstr "Les mémoires collées vont écraser la mémoire %s"
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La mémoire collee va écraser la mémoire %s"
 
-#: ../wxui/main.py:1865
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Soyez certain de quitter CHIRP avant d'installer la nouvelle version!"
 
@@ -2238,7 +2238,7 @@ msgstr ""
 "clonage\n"
 "    (À la fin la radio va sonner)\n"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2271,7 +2271,7 @@ msgstr "Puissance"
 msgid "Press enter to set this in memory"
 msgstr "Appuyez sur entrée pour inscrire ceci en mémoire"
 
-#: ../wxui/main.py:719
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr "Apercu avant impression"
 
@@ -2283,12 +2283,12 @@ msgstr "Impression"
 msgid "Properties"
 msgstr "Propriétés"
 
-#: ../wxui/main.py:1816
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr "Interroger %s"
 
-#: ../wxui/main.py:841
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Interroger source web"
 
@@ -2296,7 +2296,7 @@ msgstr "Interroger source web"
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Radio"
 
@@ -2350,11 +2350,11 @@ msgstr "Rafraîchissement nécessaire"
 msgid "Refreshed memory %s"
 msgstr "Mémoire %s rafraîchie"
 
-#: ../wxui/main.py:881
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Recharger pilote"
 
-#: ../wxui/main.py:890
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Recharger pilote et fichier"
 
@@ -2370,11 +2370,11 @@ msgstr ""
 "RepeaterBook est l'annuaire GRATUIT de radio amateur\n"
 "le plus complet du monde."
 
-#: ../wxui/main.py:929
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Rapport d'utilisation activé"
 
-#: ../wxui/main.py:1746
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2385,18 +2385,18 @@ msgstr ""
 "là. Nous apprécierions vraiment que vous le laissiez actif. Êtes-vous "
 "certain de vouloir désactiver le rapport d'utilisation?"
 
-#: ../wxui/main.py:1496 ../wxui/main.py:1740
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr "Redémarrage nécessaire"
 
-#: ../wxui/main.py:677
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Restaurer %i onglets"
 msgstr[1] "Restaurer %i onglets"
 
-#: ../wxui/main.py:806
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr "Restaurer les onglets au démarrage"
 
@@ -2404,15 +2404,15 @@ msgstr "Restaurer les onglets au démarrage"
 msgid "Retrieved settings"
 msgstr "Préférences récupérées"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr "Enregistrer"
 
-#: ../wxui/main.py:1371
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr "Enregistrer avant de fermer?"
 
-#: ../wxui/main.py:997 ../wxui/main.py:1296
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Enregistrer fichier"
 
@@ -2436,7 +2436,7 @@ msgstr "Brouilleur"
 msgid "Security Risk"
 msgstr "Risque de sécurité"
 
-#: ../wxui/main.py:871
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "Choix d'un plan de fréquences..."
 
@@ -2444,7 +2444,7 @@ msgstr "Choix d'un plan de fréquences..."
 msgid "Select Bands"
 msgstr "Choisir bandes"
 
-#: ../wxui/main.py:1479
+#: ../wxui/main.py:1484
 msgid "Select Language"
 msgstr "Choisir langue"
 
@@ -2452,7 +2452,7 @@ msgstr "Choisir langue"
 msgid "Select Modes"
 msgstr "Choisir modes"
 
-#: ../wxui/main.py:1801
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr "Choisir un plan de fréquences"
 
@@ -2460,7 +2460,7 @@ msgstr "Choisir un plan de fréquences"
 msgid "Service"
 msgstr "Service"
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "Préférences"
 
@@ -2472,7 +2472,7 @@ msgstr "Décalage (ou fréquence de transmission) contrôlée par duplex"
 msgid "Show Raw Memory"
 msgstr "Afficher les données de mémoires brutes"
 
-#: ../wxui/main.py:947
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Montrer l'emplacement du fichier de débogage"
 
@@ -2480,7 +2480,7 @@ msgstr "Montrer l'emplacement du fichier de débogage"
 msgid "Show extra fields"
 msgstr "Montrer les champs supplémentaires"
 
-#: ../wxui/main.py:952
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr "Montrer l'emplacement du fichier de débogage"
 
@@ -2533,7 +2533,7 @@ msgstr "État"
 msgid "State/Province"
 msgstr "État/Province"
 
-#: ../wxui/main.py:1789
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr "Réussi"
 
@@ -2601,7 +2601,11 @@ msgstr ""
 "comporter un risque de sécurité, il est recommandé de ne pas importer ce "
 "module. Importer tout de même?"
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr "Le paquet python3-suds est requis pour utiliser cette source."
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2650,7 +2654,7 @@ msgstr ""
 "est recommandé de télécharger une nouvelle image fraîche depuis la radio et "
 "de l'utiliser à l'avenir pour une meilleure sécurité et compatibilité."
 
-#: ../wxui/main.py:1559
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
@@ -2659,7 +2663,7 @@ msgstr ""
 "sont envoyés à la radio en temps réel dès qu'ils sont faits. Un "
 "téléchargement vers la radio n'est pas nécessaire!"
 
-#: ../wxui/main.py:1565
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2830,7 +2834,7 @@ msgstr ""
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Impossible d'éditer une mémoire avant téléchargement de la radio"
 
-#: ../wxui/main.py:1254
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Impossible de trouver la configuration de base %r"
@@ -2867,7 +2871,7 @@ msgstr "Impossible de montrer %s sur ce système"
 msgid "Unable to set %s on this memory"
 msgstr "Impossible de régler %s dans cette mémoire"
 
-#: ../wxui/main.py:1569
+#: ../wxui/main.py:1574
 msgid "Unable to upload this file"
 msgstr "Impossible de télécharger ce fichier"
 
@@ -2888,11 +2892,11 @@ msgstr "Modèle non supporté %r"
 msgid "Upload instructions"
 msgstr "Instruction de téléchargement"
 
-#: ../wxui/main.py:1003
+#: ../wxui/main.py:1008
 msgid "Upload to radio"
 msgstr "Télécharger vers la radio"
 
-#: ../wxui/main.py:835
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "Télécharger vers la radio..."
 
@@ -2901,11 +2905,11 @@ msgstr "Télécharger vers la radio..."
 msgid "Uploaded memory %s"
 msgstr "Memoire %s téléchargée"
 
-#: ../wxui/main.py:791
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr "Utiliser une police à largeur fixe"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr "Utiliser une plus grande police"
 
@@ -2941,7 +2945,7 @@ msgstr "Valeurs"
 msgid "Vendor"
 msgstr "Fabricant"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:969
 msgid "View"
 msgstr "Voir"
 
@@ -2949,7 +2953,7 @@ msgstr "Voir"
 msgid "WARNING!"
 msgstr "ATTENTION!"
 
-#: ../wxui/main.py:1781 ../wxui/memedit.py:1542
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr "Attention"
 
@@ -2958,7 +2962,7 @@ msgstr "Attention"
 msgid "Warning: %s"
 msgstr "Attention: %s"
 
-#: ../wxui/main.py:437
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr "Bienvenue"
 
@@ -2982,11 +2986,11 @@ msgstr "octets"
 msgid "bytes each"
 msgstr "octets chacun"
 
-#: ../wxui/main.py:1723
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr "desactivé"
 
-#: ../wxui/main.py:1723
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr "activé"
 

--- a/chirp/locale/hu.po
+++ b/chirp/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2015-01-28 13:47+0100\n"
 "Last-Translator: Attila Joubert <joubert.attila@gmail.com>\n"
 "Language-Team: English\n"
@@ -34,28 +34,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "... és a tömböt felfelé lépteti"
 msgstr[1] "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memória"
 msgstr[1] "Memória"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "... és a tömböt felfelé lépteti"
 msgstr[1] "... és a tömböt felfelé lépteti"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "A fájl megváltozott! Menti bezárás előtt?"
@@ -64,7 +64,7 @@ msgstr "A fájl megváltozott! Menti bezárás előtt?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, fuzzy, python-format
 msgid "...and %i more"
 msgstr "...és minden memória felfelé lép"
@@ -622,17 +622,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr ""
 
@@ -640,12 +640,12 @@ msgstr ""
 msgid "All"
 msgstr "Mind"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "CSV fájlok"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -661,7 +661,7 @@ msgstr "Hiba történt"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Automatic Repeater Offset"
@@ -670,7 +670,7 @@ msgstr "Automatic Repeater Offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr ""
 
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Bands"
 msgstr ""
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr ""
 
@@ -686,7 +686,7 @@ msgstr ""
 msgid "Bin"
 msgstr ""
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr "Böngésző"
 
@@ -694,7 +694,7 @@ msgstr "Böngésző"
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
@@ -708,13 +708,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -722,22 +722,22 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "RX DTCS kód"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Kereszt-üzem"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -768,25 +768,25 @@ msgstr ""
 msgid "Cloning"
 msgstr "Klónozás"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Letöltés a rádióról"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -822,7 +822,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Másolás"
 
@@ -844,7 +844,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Kivágás"
 
@@ -864,12 +864,12 @@ msgstr "DTCS pol."
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 #, fuzzy
 msgid "DV Memory"
 msgstr "ez a memória"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr ""
 
@@ -878,25 +878,25 @@ msgstr ""
 msgid "Dec"
 msgstr "Érzékelés"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Fejlesztői"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Digitális kód"
 
@@ -905,7 +905,7 @@ msgstr "Digitális kód"
 msgid "Digital Modes"
 msgstr "Digitális kód"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr ""
 
@@ -932,16 +932,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 #, fuzzy
 msgid "Download from radio"
 msgstr "Letöltés a rádióról"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Letöltés a rádióról"
@@ -959,7 +959,7 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -971,17 +971,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, fuzzy, python-format
 msgid "Edit details for %i memories"
 msgstr "Több memória szerkesztése"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -995,11 +995,11 @@ msgstr "Engedélyezve"
 msgid "Enter Frequency"
 msgstr "Frekvencia"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1031,21 +1031,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Folytassam kísérleti driver-rel?"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Export fájlba"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Export fájlba"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1072,13 +1072,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 #, fuzzy
 msgid "Files"
 msgstr "_Fájl"
@@ -1091,17 +1091,17 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 #, fuzzy
 msgid "Find Next"
 msgstr "RFinder"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 #, fuzzy
 msgid "Find..."
 msgstr "RFinder"
@@ -1149,11 +1149,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1219,7 +1219,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1246,7 +1246,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1264,11 +1264,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1309,21 +1309,21 @@ msgstr ""
 msgid "Getting settings"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "ez a memória"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 #, fuzzy
 msgid "Goto Memory:"
 msgstr "ez a memória"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Súgó"
 
@@ -1335,7 +1335,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Felülírja?"
@@ -1349,20 +1349,20 @@ msgstr ""
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Importálás"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importálás fájlból"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr ""
 
@@ -1370,16 +1370,16 @@ msgstr ""
 msgid "Index"
 msgstr "Sorszám"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 #, fuzzy
 msgid "Information"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Memória beszúrása fölé"
@@ -1388,7 +1388,7 @@ msgstr "Memória beszúrása fölé"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr "Belső hiba"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Érvénytelen érték! Egész szám kell legyen."
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Érvénytelen érték %s"
@@ -1411,12 +1411,12 @@ msgstr "Érvénytelen érték %s"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "Érvénytelen érték %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1429,11 +1429,11 @@ msgstr "Érvénytelen %s mezőérték"
 msgid "Issue number:"
 msgstr ""
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 #, fuzzy
 msgid "Language"
 msgstr "Nyelv választás"
@@ -1464,12 +1464,12 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "Rádió"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 #, fuzzy
 msgid "Load Module..."
 msgstr "Modul betöltése"
@@ -1479,18 +1479,18 @@ msgstr "Modul betöltése"
 msgid "Load module from issue"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1517,11 +1517,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Memória"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1539,7 +1539,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 #, fuzzy
 msgid "Mode"
 msgstr "Mód"
@@ -1553,17 +1553,17 @@ msgstr "Modell"
 msgid "Modes"
 msgstr "Mód"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 #, fuzzy
 msgid "Module"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1572,30 +1572,30 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Lefel_é"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Fe_lfelé"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 #, fuzzy
 msgid "New version available"
 msgstr "A CHIRP egy új verziója érhető el:"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Memória beszúrása alá"
@@ -1617,7 +1617,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr ""
 
@@ -1633,7 +1633,7 @@ msgstr ""
 msgid "Only certain modes"
 msgstr ""
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr ""
 
@@ -1641,37 +1641,37 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 #, fuzzy
 msgid "Open Recent"
 msgstr "Leg_utóbbi"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "A csoportos beállítás megnyitása"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "A(z) {name} konfigurációs készlet megnyitása"
@@ -1693,7 +1693,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Felülírja?"
@@ -1709,31 +1709,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1763,7 +1763,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1792,7 +1792,7 @@ msgstr "Teljesítmény"
 msgid "Press enter to set this in memory"
 msgstr "Memória beállítási hiba"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr ""
 
@@ -1800,16 +1800,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, fuzzy, python-format
 msgid "Query %s"
 msgstr "Lekérdezés hiba"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 #, fuzzy
 msgid "Query Source"
 msgstr "Lekérd. adatforrása"
@@ -1819,11 +1819,11 @@ msgstr "Lekérd. adatforrása"
 msgid "RX DTCS"
 msgstr "RX DTCS kód"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Rádió"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr ""
@@ -1870,11 +1870,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr "ezek a memóriák"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1888,30 +1888,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Listázás letiltva"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1919,15 +1919,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1952,7 +1952,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Oszlopok kiválasztása"
@@ -1962,7 +1962,7 @@ msgstr "Oszlopok kiválasztása"
 msgid "Select Bands"
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "Oszlopok kiválasztása"
@@ -1972,7 +1972,7 @@ msgstr "Oszlopok kiválasztása"
 msgid "Select Modes"
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1980,7 +1980,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "Beállítás"
 
@@ -1988,59 +1988,59 @@ msgstr "Beállítás"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr "Memóriasor mutatása"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "A beillesztett {number}. számú memória nem kompatibilis ezzel a rádióval, "
 "mert:"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Felülírja?"
@@ -2058,7 +2058,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr ""
 
@@ -2102,7 +2102,11 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2112,7 +2116,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "ez a memória"
@@ -2137,13 +2141,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2178,12 +2182,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "... és a tömböt felfelé lépteti"
@@ -2221,7 +2225,7 @@ msgstr ""
 msgid "Tone"
 msgstr "CTCSS"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Hang (CTCSS) mód"
 
@@ -2259,7 +2263,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Lépésköz"
@@ -2274,16 +2278,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "A csoportos beállítás megnyitása"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Nem érzékelek a {port} porton!"
@@ -2314,7 +2318,7 @@ msgstr "Ennél a modellnél nem változtatható"
 msgid "Unable to set %s on this memory"
 msgstr "Ennél a modellnél nem változtatható"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Ennél a modellnél nem változtatható"
@@ -2337,12 +2341,12 @@ msgstr "Nem támogatott fájltípus"
 msgid "Upload instructions"
 msgstr "{instructions}"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Feltöltés a rádióra"
@@ -2352,11 +2356,11 @@ msgstr "Feltöltés a rádióra"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr ""
 
@@ -2384,7 +2388,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2392,7 +2396,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Gyártó"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 #, fuzzy
 msgid "View"
 msgstr "Né_zet"
@@ -2401,16 +2405,16 @@ msgstr "Né_zet"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr ""
 
@@ -2434,12 +2438,12 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 #, fuzzy
 msgid "disabled"
 msgstr "Engedélyezve"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 #, fuzzy
 msgid "enabled"
 msgstr "Engedélyezve"

--- a/chirp/locale/it.po
+++ b/chirp/locale/it.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2024-05-18 19:22+0200\n"
 "Last-Translator: Giovanni Scafora IK5TWZ <scafora.giovanni@gmail.com>\n"
 "Language-Team: CHIRP Italian Translation\n"
@@ -43,28 +43,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s deve essere compreso tra %(min)i e %(max)i"
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i memoria e sposta tutto su"
 msgstr[1] "%i memorie e sposta tutto su"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i memoria"
 msgstr[1] "%i memorie"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i memoria e sposta il blocco su"
 msgstr[1] "%i memorie e sposta il blocco su"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s non è stato salvato. Salvarlo prima di chiudere?"
@@ -73,7 +73,7 @@ msgstr "%s non è stato salvato. Salvarlo prima di chiudere?"
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr "...ed altri %i"
@@ -1004,7 +1004,7 @@ msgstr ""
 "\n"
 "Potrebbe non funzionare, se si accende la radio con il cavo già collegato"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -1012,11 +1012,11 @@ msgstr ""
 "È disponibile una nuova versione di CHIRP. Visitare il sito web prima "
 "possibile per scaricarla!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "Informazioni"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr "Informazioni su CHIRP"
 
@@ -1024,11 +1024,11 @@ msgstr "Informazioni su CHIRP"
 msgid "All"
 msgstr "Tutto"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Tutti i file"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Tutti i formati supportati|"
 
@@ -1044,7 +1044,7 @@ msgstr "Si è verificato un errore"
 msgid "Applying settings"
 msgstr "Applicazione delle impostazioni"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 msgid "Automatic from system"
 msgstr "Automatico dal sistema"
 
@@ -1052,7 +1052,7 @@ msgstr "Automatico dal sistema"
 msgid "Available modules"
 msgstr "Moduli disponibili"
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr "Piano di banda"
 
@@ -1060,7 +1060,7 @@ msgstr "Piano di banda"
 msgid "Bands"
 msgstr "Bande"
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Banchi"
 
@@ -1068,7 +1068,7 @@ msgstr "Banchi"
 msgid "Bin"
 msgstr "Bin"
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr "Browser"
 
@@ -1076,7 +1076,7 @@ msgstr "Browser"
 msgid "Building Radio Browser"
 msgstr "Creazione del browser della radio"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr "Per rendere effettiva la nuova selezione, è necessario riavviare CHIRP"
 
@@ -1092,7 +1092,7 @@ msgstr ""
 "Per modificare questa impostazione è necessario aggiornare le impostazioni "
 "dall'immagine, cosa che avverrà ora."
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
@@ -1100,7 +1100,7 @@ msgstr ""
 "I canali con TX e RX equivalenti %s sono rappresentati dalla modalità di "
 "tono \"%s\"."
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "File immagine di Chirp"
 
@@ -1108,21 +1108,21 @@ msgstr "File immagine di Chirp"
 msgid "Choice Required"
 msgstr "Scelta richiesta"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Scegliere il codice DTCS %s"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Scegliere il Tono %s"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "Scegliere la modalità Cross"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr "Scegliere il duplex"
 
@@ -1159,23 +1159,23 @@ msgstr "Clonazione completata, controllo dei byte spuri"
 msgid "Cloning"
 msgstr "Clonazione"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 msgid "Cloning from radio"
 msgstr "Clonazione dalla radio"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 msgid "Cloning to radio"
 msgstr "Clonazione verso la radio"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr "Chiudi"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr "Chiudi il file"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1215,7 +1215,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Converti in FM"
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Copia"
 
@@ -1236,7 +1236,7 @@ msgstr "Porta personalizzata"
 msgid "Custom..."
 msgstr "Personalizza..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Taglia"
 
@@ -1256,11 +1256,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Decodifica DTMF"
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "Memoria DV"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr "Pericolo in vista"
 
@@ -1268,26 +1268,26 @@ msgstr "Pericolo in vista"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Elimina"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Modalità sviluppatore"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Lo stato dello sviluppatore è ora impostato su %s. Per avere effetto, CHIRP "
 "deve essere riavviato"
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr "Diff memorie raw"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Codice digitale"
 
@@ -1295,7 +1295,7 @@ msgstr "Codice digitale"
 msgid "Digital Modes"
 msgstr "Modi digitali"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr "Disabilita notifiche"
 
@@ -1321,15 +1321,15 @@ msgstr "Accetti il rischio?"
 msgid "Double-click to change bank name"
 msgstr "Fare doppio clic per modificare il nome del banco"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr "Scarica"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 msgid "Download from radio"
 msgstr "Scarica dalla radio"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "Scarica dalla radio..."
 
@@ -1345,7 +1345,7 @@ msgstr "Driver"
 msgid "Driver information"
 msgstr "Informazioni sul driver"
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr "Messaggi del driver"
 
@@ -1359,17 +1359,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Modifica dettagli per %i memorie"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Modifica dettagli per la memoria %i"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Abilita modifiche automatiche"
 
@@ -1381,11 +1381,11 @@ msgstr "Abilitato"
 msgid "Enter Frequency"
 msgstr "Inserire la frequenza"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr "Inserire l'offset (MHz)"
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "Inserire la frequenza TX (MHz)"
 
@@ -1415,19 +1415,19 @@ msgstr "Errore durante la comunicazione con la radio"
 msgid "Experimental driver"
 msgstr "Driver sperimentale"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "L'esportazione può scrivere solo file CSV"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 msgid "Export to CSV"
 msgstr "Esporta in CSV"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 msgid "Export to CSV..."
 msgstr "Esporta in CSV..."
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Extra"
 
@@ -1457,13 +1457,13 @@ msgstr "Impossibile elaborare il risultato"
 msgid "Features"
 msgstr "Funzionalità"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Il file non esiste: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 msgid "Files"
 msgstr "File"
 
@@ -1475,15 +1475,15 @@ msgstr "Filtro"
 msgid "Filter results with location matching this string"
 msgstr "Filtra i risultati con i luoghi che corrispondono a questa stringa"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr "Trova"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr "Trova successivo"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 msgid "Find..."
 msgstr "Trova..."
 
@@ -1553,11 +1553,11 @@ msgstr ""
 "sarà\n"
 "    l'audio del lato destro!\n"
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1661,7 +1661,7 @@ msgstr ""
 "    l'audio del lato destro!\n"
 "6 - Accendere la radio per uscire dalla modalità clone.\n"
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1703,7 +1703,7 @@ msgstr ""
 "3 - Accendere la radio\n"
 "4 - Fare clic su OK per iniziare\n"
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1731,11 +1731,11 @@ msgstr ""
 "3 - Accendere la radio\n"
 "4 - Effettuare il download dei dati dalla radio\n"
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1785,19 +1785,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Acquisire le impostazioni"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Vai alla memoria"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Vai alla memoria:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "Vai..."
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Aiuto"
 
@@ -1809,7 +1809,7 @@ msgstr "Aiutami..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "Nascondi memorie vuote"
 
@@ -1823,19 +1823,19 @@ msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Se impostata, ordina i risultati secondo la distanza da tali coordinate"
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Importa"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 msgid "Import from file..."
 msgstr "Importa da file..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr "Importa messaggi"
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr "Importazione non consigliata"
 
@@ -1843,15 +1843,15 @@ msgstr "Importazione non consigliata"
 msgid "Index"
 msgstr "Indice"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr "Informazioni"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Informazioni"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Inserisci riga sopra"
 
@@ -1859,7 +1859,7 @@ msgstr "Inserisci riga sopra"
 msgid "Install desktop icon?"
 msgstr "Installare l'icona sul desktop?"
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Interagire con il driver"
 
@@ -1872,7 +1872,7 @@ msgstr "Errore interno del driver"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Il valore %(value)s non è valido (usare i gradi decimali)"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 msgid "Invalid Entry"
 msgstr "Valore non valido"
 
@@ -1880,12 +1880,12 @@ msgstr "Valore non valido"
 msgid "Invalid ZIP code"
 msgstr "Codice postale non valido"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Modifica non valida: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr "File del modulo non valido o non supportato"
 
@@ -1898,11 +1898,11 @@ msgstr "Valore non valido: %r"
 msgid "Issue number:"
 msgstr "Numero del problema:"
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr "In diretta live"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 msgid "Language"
 msgstr "Lingua"
 
@@ -1932,11 +1932,11 @@ msgstr "Limita stato"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Limita i risultati a questa distanza (km) dalle coordinate"
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 msgid "Live Radio"
 msgstr "Radio in diretta live"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 msgid "Load Module..."
 msgstr "Carica modulo..."
 
@@ -1944,11 +1944,11 @@ msgstr "Carica modulo..."
 msgid "Load module from issue"
 msgstr "Carica modulo dal problema"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 msgid "Load module from issue..."
 msgstr "Carica modulo dal problema..."
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
@@ -1957,7 +1957,7 @@ msgstr ""
 "(salvo istruzioni diverse) di chiudere tutte le schede, prima di caricare un "
 "modulo."
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1990,11 +1990,11 @@ msgstr "Stringa del logo 2 (12 caratteri)"
 msgid "Longitude"
 msgstr "Longitudine"
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Memorie"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoria %i non è eliminabile"
@@ -2012,7 +2012,7 @@ msgstr "La memoria deve trovarsi in un banco per essere modificata"
 msgid "Memory {num} not in bank {bank}"
 msgstr "La memoria {num} non è presente nel banco {bank}"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 msgid "Mode"
 msgstr "Modalità"
 
@@ -2024,15 +2024,15 @@ msgstr "Modello"
 msgid "Modes"
 msgstr "Modalità"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr "Modulo"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr "Modulo caricato"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr "Modulo caricato con successo"
 
@@ -2041,29 +2041,29 @@ msgstr "Modulo caricato con successo"
 msgid "More than one port found: %s"
 msgstr "Trovata più di una porta: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "Sposta giù"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "Sposta su"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 "Le operazioni di spostamento sono disabilitate quando la visualizzazione è "
 "ordinata"
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr "Nuova finestra"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr "Nuova versione disponibile"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "Nessuna riga vuota in basso!"
 
@@ -2084,7 +2084,7 @@ msgstr "Nessun risultato"
 msgid "No results!"
 msgstr "Nessun risultato!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr "Numero"
 
@@ -2100,7 +2100,7 @@ msgstr "Solo alcune bande"
 msgid "Only certain modes"
 msgstr "Solo alcune modalità"
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr "È possibile esportare solo le schede di memoria"
 
@@ -2108,35 +2108,35 @@ msgstr "È possibile esportare solo le schede di memoria"
 msgid "Only working repeaters"
 msgstr "Solo ripetitori funzionanti"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr "Apri"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 msgid "Open Recent"
 msgstr "Apri recente"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 msgid "Open Stock Config"
 msgstr "Apri configurazione standard"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Apri un file"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr "Apri un modulo"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Apri il registro di debug"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr "Apri in nuova finestra"
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 msgid "Open stock config directory"
 msgstr "Apri la directory delle configurazioni standard"
 
@@ -2156,7 +2156,7 @@ msgstr "Opzionale: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opzionale: contea, ospedale, ecc."
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "Sovrascrivere le memorie?"
 
@@ -2174,31 +2174,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Elaborazione"
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Incolla"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Le memorie incollate sovrascriveranno %s memorie esistenti"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Le memorie incollate sovrascriveranno le memorie %s"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Le memorie incollate sovrascriveranno la memoria %s"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria incollata sovrascriverà la memoria %s"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Chiudere CHIRP prima di installare la nuova versione!"
 
@@ -2247,7 +2247,7 @@ msgstr ""
 "clonazione.\n"
 "    (Al termine, la radio emetterà un segnale acustico)\n"
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2280,7 +2280,7 @@ msgstr "Potenza"
 msgid "Press enter to set this in memory"
 msgstr "Premere invio per impostarlo in memoria"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr "Anteprima di stampa"
 
@@ -2288,16 +2288,16 @@ msgstr "Anteprima di stampa"
 msgid "Printing"
 msgstr "Stampa in corso"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Proprietà"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr "Interroga %s"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Interroga fonte"
 
@@ -2305,11 +2305,11 @@ msgstr "Interroga fonte"
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Radio"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr "La radio non ha accettato il blocco %i"
@@ -2361,11 +2361,11 @@ msgstr "Aggiornamento necessario"
 msgid "Refreshed memory %s"
 msgstr "Memoria aggiornata %s"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Ricarica il driver"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Ricarica il driver e il file"
 
@@ -2381,11 +2381,11 @@ msgstr ""
 "RepeaterBook è l'elenco mondiale e GRATUITO\n"
 "più completo di ripetitori per radioamatori."
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Reporting abilitato"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2395,18 +2395,18 @@ msgstr ""
 "e piattaforme OS spendere i nostri limitati sforzi. Vi saremmo grati se le "
 "lasciaste abilitate. Vuoi davvero disabilitare le segnalazioni?"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr "Riavvio richiesto"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Ripristina %i scheda"
 msgstr[1] "Ripristina %i schede"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr "Ripristina schede all'avvio"
 
@@ -2414,15 +2414,15 @@ msgstr "Ripristina schede all'avvio"
 msgid "Retrieved settings"
 msgstr "Impostazioni recuperate"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr "Salva"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr "Salvare prima di chiudere?"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Salva file"
 
@@ -2446,7 +2446,7 @@ msgstr "Scrambler"
 msgid "Security Risk"
 msgstr "Rischio di sicurezza"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "Seleziona il piano di banda..."
 
@@ -2454,7 +2454,7 @@ msgstr "Seleziona il piano di banda..."
 msgid "Select Bands"
 msgstr "Seleziona le bande"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 msgid "Select Language"
 msgstr "Seleziona la lingua"
 
@@ -2462,7 +2462,7 @@ msgstr "Seleziona la lingua"
 msgid "Select Modes"
 msgstr "Seleziona le modalità"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr "Seleziona un piano di banda"
 
@@ -2470,7 +2470,7 @@ msgstr "Seleziona un piano di banda"
 msgid "Service"
 msgstr "Servizio"
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "Impostazioni"
 
@@ -2478,56 +2478,56 @@ msgstr "Impostazioni"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Shift (o frequenza di trasmissione) controllato dal duplex"
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr "Mostra memoria raw"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Mostra posizione del log di debug"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "Mostra campi aggiuntivi"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr "Mostra la posizione del backup dell'immagine"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Alcune memorie sono incompatibili con questa radio"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Alcune memorie non sono eliminabili"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Ordina %i memoria"
 msgstr[1] "Ordina %i memorie"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "%i memoria in ordine crescente"
 msgstr[1] "%i memorie in ordine crescente"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "%i memoria in ordine decrescente"
 msgstr[1] "%i memorie in ordine decrescente"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "Ordina per colonna:"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "Ordina memorie"
 
@@ -2543,7 +2543,7 @@ msgstr "Stato"
 msgid "State/Province"
 msgstr "Stato/Provincia"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr "Successo"
 
@@ -2608,7 +2608,11 @@ msgstr ""
 "raccomanda di non caricare questo modulo, perché potrebbe rappresentare un "
 "rischio per la sicurezza. Procedere comunque?"
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2624,7 +2628,7 @@ msgstr ""
 "in %(file)s. Si desidera aprire il file per copiare/incollare le memorie o "
 "procedere con l'importazione?"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "Questa memoria"
 
@@ -2657,7 +2661,7 @@ msgstr ""
 "scaricare una nuova immagine dalla radio e di utilizzarla in futuro, per "
 "garantire la massima sicurezza e compatibilità."
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
@@ -2666,7 +2670,7 @@ msgstr ""
 "vengono inviate alla radio in tempo reale mentre vengono apportate. Il "
 "caricamento non è necessario!"
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2720,11 +2724,11 @@ msgstr ""
 "Si prega, inoltre, di inviare richieste di bug e miglioramenti!\n"
 "Siete stati avvertiti. Procedete a vostro rischio e pericolo!"
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "Questa memoria e sposta tutto in alto"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "Questa memoria e sposta il blocco in alto"
 
@@ -2776,7 +2780,7 @@ msgstr "Caricherà un modulo da un sito web"
 msgid "Tone"
 msgstr "Tono"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Modalità tono"
 
@@ -2817,7 +2821,7 @@ msgstr ""
 "Tono di trasmissione/ricezione per la modalità TSQL, altrimenti tono di "
 "ricezione"
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Passo della sintonia"
 
@@ -2833,16 +2837,16 @@ msgstr ""
 "Impossibile determinare la porta per il cavo. Controllare i driver e i "
 "collegamenti."
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Impossibile modificare la memoria prima di averla caricata dalla radio"
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Impossibile trovare la configurazione standard %r"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 msgid "Unable to import while the view is sorted"
 msgstr "Impossibile importare mentre la visualizzazione è ordinata"
 
@@ -2874,7 +2878,7 @@ msgstr "Impossibile rivelare %s su questo sistema"
 msgid "Unable to set %s on this memory"
 msgstr "Impossibile impostare %s su questa memoria"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 msgid "Unable to upload this file"
 msgstr "Impossibile caricare questo file"
 
@@ -2895,11 +2899,11 @@ msgstr "Modello non supportato %r"
 msgid "Upload instructions"
 msgstr "Istruzioni per il caricamento"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 msgid "Upload to radio"
 msgstr "Carica sulla radio"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "Carica sulla radio..."
 
@@ -2908,11 +2912,11 @@ msgstr "Carica sulla radio..."
 msgid "Uploaded memory %s"
 msgstr "Memoria caricata %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr "Usa carattere a larghezza fissa"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr "Usa carattere più grande"
 
@@ -2940,7 +2944,7 @@ msgstr "Il valore deve essere di esattamente %i cifre decimali"
 msgid "Value must be zero or greater"
 msgstr "Il valore deve essere maggiore o uguale a zero"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "Valori"
 
@@ -2948,7 +2952,7 @@ msgstr "Valori"
 msgid "Vendor"
 msgstr "Produttore"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 msgid "View"
 msgstr "Visualizza"
 
@@ -2956,16 +2960,16 @@ msgstr "Visualizza"
 msgid "WARNING!"
 msgstr "ATTENZIONE!"
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr "Attenzione"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Attenzione: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr "Benvenuto"
 
@@ -2989,11 +2993,11 @@ msgstr "byte"
 msgid "bytes each"
 msgstr "byte ciascuno"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr "disabilitato"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr "abilitato"
 

--- a/chirp/locale/ja_JP.po
+++ b/chirp/locale/ja_JP.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2023-12-03 11:04+0900\n"
 "Last-Translator: weboo <weboo@users.noreply.github.com>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i 件削除して全体を上方向にシフト"
 msgstr[1] "%i 件削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i 件の内容を削除"
 msgstr[1] "%i 件の内容を削除"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i 件削除してグループを上方向にシフト"
 msgstr[1] "%i 件削除してグループを上方向にシフト"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s は保存されていません。保存しますか？"
@@ -63,7 +63,7 @@ msgstr "%s は保存されていません。保存しますか？"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -633,7 +633,7 @@ msgstr ""
 "\n"
 "ケーブルを接続した状態で電源オンにするとうまく動かない場合があります。"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -641,11 +641,11 @@ msgstr ""
 "新しいバージョンのCHIRPが利用可能です。できるだけ早く更新されることをお勧めし"
 "ます。今すぐ更新しますか？"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "このアプリについて"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr "CHIRP について"
 
@@ -653,11 +653,11 @@ msgstr "CHIRP について"
 msgid "All"
 msgstr "すべて"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr ""
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 msgid "Automatic from system"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr "バンドプラン"
 
@@ -689,7 +689,7 @@ msgstr "バンドプラン"
 msgid "Bands"
 msgstr "バンド"
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "バンク"
 
@@ -697,7 +697,7 @@ msgstr "バンク"
 msgid "Bin"
 msgstr ""
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr ""
 
@@ -705,7 +705,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
@@ -719,13 +719,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -733,21 +733,21 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -778,23 +778,23 @@ msgstr ""
 msgid "Cloning"
 msgstr ""
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 msgid "Cloning from radio"
 msgstr ""
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 msgid "Cloning to radio"
 msgstr ""
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr "閉じる"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr "ファイルを閉じる"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -829,7 +829,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "コピー"
 
@@ -851,7 +851,7 @@ msgstr "ポートを手動で設定"
 msgid "Custom..."
 msgstr "カスタム..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "切り取り"
 
@@ -869,11 +869,11 @@ msgstr "DTCS極性"
 msgid "DTMF decode"
 msgstr "DTMF デコード"
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr ""
 
@@ -881,24 +881,24 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "削除"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "開発者モード"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr ""
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Digital Modes"
 msgstr ""
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr "診断レポート送信を停止"
 
@@ -932,15 +932,15 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr "ダウンロード"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 msgid "Download from radio"
 msgstr "無線機からダウンロード"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "無線機からダウンロード..."
 
@@ -956,7 +956,7 @@ msgstr ""
 msgid "Driver information"
 msgstr "ドライバー情報"
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -968,17 +968,17 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "値を自動設定"
 
@@ -990,11 +990,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "周波数を入力"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1024,19 +1024,19 @@ msgstr "無線機との通信エラー"
 msgid "Experimental driver"
 msgstr "実験的ドライバー"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 msgid "Export to CSV"
 msgstr "CSVにエクスポート"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 msgid "Export to CSV..."
 msgstr "CSVにエクスポート..."
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1063,13 +1063,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 msgid "Files"
 msgstr ""
 
@@ -1081,15 +1081,15 @@ msgstr "フィルター"
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr "検索"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr "次を検索"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 msgid "Find..."
 msgstr "検索..."
 
@@ -1136,11 +1136,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1206,7 +1206,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1233,7 +1233,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1251,11 +1251,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1295,19 +1295,19 @@ msgstr ""
 msgid "Getting settings"
 msgstr "設定を取得しています"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "行移動"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "指定した行に移動:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "行移動..."
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "ヘルプ"
 
@@ -1319,7 +1319,7 @@ msgstr "ポートが不明の場合..."
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "空のメモリーを非表示"
 
@@ -1332,19 +1332,19 @@ msgstr ""
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "インポート"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 msgid "Import from file..."
 msgstr "ファイルからインポート..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr "インポートは推奨されません"
 
@@ -1352,15 +1352,15 @@ msgstr "インポートは推奨されません"
 msgid "Index"
 msgstr ""
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "上に1行追加"
 
@@ -1368,7 +1368,7 @@ msgstr "上に1行追加"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1381,7 +1381,7 @@ msgstr "内部ドライバーエラー"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1389,12 +1389,12 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1407,11 +1407,11 @@ msgstr ""
 msgid "Issue number:"
 msgstr ""
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 msgid "Language"
 msgstr ""
 
@@ -1441,12 +1441,12 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "FMラジオ"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 msgid "Load Module..."
 msgstr ""
 
@@ -1454,17 +1454,17 @@ msgstr ""
 msgid "Load module from issue"
 msgstr ""
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1491,11 +1491,11 @@ msgstr "起動メッセージ２（半角12文字）"
 msgid "Longitude"
 msgstr "軽度"
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "メモリー"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "メモリー %i は削除できません"
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 msgid "Mode"
 msgstr "受信モード"
 
@@ -1525,15 +1525,15 @@ msgstr "モデル"
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1542,27 +1542,27 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr "2つ以上のポートが見つかりました: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "下に移動"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "上に移動"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr "新規ウィンドウ"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr "新しいバージョンが利用可能です"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "空の行が見つかりません"
 
@@ -1583,7 +1583,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr "行"
 
@@ -1599,7 +1599,7 @@ msgstr ""
 msgid "Only certain modes"
 msgstr ""
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr "メモリータブのみエクスポートできます"
 
@@ -1607,35 +1607,35 @@ msgstr "メモリータブのみエクスポートできます"
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr "開く"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 msgid "Open Recent"
 msgstr "最近使ったファイル"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 msgid "Open Stock Config"
 msgstr "テンプレートを開く"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "ファイルを開く"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr "新しいウィンドウで開く"
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 msgid "Open stock config directory"
 msgstr "テンプレートディレクトリを開く"
 
@@ -1655,7 +1655,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "メモリーを上書きしますか？"
 
@@ -1670,31 +1670,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "ペースト"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "ペーストすると %s 件のメモリーが上書きされます"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "新しいバージョンをインストールする前に必ずCHIRPを終了してください。"
 
@@ -1724,7 +1724,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1752,7 +1752,7 @@ msgstr "出力"
 msgid "Press enter to set this in memory"
 msgstr ""
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr "印刷プレビュー"
 
@@ -1760,16 +1760,16 @@ msgstr "印刷プレビュー"
 msgid "Printing"
 msgstr "印刷"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "プロパティ"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr ""
 
@@ -1777,11 +1777,11 @@ msgstr ""
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "無線機"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr ""
@@ -1826,11 +1826,11 @@ msgstr "更新が必要です"
 msgid "Refreshed memory %s"
 msgstr "%s 件のメモリーを取得しました"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1844,11 +1844,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "診断レポート送信"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -1858,18 +1858,18 @@ msgstr ""
 "かを判断するのに役立ちます。このまま有効にしておいていただけると有り難いで"
 "す。本当に無効にしますか？"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr "再起動が必要です"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "最近閉じた%i個のタブを開く"
 msgstr[1] "最近閉じた%i個のタブを開く"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr "起動時にタブを復元"
 
@@ -1877,15 +1877,15 @@ msgstr "起動時にタブを復元"
 msgid "Retrieved settings"
 msgstr "設定を取得しました"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr "保存"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr "保存しますか？"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "ファイルに保存"
 
@@ -1909,7 +1909,7 @@ msgstr "スクランブル"
 msgid "Security Risk"
 msgstr "セキュリティリスク"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "バンドプランを選択..."
 
@@ -1917,7 +1917,7 @@ msgstr "バンドプランを選択..."
 msgid "Select Bands"
 msgstr ""
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "バンドプラン選択"
@@ -1926,7 +1926,7 @@ msgstr "バンドプラン選択"
 msgid "Select Modes"
 msgstr ""
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr "バンドプラン選択"
 
@@ -1934,7 +1934,7 @@ msgstr "バンドプラン選択"
 msgid "Service"
 msgstr "サービス"
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "設定"
 
@@ -1942,56 +1942,56 @@ msgstr "設定"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr ""
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "追加フィールドを表示"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr "イメージのバックアップを表示"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "並び替え（%i 件）"
 msgstr[1] "並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "昇順に並び替え（%i 件）"
 msgstr[1] "昇順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "降順に並び替え（%i 件）"
 msgstr[1] "降順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "カラムを選択"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "並び替え"
 
@@ -2007,7 +2007,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr "成功"
 
@@ -2051,7 +2051,11 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2066,7 +2070,7 @@ msgstr ""
 "に置き換えます。このファイルを開いて「メモリ」をコピー＆ペーストしますか？そ"
 "れともインポートを続けますか？"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "この行の内容を削除"
 
@@ -2093,13 +2097,13 @@ msgstr ""
 "タムバージョンのCHIRPで作成された可能性があります。データ保全と互換性のために"
 "新たに無線機からダウンロードし直すことをお勧めします。"
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2142,11 +2146,11 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "この行を削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "この行を削除してグループを上方向にシフト"
 
@@ -2183,7 +2187,7 @@ msgstr ""
 msgid "Tone"
 msgstr "トーン(Hz)"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "トーンモード"
 
@@ -2220,7 +2224,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "ステップ(kHz)"
 
@@ -2236,16 +2240,16 @@ msgstr ""
 "ポートを検出できませんでした。ドライバーがインストールされているかと接続状態"
 "をもう一度確認してください。"
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 msgid "Unable to import while the view is sorted"
 msgstr ""
 
@@ -2274,7 +2278,7 @@ msgstr ""
 msgid "Unable to set %s on this memory"
 msgstr ""
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 msgid "Unable to upload this file"
 msgstr ""
 
@@ -2295,11 +2299,11 @@ msgstr ""
 msgid "Upload instructions"
 msgstr "アップロード手順"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 msgid "Upload to radio"
 msgstr "無線機にアップロード"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "無線機にアップロード..."
 
@@ -2308,11 +2312,11 @@ msgstr "無線機にアップロード..."
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr "固定幅フォントを使用"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr "大きいフォントを使用"
 
@@ -2340,7 +2344,7 @@ msgstr "値は %i 桁にしてください"
 msgid "Value must be zero or greater"
 msgstr "値は 0 以上にしてください"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "値"
 
@@ -2348,7 +2352,7 @@ msgstr "値"
 msgid "Vendor"
 msgstr "メーカー"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 msgid "View"
 msgstr "表示"
 
@@ -2356,16 +2360,16 @@ msgstr "表示"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr "ようこそ"
 
@@ -2389,11 +2393,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr "無効"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr "有効"
 

--- a/chirp/locale/nl.po
+++ b/chirp/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2012-03-18 12:01+0100\n"
 "Last-Translator: Michael Tel <m.tel@xs4all.nl>\n"
 "Language-Team: Dutch\n"
@@ -34,28 +34,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Verwijderen (en naar boven verplaatsen)"
 msgstr[1] "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Kanalen"
 msgstr[1] "Kanalen"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Verwijderen (en naar boven verplaatsen)"
 msgstr[1] "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Het bestand is aangepast. Wilt u de wijzigingen opslaan?"
@@ -64,7 +64,7 @@ msgstr "Het bestand is aangepast. Wilt u de wijzigingen opslaan?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -622,17 +622,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr ""
 
@@ -640,12 +640,12 @@ msgstr ""
 msgid "All"
 msgstr "Alles"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "Komma gescheiden bestanden"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -661,7 +661,7 @@ msgstr "Er is een fout opgetreden"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Automatische repeater offset"
@@ -670,7 +670,7 @@ msgstr "Automatische repeater offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr ""
 
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Bands"
 msgstr ""
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Banken"
 
@@ -686,7 +686,7 @@ msgstr "Banken"
 msgid "Bin"
 msgstr ""
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
@@ -708,13 +708,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -722,22 +722,22 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS code"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross-mode"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -768,25 +768,25 @@ msgstr ""
 msgid "Cloning"
 msgstr "Klonen"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Download van radio"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Naar radio uploaden"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -822,7 +822,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Kopiëren"
 
@@ -844,7 +844,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Knippen"
 
@@ -864,11 +864,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr ""
 
@@ -877,25 +877,25 @@ msgstr ""
 msgid "Dec"
 msgstr "Detecteren"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Ontwerper"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Digitale code"
 
@@ -904,7 +904,7 @@ msgstr "Digitale code"
 msgid "Digital Modes"
 msgstr "Digitale code"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr ""
 
@@ -930,16 +930,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download van radio"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download van radio"
@@ -957,7 +957,7 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -969,17 +969,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -992,11 +992,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Frequentie"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1027,21 +1027,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Exporteren naar bestand"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Exporteren naar bestand"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1068,13 +1068,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 #, fuzzy
 msgid "Files"
 msgstr "_Bestanden"
@@ -1087,15 +1087,15 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 msgid "Find..."
 msgstr ""
 
@@ -1142,11 +1142,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1212,7 +1212,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1239,7 +1239,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1257,11 +1257,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1301,20 +1301,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Toon ruw kanaal"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Help"
 
@@ -1326,7 +1326,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Overschrijven?"
@@ -1340,20 +1340,20 @@ msgstr ""
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Importeren"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importeren van bestand"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Importeren uit RFinder"
@@ -1362,15 +1362,15 @@ msgstr "Importeren uit RFinder"
 msgid "Index"
 msgstr "Index"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Regel hierboven invoegen"
@@ -1379,7 +1379,7 @@ msgstr "Regel hierboven invoegen"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1393,7 +1393,7 @@ msgstr "Interne fout"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ongeldige waarde. Het moet een integer zijn."
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ongeldige waarde voor dit veld"
@@ -1402,12 +1402,12 @@ msgstr "Ongeldige waarde voor dit veld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1420,11 +1420,11 @@ msgstr "Ongeldige waarde voor dit veld"
 msgid "Issue number:"
 msgstr ""
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 #, fuzzy
 msgid "Language"
 msgstr "Taal wijzigen"
@@ -1455,12 +1455,12 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "Radio"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 #, fuzzy
 msgid "Load Module..."
 msgstr "Toonmodus"
@@ -1470,18 +1470,18 @@ msgstr "Toonmodus"
 msgid "Load module from issue"
 msgstr "Toonmodus"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Toonmodus"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1508,11 +1508,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Kanalen"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1530,7 +1530,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1544,15 +1544,15 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Mode"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1561,29 +1561,29 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Verplaats omlaa_g"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Verplaats om_hoog"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Regel hieronder invoegen"
@@ -1605,7 +1605,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr ""
 
@@ -1621,7 +1621,7 @@ msgstr ""
 msgid "Only certain modes"
 msgstr ""
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr ""
 
@@ -1629,37 +1629,37 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Recent"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Openen aanwezige configuratie"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Openen van aanwezige configuratie {name}"
@@ -1681,7 +1681,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Overschrijven?"
@@ -1697,31 +1697,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Plakken"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1751,7 +1751,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1780,7 +1780,7 @@ msgstr "Vermogen"
 msgid "Press enter to set this in memory"
 msgstr "Fout bij het instellen van het geheugen"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr ""
 
@@ -1788,16 +1788,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr ""
 
@@ -1805,11 +1805,11 @@ msgstr ""
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Radio"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr ""
@@ -1855,11 +1855,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1874,30 +1874,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Rapportering is uitgeschakeld"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1905,15 +1905,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1937,7 +1937,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Kolommen selecteren"
@@ -1947,7 +1947,7 @@ msgstr "Kolommen selecteren"
 msgid "Select Bands"
 msgstr "Kolommen selecteren"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "Kolommen selecteren"
@@ -1957,7 +1957,7 @@ msgstr "Kolommen selecteren"
 msgid "Select Modes"
 msgstr "Kolommen selecteren"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1965,7 +1965,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr ""
 
@@ -1973,57 +1973,57 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr "Toon ruw kanaal"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Geplakt kanaal {number} is niet compatibel met deze radio omdat:"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Overschrijven?"
@@ -2040,7 +2040,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr ""
 
@@ -2084,7 +2084,11 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2094,7 +2098,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Toon ruw kanaal"
@@ -2119,13 +2123,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2160,12 +2164,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
@@ -2203,7 +2207,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Toon"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Toonmodus"
 
@@ -2241,7 +2245,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Kanaal-afstand"
@@ -2256,16 +2260,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Openen aanwezige configuratie"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Niet in staat om de radio op {port} te detecteren"
@@ -2296,7 +2300,7 @@ msgstr "Niet in staat om wijzigingen voor dit model te maken"
 msgid "Unable to set %s on this memory"
 msgstr "Niet in staat om wijzigingen voor dit model te maken"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Niet in staat om wijzigingen voor dit model te maken"
@@ -2318,12 +2322,12 @@ msgstr "Niet-ondersteunende bestandstype"
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Naar radio uploaden"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Naar radio uploaden"
@@ -2333,11 +2337,11 @@ msgstr "Naar radio uploaden"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr ""
 
@@ -2365,7 +2369,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2373,7 +2377,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Merk"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 #, fuzzy
 msgid "View"
 msgstr "Bee_ld"
@@ -2382,16 +2386,16 @@ msgstr "Bee_ld"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr ""
 
@@ -2415,11 +2419,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/pl.po
+++ b/chirp/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2023-07-12 21:21+0200\n"
 "Last-Translator: szporwolik\n"
 "Language-Team: Polish\n"
@@ -35,7 +35,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s muszą być pomiędzy %(min)i oraz %(max)i"
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -43,7 +43,7 @@ msgstr[0] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[1] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[2] "%i pamięci oraz przesuń wszystkie do góry"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -51,7 +51,7 @@ msgstr[0] "%i pamięci"
 msgstr[1] "%i pamięci"
 msgstr[2] "%i pamięci"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -59,7 +59,7 @@ msgstr[0] "%i pamięci oraz przesuń blok do góry"
 msgstr[1] "%i pamięci oraz przesuń blok do góry"
 msgstr[2] "%i pamięci oraz przesuń blok do góry"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s nie został zapisany. Zapisać przed zamknięciem?"
@@ -68,7 +68,7 @@ msgstr "%s nie został zapisany. Zapisać przed zamknięciem?"
 msgid "(none)"
 msgstr "(brak)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr "...oraz %i więcej"
@@ -638,7 +638,7 @@ msgstr ""
 "\n"
 "Obraz może nie działać, jeśli radio zostanie włączone z podłączonym kablem"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -646,11 +646,11 @@ msgstr ""
 "Nowa wersja programu CHIRP jest dostępna. Odwiedź stronę internetową "
 "projektu i pobierz ją!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "O programie"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr "O programie CHIRP"
 
@@ -658,11 +658,11 @@ msgstr "O programie CHIRP"
 msgid "All"
 msgstr "Wszystkie"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Wszystkie pliki"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Wszystkie wspierane formaty|"
 
@@ -678,7 +678,7 @@ msgstr "Wystąpił błąd"
 msgid "Applying settings"
 msgstr "Stosowanie ustawień"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Automatyczny offset repeatera"
@@ -687,7 +687,7 @@ msgstr "Automatyczny offset repeatera"
 msgid "Available modules"
 msgstr "Dostępne moduły"
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr "Bandplan"
 
@@ -695,7 +695,7 @@ msgstr "Bandplan"
 msgid "Bands"
 msgstr "Pasma"
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Banki"
 
@@ -703,7 +703,7 @@ msgstr "Banki"
 msgid "Bin"
 msgstr "Bin"
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr "Przeglądarka"
 
@@ -711,7 +711,7 @@ msgstr "Przeglądarka"
 msgid "Building Radio Browser"
 msgstr "Budowanie przeglądarki radiostacji"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 #, fuzzy
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
@@ -730,14 +730,14 @@ msgstr ""
 "Zmiana tego ustawienia wymaga odświeżenia z obrazu, co zostanie teraz "
 "wykonane."
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 "Kanały z takim samym TX oraz RX %s są reprezentowane trybem tonu \"%s\""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Pliki obrazu CHIRP"
 
@@ -745,21 +745,21 @@ msgstr "Pliki obrazu CHIRP"
 msgid "Choice Required"
 msgstr "Wymagany wybór"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Wybierz %s kod DTCS "
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Wybierz %s ton"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "Wybierz tryb krzyżowy"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr "Wybierz duplex"
 
@@ -790,23 +790,23 @@ msgstr "Klonowane zakończone, sprawdzanie niewłaściwych bajtów"
 msgid "Cloning"
 msgstr "Klonowanie"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 msgid "Cloning from radio"
 msgstr "Pobieranie z radiostacji"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 msgid "Cloning to radio"
 msgstr "Wysyłanie do radiostacji"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr "Zamknij"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr "Zamknij plik"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -842,7 +842,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Kopiuj"
 
@@ -865,7 +865,7 @@ msgstr "Wprowadź port:"
 msgid "Custom..."
 msgstr "Nietypowy..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Wytnij"
 
@@ -885,11 +885,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "Pamięć DV"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr "Niebezpieczeństwo"
 
@@ -897,26 +897,26 @@ msgstr "Niebezpieczeństwo"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Tryb dewelopera"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Tryb developera jest teraz %s. CHIRP musi zostać ponowie uruchomiony, aby "
 "zmiany przyniosły efekt"
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr "Porównaj surowe pamięci"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Kod cyfrowy"
 
@@ -925,7 +925,7 @@ msgstr "Kod cyfrowy"
 msgid "Digital Modes"
 msgstr "Kod cyfrowy"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr "Wyłącz raportowanie"
 
@@ -951,15 +951,15 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr "Kliknij podwójnie w celu zmiany nazwy banku"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr "Pobierz"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 msgid "Download from radio"
 msgstr "Pobierz z radiostacji"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Pobierz z radiostacji"
@@ -977,7 +977,7 @@ msgstr "Przeładuj sterownik"
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -989,17 +989,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Dupleks"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Zmień szczegóły dla %i pamięci"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Zmień szczególy dla pamięci %i"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Zezwól na automatyczną edycję"
 
@@ -1011,11 +1011,11 @@ msgstr "Włączony"
 msgid "Enter Frequency"
 msgstr "Wprowadź częstotliwość"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr "Wprowadź przesunięcie (MHz)"
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "Wprowadź częstotliwość nadawania (MHz)"
 
@@ -1045,20 +1045,20 @@ msgstr "Błąd komunikacji z radiostacją"
 msgid "Experimental driver"
 msgstr "Sterownik eksperymentalny"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "Eksport może tylko zapisywać pliki CSV"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 msgid "Export to CSV"
 msgstr "Eksportuj do pliku CSV"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Eksportuj do pliku CSV"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Dodatkowa"
 
@@ -1088,13 +1088,13 @@ msgstr "Parsowanie wyniku nie udało się"
 msgid "Features"
 msgstr "Funkcje"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Plik nie istnieje: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 msgid "Files"
 msgstr "Pliki"
 
@@ -1106,15 +1106,15 @@ msgstr "Filtr"
 msgid "Filter results with location matching this string"
 msgstr "Filtruj wyniki z lokalizacją pasująco do tej wartości tekstowej"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr "Wyszukaj"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr "Wyszukaj następny"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 #, fuzzy
 msgid "Find..."
 msgstr "Wyszukaj"
@@ -1162,11 +1162,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1232,7 +1232,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1259,7 +1259,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1277,11 +1277,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1321,20 +1321,20 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Pobieranie ustawień"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Idź do pamięci"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Idź do pamięci:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 #, fuzzy
 msgid "Goto..."
 msgstr "Idź do"
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Pomoc"
 
@@ -1346,7 +1346,7 @@ msgstr "Pomocy..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "Ukrywaj puste pamięci"
 
@@ -1359,20 +1359,20 @@ msgstr ""
 msgid "If set, sort results by distance from these coordinates"
 msgstr "Jeśli ustawiono, sortuje wyniki po odległości od tych współrzędnych"
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Importuj"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importuj z pliku"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr "Importuj nie jest zalecany"
 
@@ -1380,15 +1380,15 @@ msgstr "Importuj nie jest zalecany"
 msgid "Index"
 msgstr "Indeks"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Informacja"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Umieść wiersz wyżej"
 
@@ -1396,7 +1396,7 @@ msgstr "Umieść wiersz wyżej"
 msgid "Install desktop icon?"
 msgstr "Utworzyć skrót pulpitu?"
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Interakcja ze sterownikiem"
 
@@ -1410,7 +1410,7 @@ msgstr "Błąd wewnętrzny"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Niewłaściwe %(value)s (używaj stopni dziesiętnych)"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 msgid "Invalid Entry"
 msgstr "Niewłaściwy wpis: %s"
 
@@ -1418,12 +1418,12 @@ msgstr "Niewłaściwy wpis: %s"
 msgid "Invalid ZIP code"
 msgstr "Niewłaściwy kod pocztowy"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Niewłaściwa edycja: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr "Niewłaściwy lub niespierany plik modułu"
 
@@ -1436,11 +1436,11 @@ msgstr "Niewłaściwa wartość: %r"
 msgid "Issue number:"
 msgstr "Numer zgłoszenia:"
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr "Na żywo"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 msgid "Language"
 msgstr ""
 
@@ -1470,12 +1470,12 @@ msgstr "Ogranicz status"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Ogranicz wyniki do odległości (km) od współrzędnych"
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "Radiostacja"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 #, fuzzy
 msgid "Load Module..."
 msgstr "Załaduj moduł"
@@ -1484,18 +1484,18 @@ msgstr "Załaduj moduł"
 msgid "Load module from issue"
 msgstr "Załaduj moduł ze zgłoszenia"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Załaduj moduł ze zgłoszenia"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1528,11 +1528,11 @@ msgstr ""
 msgid "Longitude"
 msgstr "Długość geograficzna"
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Pamięci"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Pamięć %i jest nieusuwalna"
@@ -1550,7 +1550,7 @@ msgstr "Pamięć musi być w banku, aby można ją było edytować"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Pamięć {num} nie jest w banku {bank}"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 msgid "Mode"
 msgstr "Tryb"
 
@@ -1562,15 +1562,15 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Tryby"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr "Moduł"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr "Załadowano moduł"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr "Pomyślnie załadowano moduł"
 
@@ -1579,27 +1579,27 @@ msgstr "Pomyślnie załadowano moduł"
 msgid "More than one port found: %s"
 msgstr "Znaleziono więcej niż jeden port: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "Przesuń w dół"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "Przesuń w górę"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr "Nowe okno"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr "Nowa wersja jest dostępna"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "Brak pustych wierszy poniżej!"
 
@@ -1620,7 +1620,7 @@ msgstr "Brak wyników"
 msgid "No results!"
 msgstr "Brak wyników!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr "Numer"
 
@@ -1636,7 +1636,7 @@ msgstr "Tylko konkretne pasma"
 msgid "Only certain modes"
 msgstr "Tylko konkretne tryby"
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr "Tylko zakładki pamięci mogą być wyeksportowane"
 
@@ -1644,35 +1644,35 @@ msgstr "Tylko zakładki pamięci mogą być wyeksportowane"
 msgid "Only working repeaters"
 msgstr "Tylko czynne przemienniki"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr "Otwórz"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 msgid "Open Recent"
 msgstr "Otwórz ostatnio używany"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 msgid "Open Stock Config"
 msgstr "Otwórz konfigurację wstępną"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Otwórz plik"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr "Otwórz moduł"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Otwórz log debugowy"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr "Otwórz w nowym oknie"
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 msgid "Open stock config directory"
 msgstr "Otwórz katalog konfiguracji wstępnych"
 
@@ -1692,7 +1692,7 @@ msgstr "Opcjonalnie: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcjonalnie: Szpital, Hrabstwo itp."
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "Nadpisać pamięci?"
 
@@ -1707,31 +1707,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Parsowanie"
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Wklej"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Wklejone pamięci nadpisze %s istniejących pamięci"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Wklejone pamięci nadpisze pamięci %s"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Wklejone pamięci nadpiszą pamięć %s"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Wklejona pamięć nadpisze pamięć %s"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Proszę wyjdź z programu CHIRP przed instalacją nowej wersji!"
 
@@ -1761,7 +1761,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1793,7 +1793,7 @@ msgstr "Moc"
 msgid "Press enter to set this in memory"
 msgstr "Naciśnij przycisk enter, aby ustawić to w pamięci"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr "Podgląd wydruku"
 
@@ -1801,16 +1801,16 @@ msgstr "Podgląd wydruku"
 msgid "Printing"
 msgstr "Drukowanie"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Właściwości"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr "Odpytywanie %s"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Źródło zapytań"
 
@@ -1818,11 +1818,11 @@ msgstr "Źródło zapytań"
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Radiostacja"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr "Radiostacja nie potwierdziła (ack) bloku %i"
@@ -1870,11 +1870,11 @@ msgstr "Wymagane jest odświeżenie"
 msgid "Refreshed memory %s"
 msgstr "Odświeżono pamięć %s"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Przeładuj sterownik"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Przeładuj sterownik oraz plik"
 
@@ -1888,11 +1888,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Raportowanie jest włączone"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -1902,11 +1902,11 @@ msgstr ""
 "oraz systemów operacyjnych należy traktować priorytetowo. Naprawdę doceniamy "
 "zostawienie tej opcji włączonej. Naprawdę wyłączyć raportowanie?"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr "Wymagany jest restart"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
@@ -1914,7 +1914,7 @@ msgstr[0] "Przywrócono %i zakładek"
 msgstr[1] "Przywrócono %i zakładek"
 msgstr[2] "Przywrócono %i zakładek"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Przywrócono %i zakładek"
@@ -1923,15 +1923,15 @@ msgstr "Przywrócono %i zakładek"
 msgid "Retrieved settings"
 msgstr "Pobrano ustawienia"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr "Zapisać przed zamknięciem?"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Zapisz plik"
 
@@ -1955,7 +1955,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Wybierz bandplan"
@@ -1964,7 +1964,7 @@ msgstr "Wybierz bandplan"
 msgid "Select Bands"
 msgstr "Wybierz pasma"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "Wybierz pasma"
@@ -1973,7 +1973,7 @@ msgstr "Wybierz pasma"
 msgid "Select Modes"
 msgstr "Wybierz tryby"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr "Wybierz bandplan"
 
@@ -1981,7 +1981,7 @@ msgstr "Wybierz bandplan"
 msgid "Service"
 msgstr "Usługa"
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "Ustawienia"
 
@@ -1989,32 +1989,32 @@ msgstr "Ustawienia"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr "Pokaż surową pamięć"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Pokaż lokalizację pliku debug"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "Pokazuj dodatkowe pola"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Show image backup location"
 msgstr "Pokaż lokalizację pliku debug"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Niektóre pamięci są niekompatybilne z tą radiostacją"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Niektóre pamięci są nieusuwalne"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -2022,7 +2022,7 @@ msgstr[0] "Sortuj %i pamięci"
 msgstr[1] "Sortuj %i pamięci"
 msgstr[2] "Sortuj %i pamięci"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -2030,7 +2030,7 @@ msgstr[0] "Sortuj %i pamięci rosnąco"
 msgstr[1] "Sortuj %i pamięci rosnąco"
 msgstr[2] "Sortuj %i pamięci rosnąco"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -2038,11 +2038,11 @@ msgstr[0] "Sortuj %i pamięci malejąco"
 msgstr[1] "Sortuj %i pamięci malejąco"
 msgstr[2] "Sortuj %i pamięci malejąco"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "Sortuj wg kolumny:"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "Sortuj pamięci"
 
@@ -2058,7 +2058,7 @@ msgstr "Stan"
 msgid "State/Province"
 msgstr "Stan/Prowincja"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr "Sukces"
 
@@ -2105,7 +2105,11 @@ msgstr ""
 "stwarzać ryzyko, dlatego rekomendujemy nie ładowanie tego modułu. "
 "Kontynuować pomimo tego?"
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2120,7 +2124,7 @@ msgstr ""
 "aktualnie otwartym pliku tymi z %(file)s. Czy chcesz otworzyć ten plik, aby "
 "kopiować/wklejać pamięci lub kontynuować import?"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "Tą pamięć"
 
@@ -2144,13 +2148,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2185,11 +2189,11 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "Tą pamięć i przeusń wszystkie wyżej"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "Tą pamięć i przesuń blok wyżej"
 
@@ -2231,7 +2235,7 @@ msgstr "To załaduje moduł ze strony zgłoszenia"
 msgid "Tone"
 msgstr "Ton TX"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Tryb tonu"
 
@@ -2268,7 +2272,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Krok strojenia"
 
@@ -2283,16 +2287,16 @@ msgid ""
 msgstr ""
 "Nie można wykryć portu kabla. Należy sprawdzić sterowniki oraz połączenie."
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Przed pobraniem pamięci, nie można jej edytować"
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Nie znaleziono konfiguracji wstępnej %r"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Przed pobraniem pamięci, nie można jej edytować"
@@ -2325,7 +2329,7 @@ msgstr "Nie można odkryć %s na tym systemie"
 msgid "Unable to set %s on this memory"
 msgstr "Nie można ustawić %s na tej pamięci"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Nie można odkryć %s na tym systemie"
@@ -2347,11 +2351,11 @@ msgstr "Nieobsługiwany typ pliku"
 msgid "Upload instructions"
 msgstr "Instrukcje wysyłania"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 msgid "Upload to radio"
 msgstr "Wyślij do radiostacji"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Wyślij do radiostacji"
@@ -2361,11 +2365,11 @@ msgstr "Wyślij do radiostacji"
 msgid "Uploaded memory %s"
 msgstr "Wysłano pamięć %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr "Używaj czcionki o stałej szerokości znaków"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr "Używaj większej czcionki"
 
@@ -2393,7 +2397,7 @@ msgstr "Wartość musi mieć dokładnie %i cyfr dziesiętnych"
 msgid "Value must be zero or greater"
 msgstr "Wartość musi wynosić zero lub więcej"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "Wartości"
 
@@ -2401,7 +2405,7 @@ msgstr "Wartości"
 msgid "Vendor"
 msgstr "Producent"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 msgid "View"
 msgstr "Widok"
 
@@ -2409,16 +2413,16 @@ msgstr "Widok"
 msgid "WARNING!"
 msgstr "UWAGA!"
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr "Uwaga"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Uwaga: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr "Witamy"
 
@@ -2442,11 +2446,11 @@ msgstr "bajtów"
 msgid "bytes each"
 msgstr "bajtów każdy"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr "wyłączony"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr "włączony"
 

--- a/chirp/locale/pt_BR.po
+++ b/chirp/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2013-03-30 22:04-0300\n"
 "Last-Translator: Crezivando <crezivando@gmail.com>\n"
 "Language-Team: Language pt-BR\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Apagar (e deslocar)"
 msgstr[1] "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memórias"
 msgstr[1] "Memórias"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Apagar (e deslocar)"
 msgstr[1] "Apagar (e deslocar)"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Arquivo modificado, salvar alterações antes de fechar?"
@@ -63,7 +63,7 @@ msgstr "Arquivo modificado, salvar alterações antes de fechar?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -621,17 +621,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr ""
 
@@ -639,12 +639,12 @@ msgstr ""
 msgid "All"
 msgstr "Tudo"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "Arquivos CSV"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -660,7 +660,7 @@ msgstr "Ocorreu um erro"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Offset Automático Repetidoras"
@@ -669,7 +669,7 @@ msgstr "Offset Automático Repetidoras"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr ""
 
@@ -677,7 +677,7 @@ msgstr ""
 msgid "Bands"
 msgstr ""
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Bancos"
 
@@ -685,7 +685,7 @@ msgstr "Bancos"
 msgid "Bin"
 msgstr ""
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr ""
 
@@ -693,7 +693,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
@@ -707,13 +707,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -721,22 +721,22 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Modo Cross"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -767,25 +767,25 @@ msgstr ""
 msgid "Cloning"
 msgstr "Clonando"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Descarregar a partir do Rádio"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Carregar para o Rádio"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Copiar"
 
@@ -843,7 +843,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Cortar"
 
@@ -863,11 +863,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr ""
 
@@ -876,25 +876,25 @@ msgstr ""
 msgid "Dec"
 msgstr "Detectar"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Desenvolvedor"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Código Digital"
 
@@ -903,7 +903,7 @@ msgstr "Código Digital"
 msgid "Digital Modes"
 msgstr "Código Digital"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr ""
 
@@ -929,16 +929,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 #, fuzzy
 msgid "Download from radio"
 msgstr "Descarregar a partir do Rádio"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Descarregar a partir do Rádio"
@@ -956,7 +956,7 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -968,17 +968,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -991,11 +991,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Frequência"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1026,21 +1026,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Exportar Para Arquivo"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Exportar Para Arquivo"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1067,13 +1067,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 #, fuzzy
 msgid "Files"
 msgstr "_Arquivo"
@@ -1086,15 +1086,15 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 msgid "Find..."
 msgstr ""
 
@@ -1141,11 +1141,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1211,7 +1211,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1238,7 +1238,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1256,11 +1256,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1300,20 +1300,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Mostrar Memória Raw"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Ajuda"
 
@@ -1325,7 +1325,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Sobrescrever?"
@@ -1339,20 +1339,20 @@ msgstr ""
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Importar"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importar do Arquivo"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Importar de RFinder"
@@ -1361,15 +1361,15 @@ msgstr "Importar de RFinder"
 msgid "Index"
 msgstr "Índice"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Inserir row acima"
@@ -1378,7 +1378,7 @@ msgstr "Inserir row acima"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1392,7 +1392,7 @@ msgstr "Erro Interno"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Valor inválido. Deve ser um número inteiro."
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Valor Inválido para este campo"
@@ -1401,12 +1401,12 @@ msgstr "Valor Inválido para este campo"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1419,11 +1419,11 @@ msgstr "Valor Inválido para este campo"
 msgid "Issue number:"
 msgstr ""
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 #, fuzzy
 msgid "Language"
 msgstr "Mudar idioma"
@@ -1454,12 +1454,12 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "Rádio"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 #, fuzzy
 msgid "Load Module..."
 msgstr "Modo Tom"
@@ -1469,18 +1469,18 @@ msgstr "Modo Tom"
 msgid "Load module from issue"
 msgstr "Modo Tom"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Modo Tom"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1507,11 +1507,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Memórias"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1529,7 +1529,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 #, fuzzy
 msgid "Mode"
 msgstr "Modo"
@@ -1543,15 +1543,15 @@ msgstr "Modelo"
 msgid "Modes"
 msgstr "Modo"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1560,29 +1560,29 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Mover Abaix_o"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Mover _Acima"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Inserir row abaixo"
@@ -1604,7 +1604,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr ""
 
@@ -1620,7 +1620,7 @@ msgstr ""
 msgid "Only certain modes"
 msgstr ""
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr ""
 
@@ -1628,37 +1628,37 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Recente"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Abrir config do estoque"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Abrir configuração de estoque {name}"
@@ -1680,7 +1680,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Sobrescrever?"
@@ -1696,31 +1696,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Colar"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1750,7 +1750,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1779,7 +1779,7 @@ msgstr "Power"
 msgid "Press enter to set this in memory"
 msgstr "Erro gravando memória"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr ""
 
@@ -1787,16 +1787,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr ""
 
@@ -1804,11 +1804,11 @@ msgstr ""
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Rádio"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr ""
@@ -1854,11 +1854,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1873,30 +1873,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Emissão de Relatórios desabilitada"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1904,15 +1904,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1936,7 +1936,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Selecionar Colunas"
@@ -1946,7 +1946,7 @@ msgstr "Selecionar Colunas"
 msgid "Select Bands"
 msgstr "Selecionar Colunas"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "Selecionar Colunas"
@@ -1956,7 +1956,7 @@ msgstr "Selecionar Colunas"
 msgid "Select Modes"
 msgstr "Selecionar Colunas"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1964,7 +1964,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr ""
 
@@ -1972,57 +1972,57 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr "Mostrar Memória Raw"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Memória colada {number} não é compatível com este rádio porque:"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Sobrescrever?"
@@ -2039,7 +2039,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr ""
 
@@ -2083,7 +2083,11 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2093,7 +2097,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Mostrar Memória Raw"
@@ -2118,13 +2122,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2159,12 +2163,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Apagar (e deslocar)"
@@ -2202,7 +2206,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Tom"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Modo Tom"
 
@@ -2240,7 +2244,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Tune Step"
@@ -2255,16 +2259,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Abrir config do estoque"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Incapaz de detectar rádio na {port}"
@@ -2295,7 +2299,7 @@ msgstr "Incapaz de efetuar alterações para este modelo"
 msgid "Unable to set %s on this memory"
 msgstr "Incapaz de efetuar alterações para este modelo"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Incapaz de efetuar alterações para este modelo"
@@ -2317,12 +2321,12 @@ msgstr "Tipo de arquivo não-suportado"
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Carregar para o Rádio"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Carregar para o Rádio"
@@ -2332,11 +2336,11 @@ msgstr "Carregar para o Rádio"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr ""
 
@@ -2364,7 +2368,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2372,7 +2376,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Fornecedor"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 #, fuzzy
 msgid "View"
 msgstr "_Visualizar"
@@ -2381,16 +2385,16 @@ msgstr "_Visualizar"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr ""
 
@@ -2414,11 +2418,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/ru.po
+++ b/chirp/locale/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2023-10-11 16:47+0300\n"
 "Last-Translator: Olesya Gerasimenko <translation-team@basealt.ru>\n"
 "Language-Team: Basealt Translation Team\n"
@@ -38,7 +38,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s должно находиться в диапазоне от %(min)i до %(max)i"
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -46,7 +46,7 @@ msgstr[0] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[1] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[2] "Ячейки памяти (%i) и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -54,7 +54,7 @@ msgstr[0] "Ячейки памяти (%i)"
 msgstr[1] "Ячейки памяти (%i)"
 msgstr[2] "Ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -62,7 +62,7 @@ msgstr[0] "Ячейки памяти (%i) и сдвинуть блок ввер�
 msgstr[1] "Ячейки памяти (%i) и сдвинуть блок вверх"
 msgstr[2] "Ячейки памяти (%i) и сдвинуть блок вверх"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Сохранение %s не было выполнено. Сохранить перед закрытием?"
@@ -71,7 +71,7 @@ msgstr "Сохранение %s не было выполнено. Сохрани
 msgid "(none)"
 msgstr "(нет)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr "...и ещё %i"
@@ -967,7 +967,7 @@ msgstr ""
 "Отправка может не получиться, если вы включите станцию, когда кабель уже "
 "подключён"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -975,11 +975,11 @@ msgstr ""
 "Доступная новая версия программы CHIRP. Как можно скорее загрузите её на веб-"
 "сайте!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "О программе"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr "О программе CHIRP"
 
@@ -987,11 +987,11 @@ msgstr "О программе CHIRP"
 msgid "All"
 msgstr "Все"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Все файлы"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Все поддерживаемые форматы|"
 
@@ -1007,7 +1007,7 @@ msgstr "Ошибка"
 msgid "Applying settings"
 msgstr "Применение параметров"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Авторазнос для репитера"
@@ -1016,7 +1016,7 @@ msgstr "Авторазнос для репитера"
 msgid "Available modules"
 msgstr "Доступные модули"
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr "Частотный план"
 
@@ -1024,7 +1024,7 @@ msgstr "Частотный план"
 msgid "Bands"
 msgstr "Полосы частот"
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Банки"
 
@@ -1032,7 +1032,7 @@ msgstr "Банки"
 msgid "Bin"
 msgstr "Бинарный"
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr "Браузер"
 
@@ -1040,7 +1040,7 @@ msgstr "Браузер"
 msgid "Building Radio Browser"
 msgstr "Браузер станций"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 #, fuzzy
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
@@ -1059,13 +1059,13 @@ msgstr ""
 "Для изменения этого параметра требуется обновить параметры из образа, что и "
 "будет сейчас выполнено."
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Каналы с эквивалентными TX и RX %s представлены видом субтона «%s»."
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Файлы образов Chirp"
 
@@ -1073,21 +1073,21 @@ msgstr "Файлы образов Chirp"
 msgid "Choice Required"
 msgstr "Необходимо сделать выбор"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Выберите код DTCS %s"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Выберите тон %s"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "Выберите кросс-режим"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr "Выберите дуплекс"
 
@@ -1124,23 +1124,23 @@ msgstr "Клонирование завершено, проверка налич
 msgid "Cloning"
 msgstr "Клонирование"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 msgid "Cloning from radio"
 msgstr "Клонирование из станции"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 msgid "Cloning to radio"
 msgstr "Клонирование на станцию"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr "Закрыть"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr "Закрыть файл"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Копировать"
 
@@ -1200,7 +1200,7 @@ msgstr "Пользовательский порт"
 msgid "Custom..."
 msgstr "Пользовательский..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Вырезать"
 
@@ -1220,11 +1220,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "DV-память"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr "Впереди опасность"
 
@@ -1232,26 +1232,26 @@ msgstr "Впереди опасность"
 msgid "Dec"
 msgstr "Десятичный"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Режим разработчика"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Режим разработчика теперь %s. Для применения изменений необходимо "
 "перезапустить CHIRP"
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr "Сравнить необработанные ячейки памяти"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Цифровой код"
 
@@ -1260,7 +1260,7 @@ msgstr "Цифровой код"
 msgid "Digital Modes"
 msgstr "Цифровой код"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr "Отключить отправку отчётов"
 
@@ -1286,15 +1286,15 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr "Сделайте двойной щелчок, чтобы изменить имя банка"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr "Загрузить"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 msgid "Download from radio"
 msgstr "Загрузить из станции"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "Загрузить из станции..."
 
@@ -1311,7 +1311,7 @@ msgstr "Перезагрузить драйвер"
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -1323,17 +1323,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Редактировать сведения о ячейках памяти (%i)"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Редактировать сведения о ячейке памяти (%i)"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Включить автоматическое редактирование"
 
@@ -1345,11 +1345,11 @@ msgstr "Включено"
 msgid "Enter Frequency"
 msgstr "Введите частоту"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr "Введите смещение (МГц)"
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "Введите частоту TX (МГц)"
 
@@ -1379,19 +1379,19 @@ msgstr "Ошибка обмена данными со станцией"
 msgid "Experimental driver"
 msgstr "Экспериментальный драйвер"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "При экспорте можно выполнять запись только в файлы CSV"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 msgid "Export to CSV"
 msgstr "Экспорт в CSV"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 msgid "Export to CSV..."
 msgstr "Экспорт в CSV..."
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Дополнительно"
 
@@ -1421,13 +1421,13 @@ msgstr "Не удалось проанализировать результат"
 msgid "Features"
 msgstr "Функции"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Файл не существует: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 msgid "Files"
 msgstr "Файлы"
 
@@ -1439,15 +1439,15 @@ msgstr "Фильтр"
 msgid "Filter results with location matching this string"
 msgstr "Фильтровать результаты с расположением, соответствующим этой строке"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr "Найти"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr "Найти далее"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 msgid "Find..."
 msgstr "Найти..."
 
@@ -1517,11 +1517,11 @@ msgstr ""
 "5 - Отключите интерфейсный кабель! Иначе с правой стороны\n"
 "    не будет звука!\n"
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1627,7 +1627,7 @@ msgstr ""
 "6 - Выключите и снова включите питание станции, чтобы выйти\n"
 "    из режима клонирования\n"
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1669,7 +1669,7 @@ msgstr ""
 "3 - Включите вашу станцию\n"
 "4 - Чтобы начать, нажмите «ОК»\n"
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1697,11 +1697,11 @@ msgstr ""
 "3 - Включите вашу станцию\n"
 "4 - Выполните загрузку ваших радиоданных\n"
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1751,19 +1751,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Получение параметров"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Перейти к ячейке памяти"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Переход к ячейке памяти:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "Переход..."
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Справка"
 
@@ -1775,7 +1775,7 @@ msgstr "Помощь..."
 msgid "Hex"
 msgstr "Шестнадцатеричный"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "Скрыть пустые ячейки памяти"
 
@@ -1789,19 +1789,19 @@ msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Если установлено, упорядочить результаты по расстоянию от этих координат"
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Импорт"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 msgid "Import from file..."
 msgstr "Импорт из файла..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr "Импорт не рекомендуется"
 
@@ -1809,15 +1809,15 @@ msgstr "Импорт не рекомендуется"
 msgid "Index"
 msgstr "Индекс"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Вставить строку выше"
 
@@ -1825,7 +1825,7 @@ msgstr "Вставить строку выше"
 msgid "Install desktop icon?"
 msgstr "Создать значок на рабочем столе?"
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Обмен данными с драйвером"
 
@@ -1839,7 +1839,7 @@ msgstr "Ошибка"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s — неверно (используйте десятичные градусы)"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 msgid "Invalid Entry"
 msgstr "Некорректная запись"
 
@@ -1847,12 +1847,12 @@ msgstr "Некорректная запись"
 msgid "Invalid ZIP code"
 msgstr "Неверный почтовый индекс"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Некорректное изменение: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr "Некорректный или неподдерживаемый файл модуля"
 
@@ -1865,11 +1865,11 @@ msgstr "Неверное значение: %r"
 msgid "Issue number:"
 msgstr "Номер задачи:"
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr "В ЭФИРЕ"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 #, fuzzy
 msgid "Language"
 msgstr "Изменить язык"
@@ -1900,12 +1900,12 @@ msgstr "Ограничение состояния"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Ограничить результаты этим расстоянием (км) от координат"
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "Станция"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 msgid "Load Module..."
 msgstr "Загрузить модуль..."
 
@@ -1913,17 +1913,17 @@ msgstr "Загрузить модуль..."
 msgid "Load module from issue"
 msgstr "Загрузить модуль из задачи"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 msgid "Load module from issue..."
 msgstr "Загрузить модуль из задачи..."
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1956,11 +1956,11 @@ msgstr ""
 msgid "Longitude"
 msgstr "Долгота"
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Ячейки памяти"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Ячейку памяти %i нельзя удалить"
@@ -1978,7 +1978,7 @@ msgstr "Чтобы редактировать ячейку памяти, нео�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Ячейка памяти {num} отсутствует в банке {bank}"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 msgid "Mode"
 msgstr "Режим"
 
@@ -1990,15 +1990,15 @@ msgstr "Модель"
 msgid "Modes"
 msgstr "Режимы"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr "Модуль"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr "Модуль загружен"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr "Модуль успешно загружен"
 
@@ -2007,27 +2007,27 @@ msgstr "Модуль успешно загружен"
 msgid "More than one port found: %s"
 msgstr "Найдено более одного порта: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "Переместить вниз"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "Переместить вверх"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr "Новое окно"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr "Доступна новая версия"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "Ниже нет пустых строк!"
 
@@ -2048,7 +2048,7 @@ msgstr "Нет результатов"
 msgid "No results!"
 msgstr "Нет результатов!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr "Число"
 
@@ -2064,7 +2064,7 @@ msgstr "Только некоторые полосы частот"
 msgid "Only certain modes"
 msgstr "Только некоторые режимы"
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr "Можно экспортировать только вкладки памяти"
 
@@ -2072,35 +2072,35 @@ msgstr "Можно экспортировать только вкладки па
 msgid "Only working repeaters"
 msgstr "Только работающие репитеры"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr "Открыть"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 msgid "Open Recent"
 msgstr "Открыть недавние"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 msgid "Open Stock Config"
 msgstr "Открыть предустановленную конфигурацию"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Открыть файл"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr "Открыть модуль"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Открыть журнал отладки"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr "Открыть в новом окне"
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 msgid "Open stock config directory"
 msgstr "Открыть каталог предустановленной конфигурации"
 
@@ -2120,7 +2120,7 @@ msgstr "Опционально: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Опционально: округ, больница и т.д."
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "Перезаписать ячейки памяти?"
 
@@ -2138,31 +2138,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Анализ"
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Вставить"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Вставленные ячейки памяти перезапишут существующие ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейку памяти %s"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Вставленная ячейка памяти перезапишет ячейку памяти %s"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Обязательно выйдите из программы CHIRP перед установкой новой версии!"
 
@@ -2210,7 +2210,7 @@ msgstr ""
 "4 - Затем нажмите кнопку «A» на вашей станции для начала клонирования.\n"
 "    (По завершении станция подаст звуковой сигнал.)\n"
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2243,7 +2243,7 @@ msgstr "Мощность"
 msgid "Press enter to set this in memory"
 msgstr "Нажмите «Ввод» для добавления в память"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr "Предпросмотр"
 
@@ -2251,16 +2251,16 @@ msgstr "Предпросмотр"
 msgid "Printing"
 msgstr "Печать"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Свойства"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr "Запрос %s"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Запрос источника"
 
@@ -2268,11 +2268,11 @@ msgstr "Запрос источника"
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Станция"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr "Станция не распознала блок %i"
@@ -2320,11 +2320,11 @@ msgstr "Требуется обновление"
 msgid "Refreshed memory %s"
 msgstr "Обновлена ячейки памяти %s"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Перезагрузить драйвер"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Перезагрузить драйвер и файл"
 
@@ -2338,11 +2338,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Отправка отчётов включена"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2353,11 +2353,11 @@ msgstr ""
 "признательны, если вы оставите эту функцию включённой. Действительно "
 "отключить отправку отчётов?"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr "Требуется перезапуск"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
@@ -2365,7 +2365,7 @@ msgstr[0] "Восстановить вкладки (%i)"
 msgstr[1] "Восстановить вкладки (%i)"
 msgstr[2] "Восстановить вкладки (%i)"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Восстановить вкладки (%i)"
@@ -2374,15 +2374,15 @@ msgstr "Восстановить вкладки (%i)"
 msgid "Retrieved settings"
 msgstr "Полученные параметры"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr "Сохранить"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr "Сохранить перед закрытием?"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Сохранить файл"
 
@@ -2406,7 +2406,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr "Угроза безопасности"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "Выбрать частотный план..."
 
@@ -2414,7 +2414,7 @@ msgstr "Выбрать частотный план..."
 msgid "Select Bands"
 msgstr "Выбор полос частот"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "Выбор полос частот"
@@ -2423,7 +2423,7 @@ msgstr "Выбор полос частот"
 msgid "Select Modes"
 msgstr "Выбор режимов"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr "Выбор частотного плана"
 
@@ -2431,7 +2431,7 @@ msgstr "Выбор частотного плана"
 msgid "Service"
 msgstr "Служба"
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "Параметры"
 
@@ -2439,32 +2439,32 @@ msgstr "Параметры"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr "Показать необработанную ячейку памяти"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Показать расположение журнала отладки"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "Показать дополнительные поля"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Show image backup location"
 msgstr "Показать расположение журнала отладки"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Некоторые ячейки памяти несовместимы с этой станцией"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Некоторые ячейки памяти нельзя удалить"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -2472,7 +2472,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i)"
 msgstr[1] "Упорядочить ячейки памяти (%i)"
 msgstr[2] "Упорядочить ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -2480,7 +2480,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по возра
 msgstr[1] "Упорядочить ячейки памяти (%i) по возрастанию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по возрастанию"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -2488,11 +2488,11 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по убыва
 msgstr[1] "Упорядочить ячейки памяти (%i) по убыванию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по убыванию"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "Сортировать по столбцу:"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "Упорядочить ячейки памяти"
 
@@ -2508,7 +2508,7 @@ msgstr "Область"
 msgid "State/Province"
 msgstr "Область/регион"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr "Успешно"
 
@@ -2571,7 +2571,11 @@ msgstr ""
 "загружать этот модуль, так как возможна угроза безопасности. Всё равно "
 "продолжить?"
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2586,7 +2590,7 @@ msgstr ""
 "текущем открытом файле на ячейки из %(file)s. Открыть этот файл для "
 "копирования/вставки ячеек памяти или продолжить импорт?"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "Эта ячейка памяти"
 
@@ -2613,13 +2617,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2658,11 +2662,11 @@ msgstr ""
 "Также присылайте отчёты об ошибках и предложения по улучшению.\n"
 "Вы были предупреждены; продолжайте на свой страх и риск!"
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "Эта ячейка памяти и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "Эта ячейка памяти и сдвинуть блок вверх"
 
@@ -2709,7 +2713,7 @@ msgstr "Будет выполнена загрузка модуля из зад�
 msgid "Tone"
 msgstr "ТонПРД"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Вид субтона"
 
@@ -2746,7 +2750,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Шаг настройки"
 
@@ -2762,16 +2766,16 @@ msgstr ""
 "Не удалось определить порт для вашего кабеля. Проверьте драйверы и "
 "подключения."
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Перед редактированием ячейки памяти необходимо загрузить станцию"
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Не удалось найти предустановленную конфигурацию %r"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Перед редактированием ячейки памяти необходимо загрузить станцию"
@@ -2804,7 +2808,7 @@ msgstr "Невозможно обнаружить %s в этой системе"
 msgid "Unable to set %s on this memory"
 msgstr "Невозможно установить %s для этой ячейки памяти"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Невозможно обнаружить %s в этой системе"
@@ -2826,11 +2830,11 @@ msgstr "Неподдерживаемый тип файла"
 msgid "Upload instructions"
 msgstr "Отправка инструкций"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 msgid "Upload to radio"
 msgstr "Отправка на станцию"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "Отправка на станцию..."
 
@@ -2839,11 +2843,11 @@ msgstr "Отправка на станцию..."
 msgid "Uploaded memory %s"
 msgstr "Отправлена ячейка памяти %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr "Использовать моноширинный шрифт"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr "Использовать более крупный шрифт"
 
@@ -2871,7 +2875,7 @@ msgstr "Значение должно содержать десятичные ц
 msgid "Value must be zero or greater"
 msgstr "Значение должно быть больше или равно нулю"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "Значения"
 
@@ -2879,7 +2883,7 @@ msgstr "Значения"
 msgid "Vendor"
 msgstr "Изготовитель"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 msgid "View"
 msgstr "Вид"
 
@@ -2887,16 +2891,16 @@ msgstr "Вид"
 msgid "WARNING!"
 msgstr "ПРЕДУПРЕЖДЕНИЕ!"
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Предупреждение: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr "Добро пожаловать"
 
@@ -2920,11 +2924,11 @@ msgstr "байт"
 msgid "bytes each"
 msgstr "байт каждый"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr "отключён"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr "включён"
 

--- a/chirp/locale/tr_TR.po
+++ b/chirp/locale/tr_TR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2024-03-02 00:22+0300\n"
 "Last-Translator: Abdullah YILMAZ (TA1AUB) <h.abdullahyilmaz@hotmail.com>\n"
 "Language-Team: TURKISH\n"
@@ -42,28 +42,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s, %(min)i ile %(max)i arasında olmalıdır"
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Kaydı ve hepsini yukarı kaydır"
 msgstr[1] "%i Kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Kaydı"
 msgstr[1] "%i Kaydı"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Kaydı ve bloğu yukarı kaydır"
 msgstr[1] "%i Kaydı ve bloğu yukarı kaydır"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s kaydedilmedi. Kapanmadan önce kaydedilsin mi?"
@@ -72,7 +72,7 @@ msgstr "%s kaydedilmedi. Kapanmadan önce kaydedilsin mi?"
 msgid "(none)"
 msgstr "(hiçbiri)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr "...ve %i daha"
@@ -963,7 +963,7 @@ msgstr ""
 "\n"
 "Kablo takılıyken telsizi açarsanız çalışmayabilir"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -971,11 +971,11 @@ msgstr ""
 "Yeni bir CHIRP sürümü mevcut. İndirmek için lütfen en kısa zamanda web "
 "sitesini ziyaret edin!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr "Hakkında"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr "CHIRP Hakkında"
 
@@ -983,11 +983,11 @@ msgstr "CHIRP Hakkında"
 msgid "All"
 msgstr "Tümü"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "Tüm Dosyalar"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr "Desteklenen tüm biçimler|"
 
@@ -1003,7 +1003,7 @@ msgstr "Bir hata oluştu"
 msgid "Applying settings"
 msgstr "Ayarlar uygulanıyor"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Otomatik Tekrarlama Ofseti"
@@ -1012,7 +1012,7 @@ msgstr "Otomatik Tekrarlama Ofseti"
 msgid "Available modules"
 msgstr "Mevcut modüller"
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr "Bant planı"
 
@@ -1020,7 +1020,7 @@ msgstr "Bant planı"
 msgid "Bands"
 msgstr "Bantlar"
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Bankalar"
 
@@ -1028,7 +1028,7 @@ msgstr "Bankalar"
 msgid "Bin"
 msgstr "Bin"
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr "Tarayıcı"
 
@@ -1036,7 +1036,7 @@ msgstr "Tarayıcı"
 msgid "Building Radio Browser"
 msgstr "Telsiz Tarayıcısı oluşturuluyor"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 #, fuzzy
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
@@ -1054,14 +1054,14 @@ msgstr ""
 "Bu ayarın değiştirilmesi, imajdaki ayarların yenilenmesini gerektirir, bu "
 "işlem şimdi gerçekleşecektir."
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 "Eşdeğer TX ve RX %s'ye sahip kanallar, \"%s\" ton modu ile temsil edilir"
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr "Chirp İmaj Dosyaları"
 
@@ -1069,21 +1069,21 @@ msgstr "Chirp İmaj Dosyaları"
 msgid "Choice Required"
 msgstr "Seçim Gerekli"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "%s DTCS Kodunu Seç"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "%s Tonunu Seç"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "Çapraz Modu Seç"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr "Dubleks seç"
 
@@ -1120,23 +1120,23 @@ msgstr "Klon tamamlandı, sahte baytlar kontrol ediliyor"
 msgid "Cloning"
 msgstr "Klonlanıyor"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 msgid "Cloning from radio"
 msgstr "Telsizden klonlanıyor"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 msgid "Cloning to radio"
 msgstr "Telsize klonlanıyor"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr "Kapat"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr "Dosyayı kapat"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1175,7 +1175,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "FM'e dönüştür"
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -1196,7 +1196,7 @@ msgstr "Özel Bağlantı Noktası"
 msgid "Custom..."
 msgstr "Özel..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Kes"
 
@@ -1216,11 +1216,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "DTMF kod çöz"
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "DV Kaydı"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr "İleride Tehlike"
 
@@ -1228,25 +1228,25 @@ msgstr "İleride Tehlike"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Sil"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "Geliştirici Modu"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Geliştirici durumu artık %s. Etkili olması için CHIRP yeniden başlatılmalıdır"
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr "Farklı Ham Kayıtlar"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Dijital Kod"
 
@@ -1254,7 +1254,7 @@ msgstr "Dijital Kod"
 msgid "Digital Modes"
 msgstr "Dijital Modlar"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr "Raporlamayı devre dışı bırak"
 
@@ -1280,15 +1280,15 @@ msgstr "Riski kabul ediyor musun?"
 msgid "Double-click to change bank name"
 msgstr "Banka adını değiştirmek için çift tıklayın"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr "İndir"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 msgid "Download from radio"
 msgstr "Telsizden indir"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "Telsizden indir..."
 
@@ -1304,7 +1304,7 @@ msgstr "Sürücü"
 msgid "Driver information"
 msgstr "Sürücü bilgileri"
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr "Sürücü mesajları"
 
@@ -1318,17 +1318,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "%i kaydı için ayrıntıları düzenle"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "%i kaydı için ayrıntıları düzenle"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr "Otomatik Düzenlemeleri Etkinleştir"
 
@@ -1340,11 +1340,11 @@ msgstr "Etkin"
 msgid "Enter Frequency"
 msgstr "Frekans Gir"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr "Ofset girin (MHz)"
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "TX Frekansını girin (MHz)"
 
@@ -1374,19 +1374,19 @@ msgstr "Telsizle iletişim hatası"
 msgid "Experimental driver"
 msgstr "Deneysel sürücü"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "Dışa aktarma yalnızca CSV dosyalarını yazabilir"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 msgid "Export to CSV"
 msgstr "CSV'ye aktar"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 msgid "Export to CSV..."
 msgstr "CSV'ye aktar..."
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -1416,13 +1416,13 @@ msgstr "Sonuç ayrıştırılamadı"
 msgid "Features"
 msgstr "Özellikler"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Dosya mevcut değil: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 msgid "Files"
 msgstr "Dosyalar"
 
@@ -1434,15 +1434,15 @@ msgstr "Filtre"
 msgid "Filter results with location matching this string"
 msgstr "Bu dizeyle eşleşen konuma sahip sonuçları filtrele"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr "Bul"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr "Sonraki Bul"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 msgid "Find..."
 msgstr "Bul..."
 
@@ -1508,11 +1508,11 @@ msgstr ""
 "4 - Telsiz > Telsizden İndir\n"
 "5 - Arayüz kablosunu çıkarın! Aksi takdirde, sağ taraf sesi olmayacaktır!\n"
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1613,7 +1613,7 @@ msgstr ""
 "5 - Arayüz kablosunu çıkarın, aksi takdirde sağ tarafta ses olmayacaktır!\n"
 "6 - Klon modundan çıkmak için telsizi kapatıp açın\n"
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1655,7 +1655,7 @@ msgstr ""
 "3 - Telsizinizi açın (şifre korumalıysa engelini kaldırın)\n"
 "4 - Başlatmak için TAMAM'a tıklayın.\n"
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1683,11 +1683,11 @@ msgstr ""
 "3 - Telsizinizi açın\n"
 "4 - Telsiz verilerinizin indirmesini gerçekleştirin\n"
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1737,19 +1737,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Ayarlar alınıyor"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Kayda Git"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Kayda Git:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "Git..."
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Yardım"
 
@@ -1761,7 +1761,7 @@ msgstr "Bana Yardım Et..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "Boş kayıtları gizle"
 
@@ -1774,19 +1774,19 @@ msgstr "İnsan tarafından okunabilen yorum (telsizde saklanmaz)"
 msgid "If set, sort results by distance from these coordinates"
 msgstr "Ayarlanırsa, sonuçları bu koordinatlardan uzaklığa göre sırala"
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 msgid "Import from file..."
 msgstr "Dosyadan İçe Aktar..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr "Mesajları içe aktar"
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr "İçe aktarma önerilmez"
 
@@ -1794,15 +1794,15 @@ msgstr "İçe aktarma önerilmez"
 msgid "Index"
 msgstr "Dizin"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Yukarıya Satır Ekle"
 
@@ -1810,7 +1810,7 @@ msgstr "Yukarıya Satır Ekle"
 msgid "Install desktop icon?"
 msgstr "Masaüstü simgesi yüklensin mi?"
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr "Sürücü ile etkileşim"
 
@@ -1823,7 +1823,7 @@ msgstr "Dahili sürücü hatası"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Geçersiz %(value)s (ondalık basamak kullanın)"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 msgid "Invalid Entry"
 msgstr "Geçersiz Girdi"
 
@@ -1831,12 +1831,12 @@ msgstr "Geçersiz Girdi"
 msgid "Invalid ZIP code"
 msgstr "Geçersiz Posta kodu"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Geçersiz düzenleme: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr "Geçersiz veya desteklenmeyen modül dosyası"
 
@@ -1849,11 +1849,11 @@ msgstr "Geçersiz değer: %r"
 msgid "Issue number:"
 msgstr "Kayıt numarası:"
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr "CANLI"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 msgid "Language"
 msgstr ""
 
@@ -1883,11 +1883,11 @@ msgstr "Durum Sınırla"
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Sonuçları koordinatlardan bu mesafeye (km) sınırla"
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 msgid "Live Radio"
 msgstr "Canlı Radyo"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 msgid "Load Module..."
 msgstr "Modül Yükle..."
 
@@ -1895,17 +1895,17 @@ msgstr "Modül Yükle..."
 msgid "Load module from issue"
 msgstr "Kayıttan modül yükle"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 msgid "Load module from issue..."
 msgstr "Kayıttan modül yükle..."
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1939,11 +1939,11 @@ msgstr "Logo dizesi 2 (12 karakter)"
 msgid "Longitude"
 msgstr "Boylam"
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "Kayıtlar"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Kayıt %i silinemez"
@@ -1961,7 +1961,7 @@ msgstr "Hafızanın düzenlenebilmesi için bir bankada olması gerekir"
 msgid "Memory {num} not in bank {bank}"
 msgstr "{num} kaydı {bank} bankasında değil"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 msgid "Mode"
 msgstr "Mod"
 
@@ -1973,15 +1973,15 @@ msgstr "Model"
 msgid "Modes"
 msgstr "Modlar"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr "Modül"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr "Modül Yüklendi"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr "Modül başarıyla yüklendi"
 
@@ -1990,27 +1990,27 @@ msgstr "Modül başarıyla yüklendi"
 msgid "More than one port found: %s"
 msgstr "Birden fazla bağlantı noktası bulundu: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "Aşağı Taşı"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "Yukarı Taşı"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr "Yeni Pencere"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr "Yeni sürüm mevcut"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "Aşağıda boş satır yok!"
 
@@ -2031,7 +2031,7 @@ msgstr "Sonuç yok"
 msgid "No results!"
 msgstr "Sonuç yok!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr "Numara"
 
@@ -2047,7 +2047,7 @@ msgstr "Sadece belirli gruplar"
 msgid "Only certain modes"
 msgstr "Yalnızca belirli modlar"
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr "Yalnızca kayıt sekmeleri dışa aktarılabilir"
 
@@ -2055,35 +2055,35 @@ msgstr "Yalnızca kayıt sekmeleri dışa aktarılabilir"
 msgid "Only working repeaters"
 msgstr "Yalnızca çalışan tekrarlayıcılar (röleler)"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr "Aç"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 msgid "Open Recent"
 msgstr "Son Kullanılanları Aç"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 msgid "Open Stock Config"
 msgstr "Hazır Yapılandırma Aç"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr "Bir dosya aç"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr "Bir modül aç"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "Hata ayıklama günlüğünü aç"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr "Yeni pencerede aç"
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 msgid "Open stock config directory"
 msgstr "Hazır yapılandırma dizinini aç"
 
@@ -2103,7 +2103,7 @@ msgstr "İsteğe bağlı: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "İsteğe bağlı: bölge, Hastane vb."
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "Kayıtların üzerine yazılsın mı?"
 
@@ -2121,31 +2121,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Ayrıştırılıyor"
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Yapıştırılan kayıtlar, mevcut %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Yapıştırılan kayıtlar %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Yapıştırılan kayıtlar, %s kaydının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Yapıştırılan kayıt, %s kaydının üzerine yazacak"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Lütfen yeni sürümü yüklemeden önce CHIRP'den çıktığınızdan emin olun!"
 
@@ -2193,7 +2193,7 @@ msgstr ""
 "4 - Ardından klonlamaya başlamak için telsizinizdeki \"A\" tuşuna basın.\n"
 "     (Sonunda telsiz bip sesi çıkaracaktır)\n"
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2226,7 +2226,7 @@ msgstr "Güç"
 msgid "Press enter to set this in memory"
 msgstr "Bu kayda almak için enter tuşuna basın"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr "Baskı Önizleme"
 
@@ -2234,16 +2234,16 @@ msgstr "Baskı Önizleme"
 msgid "Printing"
 msgstr "Baskı"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Özellikler"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr "%s sorgusu"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "Kaynaktan Sorgula"
 
@@ -2251,11 +2251,11 @@ msgstr "Kaynaktan Sorgula"
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "Telsiz"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr "Telsiz %i bloğunu onaylamadı"
@@ -2306,11 +2306,11 @@ msgstr "Yeniden Başlatma Gerekli"
 msgid "Refreshed memory %s"
 msgstr "Yenilenmiş %s kaydı"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "Sürücüyü Yeniden Yükle"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "Sürücüyü ve Dosyayı Yeniden Yükle"
 
@@ -2326,11 +2326,11 @@ msgstr ""
 "RepeaterBook, Amatör Telsiz için dünya çapında en kapsamlı \n"
 "ÜCRETSİZ röle rehberidir."
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "Raporlama etkinleştirildi"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2341,18 +2341,18 @@ msgstr ""
 "bırakırsanız gerçekten minnettar oluruz. Raporlama gerçekten devre dışı "
 "bırakılsın mı?"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr "Yeniden Başlatma Gerekiyor"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "%i sekmeyi geri yükle"
 msgstr[1] "%i sekmeyi geri yükle"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr "Başlangıçta sekmeleri geri yükle"
 
@@ -2360,15 +2360,15 @@ msgstr "Başlangıçta sekmeleri geri yükle"
 msgid "Retrieved settings"
 msgstr "Alınan ayarlar"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr "Kaydet"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr "Kapanmadan önce kaydedilsin mi?"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "Dosyayı kaydet"
 
@@ -2392,7 +2392,7 @@ msgstr "Karıştırıcı"
 msgid "Security Risk"
 msgstr "Güvenlik Riski"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr "Bant Planı Seç..."
 
@@ -2400,7 +2400,7 @@ msgstr "Bant Planı Seç..."
 msgid "Select Bands"
 msgstr "Bantları Seç"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "Bantları Seç"
@@ -2409,7 +2409,7 @@ msgstr "Bantları Seç"
 msgid "Select Modes"
 msgstr "Modları Seç"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr "Bir bant planı seçin"
 
@@ -2417,7 +2417,7 @@ msgstr "Bir bant planı seçin"
 msgid "Service"
 msgstr "Servis"
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "Ayarlar"
 
@@ -2426,56 +2426,56 @@ msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 "Çift yönlü tarafından kontrol edilen kaydırma miktarı (veya iletim frekansı)"
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr "Ham Kaydı Göster"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "Hata ayıklama günlüğü konumunu göster"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "Ekstra alanları göster"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr "İmaj yedekleme konumunu göster"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Bazı kayıtlar bu telsizle uyumlu değil"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Bazı anılar silinemez"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "%i kaydı sırala"
 msgstr[1] "%i kaydı sırala"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "%i kaydı artan şekilde sırala"
 msgstr[1] "%i kaydı artan şekilde sırala"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "%i kaydı azalan şekilde sırala"
 msgstr[1] "%i kaydı azalan şekilde sırala"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "Sütuna göre sırala:"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "Kayıtları sırala"
 
@@ -2491,7 +2491,7 @@ msgstr "Devlet"
 msgid "State/Province"
 msgstr "Eyalet/İl"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr "Başarılı"
 
@@ -2553,7 +2553,11 @@ msgstr ""
 "oluşturabileceğinden bu modülü yüklememeniz önerilir. Yine de devam edilsin "
 "mi?"
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2569,7 +2573,7 @@ msgstr ""
 "yapıştırmak için bu dosyayı açmak mı yoksa içe aktarma işlemine devam etmek "
 "mi istiyorsunuz?"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "Bu kaydı"
 
@@ -2601,7 +2605,7 @@ msgstr ""
 "telsizinizden yeni bir imaj indirmeniz ve bunu ileriye doğru kullanmanız "
 "önerilir."
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
@@ -2609,7 +2613,7 @@ msgstr ""
 "Bu, canlı modlu bir telsizdir; bu, değişiklik yaptığınızda gerçek zamanlı "
 "olarak radyoya gönderildiği anlamına gelir. Yükleme gerekli değildir!"
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 #, fuzzy
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
@@ -2660,11 +2664,11 @@ msgstr ""
 "Ayrıca lütfen hata raporu ve geliştirme istekleri gönderin!\n"
 "Uyarıldınız. Kendi sorumluluğunuzda ilerleyin!"
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "Bu kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "Bu kaydı ve bloğu yukarı kaydır"
 
@@ -2715,7 +2719,7 @@ msgstr "Bu, bir web sitesi kaydından bir modül yükleyecektir"
 msgid "Tone"
 msgstr "Ton"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Ton Modu"
 
@@ -2751,7 +2755,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr "TSQL modu için gönderme/alma tonu, aksi takdirde ton al"
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Ayarlama Adımı"
 
@@ -2767,16 +2771,16 @@ msgstr ""
 "Kablonuz için bağlantı noktası belirlenemiyor. Sürücülerinizi ve "
 "bağlantılarınızı kontrol edin."
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Radyo yüklenmeden önce kayıt düzenlenemiyor"
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "%r stok yapılandırması bulunamadı"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Radyo yüklenmeden önce kayıt düzenlenemiyor"
@@ -2809,7 +2813,7 @@ msgstr "%s bu sistemde gösterilemiyor"
 msgid "Unable to set %s on this memory"
 msgstr "Bu kayıtta %s ayarlanamıyor"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 msgid "Unable to upload this file"
 msgstr "Bu dosya yüklenemiyor"
 
@@ -2830,11 +2834,11 @@ msgstr "Desteklenmeyen model %r"
 msgid "Upload instructions"
 msgstr "Yükleme talimatları"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 msgid "Upload to radio"
 msgstr "Telsize yükle"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "Telsize yükle..."
 
@@ -2843,11 +2847,11 @@ msgstr "Telsize yükle..."
 msgid "Uploaded memory %s"
 msgstr "Yüklenen kayıt %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr "Sabit genişlikte yazı tipi kullan"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr "Daha büyük yazı tipi kullan"
 
@@ -2875,7 +2879,7 @@ msgstr "Değer tam olarak %i ondalık basamak olmalıdır"
 msgid "Value must be zero or greater"
 msgstr "Değer sıfır veya daha büyük olmalıdır"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "Değerler"
 
@@ -2883,7 +2887,7 @@ msgstr "Değerler"
 msgid "Vendor"
 msgstr "Tedarikçi"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 msgid "View"
 msgstr "Göster"
 
@@ -2891,16 +2895,16 @@ msgstr "Göster"
 msgid "WARNING!"
 msgstr "UYARI!"
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr "Uyarı"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Uyarı: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr "Hoşgeldiniz"
 
@@ -2924,11 +2928,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "her biri bayt"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr "devre dışı bırakıldı"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr "etkinleştirildi"
 

--- a/chirp/locale/uk_UA.po
+++ b/chirp/locale/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2015-11-30 10:36+0200\n"
 "Last-Translator: laser <student.laser@gmail.com>\n"
 "Language-Team: laser <student.laser@gmail.com>\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Видалити (та зсунути вгору)"
 msgstr[1] "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Пам'ять"
 msgstr[1] "Пам'ять"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Видалити (та зсунути вгору)"
 msgstr[1] "Видалити (та зсунути вгору)"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Файл змінено, зберегти зміни перед закриттям?"
@@ -63,7 +63,7 @@ msgstr "Файл змінено, зберегти зміни перед закр
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -621,17 +621,17 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr ""
 
@@ -639,12 +639,12 @@ msgstr ""
 msgid "All"
 msgstr "Все"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 #, fuzzy
 msgid "All Files"
 msgstr "CSV-файли"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -660,7 +660,7 @@ msgstr "Сталася помилка"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Автоматичний рознос репітера"
@@ -669,7 +669,7 @@ msgstr "Автоматичний рознос репітера"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr ""
 
@@ -677,7 +677,7 @@ msgstr ""
 msgid "Bands"
 msgstr ""
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr "Банки"
 
@@ -685,7 +685,7 @@ msgstr "Банки"
 msgid "Bin"
 msgstr ""
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr ""
 
@@ -693,7 +693,7 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
@@ -707,13 +707,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -721,22 +721,22 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS код"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Кросрежим"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -767,25 +767,25 @@ msgstr ""
 msgid "Cloning"
 msgstr "Клонування"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Скопіювати з радіостанції"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 #, fuzzy
 msgid "Copy"
 msgstr "Копіювати"
@@ -844,7 +844,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 #, fuzzy
 msgid "Cut"
 msgstr "Вирізати"
@@ -865,11 +865,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr ""
 
@@ -878,27 +878,27 @@ msgstr ""
 msgid "Dec"
 msgstr "Визначити"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 #, fuzzy
 msgid "Delete"
 msgstr "Видалити"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Розробник"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Цифровий код"
 
@@ -907,7 +907,7 @@ msgstr "Цифровий код"
 msgid "Digital Modes"
 msgstr "Цифровий код"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr ""
 
@@ -933,16 +933,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 #, fuzzy
 msgid "Download from radio"
 msgstr "Скопіювати з радіостанції"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Скопіювати з радіостанції"
@@ -960,7 +960,7 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -972,17 +972,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -995,11 +995,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Частота"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1030,21 +1030,21 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Експорт до файлу"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Експорт до файлу"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1071,13 +1071,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 #, fuzzy
 msgid "Files"
 msgstr "_Файл"
@@ -1090,15 +1090,15 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 msgid "Find..."
 msgstr ""
 
@@ -1145,11 +1145,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1215,7 +1215,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1242,7 +1242,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1260,11 +1260,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1304,20 +1304,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Показати Raw пам'ять"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "Довідка"
 
@@ -1329,7 +1329,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Перезаписати?"
@@ -1343,20 +1343,20 @@ msgstr ""
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "Імпорт"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 #, fuzzy
 msgid "Import from file..."
 msgstr "Імпортувати з файлу"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Імпорт з RFinder"
@@ -1365,15 +1365,15 @@ msgstr "Імпорт з RFinder"
 msgid "Index"
 msgstr "Зміст"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Додати рядок зверху"
@@ -1382,7 +1382,7 @@ msgstr "Додати рядок зверху"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1396,7 +1396,7 @@ msgstr "Внутрішня помилка"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Неприпустиме значення. Повинно бути цілим числом."
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Неприпустиме значення для цього поля"
@@ -1405,12 +1405,12 @@ msgstr "Неприпустиме значення для цього поля"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1423,11 +1423,11 @@ msgstr "Неприпустиме значення для цього поля"
 msgid "Issue number:"
 msgstr ""
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 #, fuzzy
 msgid "Language"
 msgstr "Змінити мову"
@@ -1458,12 +1458,12 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "Радіостанція"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 #, fuzzy
 msgid "Load Module..."
 msgstr "Тоновий режим"
@@ -1473,18 +1473,18 @@ msgstr "Тоновий режим"
 msgid "Load module from issue"
 msgstr "Тоновий режим"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Тоновий режим"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1511,12 +1511,12 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 #, fuzzy
 msgid "Memories"
 msgstr "Пам'ять"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1534,7 +1534,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 #, fuzzy
 msgid "Mode"
 msgstr "Режим"
@@ -1548,15 +1548,15 @@ msgstr "Модель"
 msgid "Modes"
 msgstr "Режим"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1565,29 +1565,29 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Перемістити В_низ"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Перемістити В_гору"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Додати рядок знизу"
@@ -1609,7 +1609,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr ""
 
@@ -1625,7 +1625,7 @@ msgstr ""
 msgid "Only certain modes"
 msgstr ""
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr ""
 
@@ -1633,37 +1633,37 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 #, fuzzy
 msgid "Open Recent"
 msgstr "Ос_танні"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Відкрити заводські конфігурації"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Відкрите заводські конфігурації {name}"
@@ -1685,7 +1685,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Перезаписати?"
@@ -1701,32 +1701,32 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 #, fuzzy
 msgid "Paste"
 msgstr "Вставити"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1756,7 +1756,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1785,7 +1785,7 @@ msgstr "Потужність"
 msgid "Press enter to set this in memory"
 msgstr "Помилка настройки пам'яті"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr ""
 
@@ -1793,16 +1793,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr ""
 
@@ -1810,12 +1810,12 @@ msgstr ""
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 #, fuzzy
 msgid "Radio"
 msgstr "Радіостанція"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr ""
@@ -1861,11 +1861,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1880,30 +1880,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Звіти вимкнуто"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1911,15 +1911,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Виберіть Стовпці"
@@ -1953,7 +1953,7 @@ msgstr "Виберіть Стовпці"
 msgid "Select Bands"
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "Виберіть Стовпці"
@@ -1963,7 +1963,7 @@ msgstr "Виберіть Стовпці"
 msgid "Select Modes"
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1971,7 +1971,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr ""
 
@@ -1979,58 +1979,58 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Показати Raw пам'ять"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Вставлена пам'ять {number} несумісна із цією радіостанцією тому що:"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Перезаписати?"
@@ -2047,7 +2047,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr ""
 
@@ -2091,7 +2091,11 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2101,7 +2105,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Показати Raw пам'ять"
@@ -2126,13 +2130,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2167,12 +2171,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Видалити (та зсунути вгору)"
@@ -2210,7 +2214,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Тон"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Тоновий режим"
 
@@ -2248,7 +2252,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Крок настройки"
@@ -2263,16 +2267,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Відкрити заводські конфігурації"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Не вдалося виявити радіо на {port}"
@@ -2303,7 +2307,7 @@ msgstr "Не вдається внести зміни до цієї моделі
 msgid "Unable to set %s on this memory"
 msgstr "Не вдається внести зміни до цієї моделі"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Не вдається внести зміни до цієї моделі"
@@ -2325,12 +2329,12 @@ msgstr "Файл непідтримуваного типу"
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Записати в радіостанцію"
@@ -2340,11 +2344,11 @@ msgstr "Записати в радіостанцію"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr ""
 
@@ -2372,7 +2376,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2380,7 +2384,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Виробник"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 #, fuzzy
 msgid "View"
 msgstr "В_игляд"
@@ -2389,16 +2393,16 @@ msgstr "В_игляд"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr ""
 
@@ -2422,11 +2426,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/zh_CN.po
+++ b/chirp/locale/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-24 15:35-0400\n"
 "PO-Revision-Date: 2024-01-26 13:30+0800\n"
 "Last-Translator: DuckSoft, BH2UEP <realducksoft@gmail.com>\n"
 "Language-Team: \n"
@@ -33,25 +33,25 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "...并将区块上移"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "存储"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "...并将区块上移"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1374
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s 还没有被保存。要在关闭程序前保存吗？"
@@ -60,7 +60,7 @@ msgstr "%s 还没有被保存。要在关闭程序前保存吗？"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, fuzzy, python-format
 msgid "...and %i more"
 msgstr "...并将所有存储上移"
@@ -630,17 +630,17 @@ msgstr ""
 "\n"
 "如果在已连接数据线的情况下打开电台，则可能无法进行"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1878
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr "新的 CHIRP 版本已经推出。请尽快访问网站下载！"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:920
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1723
 msgid "About CHIRP"
 msgstr "关于CHIRP"
 
@@ -648,11 +648,11 @@ msgstr "关于CHIRP"
 msgid "All"
 msgstr "全选"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1204
 msgid "All Files"
 msgstr "全部文件"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1215
 msgid "All supported formats|"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr "发生错误"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1470
 msgid "Automatic from system"
 msgstr ""
 
@@ -676,7 +676,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1816
 msgid "Bandplan"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Bands"
 msgstr ""
 
-#: ../wxui/main.py:208
+#: ../wxui/main.py:209
 msgid "Banks"
 msgstr ""
 
@@ -692,7 +692,7 @@ msgstr ""
 msgid "Bin"
 msgstr ""
 
-#: ../wxui/main.py:219
+#: ../wxui/main.py:220
 msgid "Browser"
 msgstr "数据浏览器"
 
@@ -700,7 +700,7 @@ msgstr "数据浏览器"
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1499
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
@@ -714,13 +714,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1203
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -728,21 +728,21 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "选择 %s DTCS 接收代码"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "收发使用不同亚音频"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -773,23 +773,23 @@ msgstr ""
 msgid "Cloning"
 msgstr "正在复制"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
 msgid "Cloning from radio"
 msgstr "从电台下载"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
 msgid "Cloning to radio"
 msgstr "上传到电台"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1003
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1004
 msgid "Close file"
 msgstr "全部文件"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -823,7 +823,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "复制"
 
@@ -845,7 +845,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "剪切"
 
@@ -865,11 +865,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "该存储"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1737
 msgid "Danger Ahead"
 msgstr ""
 
@@ -877,24 +877,24 @@ msgstr ""
 msgid "Dec"
 msgstr "探测"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "删除"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:925
 msgid "Developer Mode"
 msgstr "开发者模式"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1743
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
 msgid "Diff Raw Memories"
 msgstr "对比原始存储"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "数字代码"
 
@@ -902,7 +902,7 @@ msgstr "数字代码"
 msgid "Digital Modes"
 msgstr "数字代码"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1755
 msgid "Disable reporting"
 msgstr ""
 
@@ -928,15 +928,15 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1005
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1006
 msgid "Download from radio"
 msgstr "从电台下载"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:832
 msgid "Download from radio..."
 msgstr "从电台下载……"
 
@@ -953,7 +953,7 @@ msgstr "重新加载驱动程序"
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:549
 msgid "Driver messages"
 msgstr ""
 
@@ -965,17 +965,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "差频方向"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:869
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -987,11 +987,11 @@ msgstr "已启用"
 msgid "Enter Frequency"
 msgstr "频率"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1022,19 +1022,19 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "继续使用不稳定的驱动？"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1359
 msgid "Export to CSV"
 msgstr "以CSV文件格式导出"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:707
 msgid "Export to CSV..."
 msgstr "以CSV文件格式导出……"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1061,13 +1061,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:554
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1207 ../wxui/main.py:1287 ../wxui/main.py:1297
+#: ../wxui/main.py:1355 ../wxui/main.py:1689 ../wxui/main.py:1690
 msgid "Files"
 msgstr "文件"
 
@@ -1079,17 +1079,17 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1429
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:775
 #, fuzzy
 msgid "Find Next"
 msgstr "RFinder"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:761
 #, fuzzy
 msgid "Find..."
 msgstr "寻找……"
@@ -1137,11 +1137,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
-#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
+#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
+#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
+#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1207,7 +1207,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1244,7 +1244,7 @@ msgstr ""
 "3 - 打开电台\n"
 "4 - 单击 \"确定 \"开始\n"
 
-#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
+#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1272,11 +1272,11 @@ msgstr ""
 "3 - 打开电台\n"
 "4 - 下载电台数据\n"
 
-#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
-#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
-#: ../drivers/baofeng_uv17Pro.py:447
+#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
+#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
+#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
+#: ../drivers/baofeng_wp970i.py:334
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1326,19 +1326,19 @@ msgstr ""
 msgid "Getting settings"
 msgstr "正在获取设置"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "前往数据"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "前往数据："
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "前往……"
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:971
 msgid "Help"
 msgstr "帮助"
 
@@ -1350,7 +1350,7 @@ msgstr "帮助..."
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "隐藏无数据的内容"
 
@@ -1363,19 +1363,19 @@ msgstr ""
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1342
 msgid "Import"
 msgstr "导入"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:701
 msgid "Import from file..."
 msgstr "从文件导入……"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1346
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1340
 msgid "Import not recommended"
 msgstr ""
 
@@ -1383,15 +1383,15 @@ msgstr ""
 msgid "Index"
 msgstr "索引"
 
-#: ../wxui/main.py:221
+#: ../wxui/main.py:222
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "{information}"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "上方插入一行"
 
@@ -1399,7 +1399,7 @@ msgstr "上方插入一行"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:909
 msgid "Interact with driver"
 msgstr ""
 
@@ -1413,7 +1413,7 @@ msgstr "内部错误"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "无效值。必须为整数。"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
 msgid "Invalid Entry"
 msgstr "设置值无效：%s"
 
@@ -1421,12 +1421,12 @@ msgstr "设置值无效：%s"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "设置值无效：%s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1686
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1439,11 +1439,11 @@ msgstr "%r 值无效"
 msgid "Issue number:"
 msgstr ""
 
-#: ../wxui/main.py:339
+#: ../wxui/main.py:340
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:818 ../wxui/main.py:1484
 #, fuzzy
 msgid "Language"
 msgstr "更改语言 (Change Language)"
@@ -1474,12 +1474,12 @@ msgstr ""
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/main.py:1567
 #, fuzzy
 msgid "Live Radio"
 msgstr "电台"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:713
 msgid "Load Module..."
 msgstr "加载模块……"
 
@@ -1488,18 +1488,18 @@ msgstr "加载模块……"
 msgid "Load module from issue"
 msgstr "加载模块"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:962
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "加载模块"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1791
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1693
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1526,11 +1526,11 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/main.py:200
+#: ../wxui/main.py:201
 msgid "Memories"
 msgstr "存储"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1548,7 +1548,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
 msgid "Mode"
 msgstr "制式"
 
@@ -1560,15 +1560,15 @@ msgstr "型号"
 msgid "Modes"
 msgstr "制式"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1690
 msgid "Module"
 msgstr "模块"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1662
 msgid "Module Loaded"
 msgstr "模块加载"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1802
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1577,27 +1577,27 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "下移"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "上移"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:659
 msgid "New Window"
 msgstr "创建一个新的窗口"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1880
 msgid "New version available"
 msgstr "有新版本"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr ""
 
@@ -1618,7 +1618,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
 msgid "Number"
 msgstr ""
 
@@ -1634,7 +1634,7 @@ msgstr ""
 msgid "Only certain modes"
 msgstr ""
 
-#: ../wxui/main.py:321
+#: ../wxui/main.py:322
 msgid "Only memory tabs may be exported"
 msgstr ""
 
@@ -1642,36 +1642,36 @@ msgstr ""
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:999 ../wxui/main.py:1342
 msgid "Open"
 msgstr "打开"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:688
 msgid "Open Recent"
 msgstr ""
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:670
 msgid "Open Stock Config"
 msgstr "打开预留配置"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:1000 ../wxui/main.py:1218
 #, fuzzy
 msgid "Open a file"
 msgstr "打开最近的文件"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1708
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:946
 msgid "Open debug log"
 msgstr "打开调试日志"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:524
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/main.py:617
 msgid "Open stock config directory"
 msgstr ""
 
@@ -1692,7 +1692,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "要覆盖吗？"
 
@@ -1707,31 +1707,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "粘贴"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1884
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1761,7 +1761,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1731
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1789,7 +1789,7 @@ msgstr "功率"
 msgid "Press enter to set this in memory"
 msgstr "设置存储时出错"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:724
 msgid "Print Preview"
 msgstr "打印预览"
 
@@ -1797,16 +1797,16 @@ msgstr "打印预览"
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "属性"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1830
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:846
 msgid "Query Source"
 msgstr "查询数据源"
 
@@ -1814,11 +1814,11 @@ msgstr "查询数据源"
 msgid "RX DTCS"
 msgstr "DTCS 接收代码"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:970
 msgid "Radio"
 msgstr "电台"
 
-#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
+#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr ""
@@ -1865,11 +1865,11 @@ msgstr "需要刷新"
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:886
 msgid "Reload Driver"
 msgstr "重新加载驱动程序"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:895
 msgid "Reload Driver and File"
 msgstr "重新加载驱动程序和文件"
 
@@ -1883,28 +1883,28 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:934
 msgid "Reporting enabled"
 msgstr "启用报告功能"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1751
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1501 ../wxui/main.py:1745
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:682
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:811
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1912,15 +1912,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1001
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1376
 msgid "Save before closing?"
 msgstr "在保存前关闭？"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1002 ../wxui/main.py:1301
 msgid "Save file"
 msgstr "保存文件"
 
@@ -1945,7 +1945,7 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:876
 msgid "Select Bandplan..."
 msgstr ""
 
@@ -1954,7 +1954,7 @@ msgstr ""
 msgid "Select Bands"
 msgstr "选择列"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1484
 #, fuzzy
 msgid "Select Language"
 msgstr "更改语言 (Change Language)"
@@ -1964,7 +1964,7 @@ msgstr "更改语言 (Change Language)"
 msgid "Select Modes"
 msgstr "选择列"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1815
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1972,7 +1972,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: ../wxui/main.py:213
+#: ../wxui/main.py:214
 msgid "Settings"
 msgstr "设置"
 
@@ -1980,54 +1980,54 @@ msgstr "设置"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
 msgid "Show Raw Memory"
 msgstr "显示原始存储"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:952
 msgid "Show debug log location"
 msgstr "打开调试日志所在文件夹"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "显示更多其他内容"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:957
 #, fuzzy
 msgid "Show image backup location"
 msgstr "打开调试日志所在文件夹"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "某些内容与此电台不兼容"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "某些内容不可被删除"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr ""
 
@@ -2044,7 +2044,7 @@ msgstr ""
 msgid "State/Province"
 msgstr "州/省"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1803
 msgid "Success"
 msgstr ""
 
@@ -2088,7 +2088,11 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1843
+msgid "The python3-suds package is required to query this source."
+msgstr ""
+
+#: ../wxui/main.py:1333
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2098,7 +2102,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "该内容"
 
@@ -2122,13 +2126,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1564
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1570
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2170,12 +2174,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "...并将区块上移"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "...并将区块上移"
@@ -2213,7 +2217,7 @@ msgstr ""
 msgid "Tone"
 msgstr "亚音频"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "亚音频制式"
 
@@ -2250,7 +2254,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "调谐间隔"
 
@@ -2264,16 +2268,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1259
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "无法打开此镜像：型号不支持"
@@ -2303,7 +2307,7 @@ msgstr "无法在此系统上显示 %s"
 msgid "Unable to set %s on this memory"
 msgstr "无法在此内容上设置 %s"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1574
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "无法在此系统上显示 %s"
@@ -2325,11 +2329,11 @@ msgstr "不支持的文件类型"
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1008
 msgid "Upload to radio"
 msgstr "上传到电台"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:840
 msgid "Upload to radio..."
 msgstr "上传到电台……"
 
@@ -2338,11 +2342,11 @@ msgstr "上传到电台……"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:796
 msgid "Use fixed-width font"
 msgstr "使用固定宽度字体"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:804
 msgid "Use larger font"
 msgstr "使用大号字体"
 
@@ -2370,7 +2374,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2378,7 +2382,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "厂商"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:969
 msgid "View"
 msgstr "查看"
 
@@ -2386,16 +2390,16 @@ msgstr "查看"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/main.py:1795 ../wxui/memedit.py:1542
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:442
 msgid "Welcome"
 msgstr ""
 
@@ -2419,11 +2423,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "disabled"
 msgstr "已禁用"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1728
 msgid "enabled"
 msgstr "已启用"
 

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -26,6 +26,7 @@ import time
 import typing
 import webbrowser
 
+from chirp.sources import radioreference
 
 import wx
 import wx.aui
@@ -1835,7 +1836,12 @@ class ChirpMain(wx.Frame):
             self.add_editorset(editorset)
 
     def _menu_query_rr(self, event):
-        self._do_network_query(query_sources.RRQueryDialog)
+        if radioreference.HAVE_SUDS:
+            self._do_network_query(query_sources.RRQueryDialog)
+        else:
+            common.error_proof.show_error(
+                _('The python3-suds package is required '
+                  'to query this source.'))
 
     def _menu_query_rb(self, event):
         self._do_network_query(query_sources.RepeaterBookQueryDialog)


### PR DESCRIPTION
On Linux, the python3-suds is an optional dependency. When it is not installed, it doesn't do anything in the GUI; it only displays an error on the console.