### PR TITLE
Limit Repeaterbook Queries to Open Repeaters

### DIFF
--- a/chirp/locale/de.po
+++ b/chirp/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2012-10-02 22:11+0100\n"
 "Last-Translator: Benjamin, HB9EUK <hb9euk@hb9d.org>\n"
 "Language-Team: German\n"
@@ -35,28 +35,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Löschen (und nach oben verschieben)"
 msgstr[1] "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Speicher"
 msgstr[1] "Speicher"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Löschen (und nach oben verschieben)"
 msgstr[1] "Löschen (und nach oben verschieben)"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Datei wurde geändert, speichern Sie die Änderungen vor dem Schliessen?"
@@ -65,7 +65,7 @@ msgstr "Datei wurde geändert, speichern Sie die Änderungen vor dem Schliessen?
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -623,34 +623,34 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Alle"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "CSV Datei"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr ""
 
@@ -662,7 +662,7 @@ msgstr "Ein Fehler ist aufgetreten"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Automatischer Repeater-Offset"
@@ -671,11 +671,11 @@ msgstr "Automatischer Repeater-Offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr ""
 
@@ -695,11 +695,11 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr ""
 
@@ -709,13 +709,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -723,22 +723,22 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross Mode"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -747,7 +747,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Importieren von:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr ""
 
@@ -779,15 +779,15 @@ msgstr "Download vom Gerät"
 msgid "Cloning to radio"
 msgstr "Upload zum Gerät"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -819,16 +819,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Kopieren"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Ausschneiden"
 
@@ -865,11 +865,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr ""
 
@@ -878,34 +878,34 @@ msgstr ""
 msgid "Dec"
 msgstr "Erkennung"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Entwickler"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Digital Code"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 #, fuzzy
 msgid "Digital Modes"
 msgstr "Digital Code"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr ""
 
@@ -915,7 +915,7 @@ msgid "Disabled"
 msgstr "Aktiviert"
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr ""
 
@@ -932,16 +932,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download vom Gerät"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download vom Gerät"
@@ -959,11 +959,11 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -971,17 +971,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -995,11 +995,11 @@ msgstr "Aktiviert"
 msgid "Enter Frequency"
 msgstr "Frequenz"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1026,26 +1026,30 @@ msgstr "Fehler beim Setzen der Speicher"
 msgid "Error communicating with radio"
 msgstr ""
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 #, fuzzy
 msgid "Experimental driver"
 msgstr "Weiter mit dem experimentellen Treiber?"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 #, fuzzy
 msgid "Export to CSV"
 msgstr "In Datei exportieren"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "In Datei exportieren"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1053,7 +1057,7 @@ msgstr ""
 msgid "FM Radio"
 msgstr ""
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1072,13 +1076,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 #, fuzzy
 msgid "Files"
 msgstr "_Datei"
@@ -1091,17 +1095,17 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 #, fuzzy
 msgid "Find Next"
 msgstr "RFinder"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 #, fuzzy
 msgid "Find..."
 msgstr "RFinder"
@@ -1150,7 +1154,7 @@ msgid ""
 msgstr ""
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1219,7 +1223,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1299,8 +1303,8 @@ msgstr "Frequenz"
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr ""
 
@@ -1308,20 +1312,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Zeige RAW Speicher"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Hilfe"
 
@@ -1333,7 +1337,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Überschreiben?"
@@ -1343,24 +1347,24 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "Importieren"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importieren von Datei"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 msgid "Import not recommended"
 msgstr ""
 
@@ -1372,11 +1376,11 @@ msgstr "Index"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Zeile oben einfügen"
@@ -1385,7 +1389,7 @@ msgstr "Zeile oben einfügen"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1399,7 +1403,7 @@ msgstr "Interner Fehler"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ungültiger Wert. Muss eine ganze Zahl sein."
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ungültiger Wert für dieses Feld"
@@ -1408,12 +1412,12 @@ msgstr "Ungültiger Wert für dieses Feld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1430,13 +1434,13 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 #, fuzzy
 msgid "Language"
 msgstr "Sprache wählen"
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr ""
 
@@ -1445,7 +1449,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr ""
 
@@ -1453,20 +1457,24 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+msgid "Limit use"
+msgstr ""
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "Gerät"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Load Module..."
 msgstr "Module laden"
@@ -1476,18 +1484,18 @@ msgstr "Module laden"
 msgid "Load module from issue"
 msgstr "Module laden"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Module laden"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1510,7 +1518,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr ""
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr ""
 
@@ -1518,7 +1526,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Speicher"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1536,7 +1544,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1545,22 +1553,22 @@ msgstr "Mode"
 msgid "Model"
 msgstr "Model"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Modes"
 msgstr "Mode"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 #, fuzzy
 msgid "Module"
 msgstr "Module laden"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Module laden"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1569,30 +1577,30 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Nach _Unten"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Nach _Oben"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 #, fuzzy
 msgid "New version available"
 msgstr "Eine neue Version von CHIRP ist verfügbar:"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Zeile unten einfügen"
@@ -1610,11 +1618,11 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr ""
 
@@ -1622,7 +1630,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr ""
 
@@ -1634,55 +1642,59 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Aktuell"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Speichervorgaben öffnen"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Vorgaben öffnen {name}"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Optionen"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1690,7 +1702,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Überschreiben?"
@@ -1706,31 +1718,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1760,7 +1772,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1789,7 +1801,7 @@ msgstr "Leistung"
 msgid "Press enter to set this in memory"
 msgstr "Fehler beim Setzen der Speicher"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr ""
 
@@ -1797,16 +1809,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 #, fuzzy
 msgid "Query Source"
 msgstr "Datenquelle abfragen"
@@ -1815,7 +1827,7 @@ msgstr "Datenquelle abfragen"
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "Gerät"
 
@@ -1836,11 +1848,11 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1865,11 +1877,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1884,30 +1896,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Report ist deaktiviert"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1915,15 +1927,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr ""
 
@@ -1948,27 +1960,27 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Spalten auswählen"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 #, fuzzy
 msgid "Select Bands"
 msgstr "Spalten auswählen"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "Spalten auswählen"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Select Modes"
 msgstr "Spalten auswählen"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1984,58 +1996,58 @@ msgstr "Einstellungen"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Zeige RAW Speicher"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "Eingefügter Speicher {number} ist nicht mit diesem Gerät kompatibel weil:"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Überschreiben?"
@@ -2045,7 +2057,7 @@ msgstr "Überschreiben?"
 msgid "Sorting"
 msgstr "Einstellungen"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr ""
 
@@ -2053,7 +2065,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr ""
 
@@ -2061,7 +2073,7 @@ msgstr ""
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2097,7 +2109,7 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2107,7 +2119,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Zeige RAW Speicher"
@@ -2132,13 +2144,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2173,12 +2185,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Löschen (und nach oben verschieben)"
@@ -2216,7 +2228,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Tone"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Tone Mode"
 
@@ -2254,7 +2266,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Abstimmungsschritt"
@@ -2269,16 +2281,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Speichervorgaben öffnen"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Kann Gerät auf {port} nicht erkennen"
@@ -2309,12 +2321,12 @@ msgstr "Keine Änderungen bei diesem Modell möglich"
 msgid "Unable to set %s on this memory"
 msgstr "Keine Änderungen bei diesem Modell möglich"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Keine Änderungen bei diesem Modell möglich"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr ""
 
@@ -2331,12 +2343,12 @@ msgstr "Nicht unterstuetzter Dateityp"
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Upload zum Gerät"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Upload zum Gerät"
@@ -2346,11 +2358,11 @@ msgstr "Upload zum Gerät"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr ""
 
@@ -2378,7 +2390,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2386,7 +2398,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Hersteller"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 #, fuzzy
 msgid "View"
 msgstr "_Ansicht"
@@ -2395,16 +2407,16 @@ msgstr "_Ansicht"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr ""
 
@@ -2428,12 +2440,12 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 #, fuzzy
 msgid "disabled"
 msgstr "Aktiviert"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 #, fuzzy
 msgid "enabled"
 msgstr "Aktiviert"

--- a/chirp/locale/el.po
+++ b/chirp/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2023-02-11 15:12+0200\n"
 "Last-Translator: Sokratis Alichanidis <sv2hzs@posteo.net>\n"
 "Language-Team: Greek\n"
@@ -37,28 +37,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 msgstr[1] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Μνήμες"
 msgstr[1] "Μνήμες"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
 msgstr[1] "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr ""
@@ -67,7 +67,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(καμία)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -625,7 +625,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -633,27 +633,27 @@ msgstr ""
 "Μία νέα έκδοση του CHIRP είναι διαθέσιμη. Παρακαλούμε επισκεφθείτε την "
 "ιστοσελίδα το συντομότερο δυνατό για να την κατεβάσετε!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "Σχετικά"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr "Σχετικά με το CHIRP"
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Όλες"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Όλα τα αρχεία"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Όλοι οι τύποι αρχείων|"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr "Ραδιοερασιτέχνη"
 
@@ -665,7 +665,7 @@ msgstr "Παρουσιάστηκε ένα σφάλμα"
 msgid "Applying settings"
 msgstr "Εφαρμογή ρυθμίσεων"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 msgid "Automatic from system"
 msgstr ""
 
@@ -673,11 +673,11 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr "Χάρτης συχνοτήτων"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr "Μπάντες"
 
@@ -697,11 +697,11 @@ msgstr "Περιηγητής"
 msgid "Building Radio Browser"
 msgstr "Δημιουργία Περιηγητή Πομποδεκτών"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr "Καναδάς"
 
@@ -711,13 +711,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Αρχεία ειδώλου CHIRP"
 
@@ -725,21 +725,21 @@ msgstr "Αρχεία ειδώλου CHIRP"
 msgid "Choice Required"
 msgstr "Απαιτείται επιλογή"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Επιλέξτε κωδικό DTCS %s"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Επιλέξτε τόνο %s"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 #, fuzzy
 msgid "Choose duplex"
 msgstr "Επιλογή duplex"
@@ -749,7 +749,7 @@ msgstr "Επιλογή duplex"
 msgid "Choose the module to load from issue %i:"
 msgstr ""
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr "Πόλη"
 
@@ -779,15 +779,15 @@ msgstr "Λήψη από πομποδέκτη"
 msgid "Cloning to radio"
 msgstr "Αποστολή σε πομποδέκτη"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr "Κλείσιμο"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr "Κλείσιμο αρχείου"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -818,16 +818,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr ""
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr "Χώρα"
 
@@ -845,7 +845,7 @@ msgstr "Εισάγετε προσαρμοσμένη θύρα:"
 msgid "Custom..."
 msgstr "Προσαρμοσμένη..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 #, fuzzy
 msgid "Cut"
 msgstr "Χώρα"
@@ -866,11 +866,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "Μνήμη DV"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr ""
 
@@ -878,34 +878,34 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Λειτουργία προγραμματιστή"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 #, fuzzy
 msgid "Digital Code"
 msgstr "Ψηφιακός Κωδικός"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 #, fuzzy
 msgid "Digital Modes"
 msgstr "Ψηφιακός Κωδικός"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 #, fuzzy
 msgid "Disable reporting"
 msgstr "Αναφορές απενεργοποιημένες"
@@ -915,7 +915,7 @@ msgid "Disabled"
 msgstr ""
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr "Απόσταση"
 
@@ -932,15 +932,15 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr "Κάντε διπλό κλικ για μετονομασία της ομάδας μνημών"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr "Λήψη"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 msgid "Download from radio"
 msgstr "Λήψη Από Πομποδέκτη"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Λήψη Από Πομποδέκτη"
@@ -958,11 +958,11 @@ msgstr "Επαναφόρτωση Οδηγού"
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -970,17 +970,17 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Επεξεργασία λεπτομερειών για %i μνήμες"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Επεξεργασία λεπτομερειών για τη μνήμη %i"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 #, fuzzy
 msgid "Enable Automatic Edits"
 msgstr "Ενεργοποίηση αυτόματης επεξεργασίας"
@@ -993,11 +993,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Εισάγετε συχνότητα"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "Εισάγετε συχνότητα εκπομπής (MHz)"
 
@@ -1023,24 +1023,28 @@ msgstr "Σφάλμα εφαρμογής ρυθμίσεων"
 msgid "Error communicating with radio"
 msgstr "Σφάλμα επικοινωνίας με τον πομποδέκτη"
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr "Πειραματικός οδηγός"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "Η εξαγωγή είναι δυνατή μόνο σε αρχεία CSV"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 msgid "Export to CSV"
 msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Περισσότερα"
 
@@ -1048,7 +1052,7 @@ msgstr "Περισσότερα"
 msgid "FM Radio"
 msgstr ""
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1068,13 +1072,13 @@ msgstr "Αδυναμία φόρτωσης περιηγητή πομποδεκτ�
 msgid "Features"
 msgstr "Δυνατότητες"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Το αρχείο δεν υπάρχει: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 msgid "Files"
 msgstr "Αρχεία"
 
@@ -1086,15 +1090,15 @@ msgstr "Φίλτρο"
 msgid "Filter results with location matching this string"
 msgstr "Φιλτράρισμα αποτελεσμάτων με τοποθεσία σύμφωνη με αυτό το λεκτικό"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr "Εύρεση"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr "Εύρεση επόμενου"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 #, fuzzy
 msgid "Find..."
 msgstr "Εύρεση"
@@ -1143,7 +1147,7 @@ msgid ""
 msgstr ""
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1212,7 +1216,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1292,8 +1296,8 @@ msgstr "Συχνότητα"
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1301,20 +1305,20 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Λήψη ρυθμίσεων"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Μετάβαση σε Μνήμη"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Μετάβαση σε Μνήμη:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 #, fuzzy
 msgid "Goto..."
 msgstr "Μετάβαση σε"
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr ""
 
@@ -1326,7 +1330,7 @@ msgstr "Βοήθεια..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Αντικατάσταση μνημών;"
@@ -1336,23 +1340,23 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr ""
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 msgid "Import from file..."
 msgstr ""
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 msgid "Import not recommended"
 msgstr ""
 
@@ -1364,11 +1368,11 @@ msgstr ""
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Εισαγωγή γραμμής επάνω"
 
@@ -1376,7 +1380,7 @@ msgstr "Εισαγωγή γραμμής επάνω"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 #, fuzzy
 msgid "Interact with driver"
 msgstr "Αλληλεπίδραση με οδηγό"
@@ -1391,7 +1395,7 @@ msgstr "Αλληλεπίδραση με οδηγό"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Μη έγκυρη τιμή: %s"
@@ -1400,12 +1404,12 @@ msgstr "Μη έγκυρη τιμή: %s"
 msgid "Invalid ZIP code"
 msgstr "Μη έγκυρος ΤΚ"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Μη έγκυρη τιμή: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1423,12 +1427,12 @@ msgstr ""
 msgid "LIVE"
 msgstr "LIVE"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 msgid "Language"
 msgstr ""
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr "Γεωγραφικό πλάτος"
 
@@ -1437,7 +1441,7 @@ msgstr "Γεωγραφικό πλάτος"
 msgid "Length must be %i"
 msgstr "Το μήκος πρέπει να είναι %i"
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr "Περιορισμός Μπαντών"
 
@@ -1445,21 +1449,26 @@ msgstr "Περιορισμός Μπαντών"
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 #, fuzzy
 msgid "Limit Status"
 msgstr "Περιορισμός Μπαντών"
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Limit use"
+msgstr "Περιορισμός Μπαντών"
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "Πομποδέκτης"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Load Module..."
 msgstr "Φόρτωση Module"
@@ -1469,18 +1478,18 @@ msgstr "Φόρτωση Module"
 msgid "Load module from issue"
 msgstr "Φόρτωση Module"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Φόρτωση Module"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1503,7 +1512,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr ""
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr "Γεωγραφικό μήκος"
 
@@ -1511,7 +1520,7 @@ msgstr "Γεωγραφικό μήκος"
 msgid "Memories"
 msgstr "Μνήμες"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Η μνήμη %i δεν μπορεί να διαγραφεί"
@@ -1529,7 +1538,7 @@ msgstr "Η μνήμη πρέπει να βρίσκεται σε ομάδα γι�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Η μνήμη {num} δεν βρίσκεται στην ομάδα μνημών {bank}"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 #, fuzzy
 msgid "Mode"
 msgstr "Λειτουργία"
@@ -1538,20 +1547,20 @@ msgstr "Λειτουργία"
 msgid "Model"
 msgstr "Μοντέλο"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr "Module"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Module"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1560,27 +1569,27 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr "Βρέθηκαν περισσότερες από μία θύρες: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr ""
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr ""
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr "Διαθέσιμη νέα έκδοση"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "Καμία κενή σειρά από κάτω!"
 
@@ -1598,11 +1607,11 @@ msgstr ""
 msgid "No results"
 msgstr "Κανένα αποτέλεσμα!"
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr "Κανένα αποτέλεσμα!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr "Αριθμός"
 
@@ -1610,7 +1619,7 @@ msgstr "Αριθμός"
 msgid "Offset"
 msgstr ""
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr "Μόνο ορισμένες μπάντες"
 
@@ -1622,52 +1631,56 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr "Μόνο οι καρτέλες μνημών μπορούν να εξαχθούν"
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr "Άνοιγμα"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 msgid "Open Recent"
 msgstr "Άνοιγμα πρόσφατου"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 msgid "Open Stock Config"
 msgstr "Άνοιγμα προεπιλεγμένων ρυθμίσεων"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Άνοιγμα αρχείου"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr "Άνοιγμα αρθρώματος"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Άνοιγμα αρχείου καταγραφής αποσφαλμάτωσης"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Άνοιγμα προεπιλεγμένων ρυθμίσεων"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr "Προαιρετικό: -122.0000"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 msgid "Optional: 100"
 msgstr "Προαιρετικό: 100"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr "Προαιρετικό: 45.0000"
 
@@ -1676,7 +1689,7 @@ msgstr "Προαιρετικό: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Προαιρετικό: Επαρχία, Νοσοκομείο κλπ"
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "Αντικατάσταση μνημών;"
 
@@ -1691,31 +1704,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr ""
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 "Παρακαλούμε βεβαιωθείτε ότι έχετε κλείσει το CHIRP πριν εγκαταστήσετε την "
@@ -1747,7 +1760,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1775,7 +1788,7 @@ msgstr "Ισχύς"
 msgid "Press enter to set this in memory"
 msgstr "Πατήστε enter για καταχώρηση στη μνήμη"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr "Προεπισκόπηση εκτύπωσης"
 
@@ -1783,16 +1796,16 @@ msgstr "Προεπισκόπηση εκτύπωσης"
 msgid "Printing"
 msgstr "Εκτύπωση"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Ιδιότητες"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr "Ερώτημα %s"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Ερώτημα Πηγής"
 
@@ -1800,7 +1813,7 @@ msgstr "Ερώτημα Πηγής"
 msgid "RX DTCS"
 msgstr "DTCS Λήψης"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "Πομποδέκτης"
 
@@ -1820,11 +1833,11 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1850,11 +1863,11 @@ msgstr "Απαιτείται επανεκκίνηση"
 msgid "Refreshed memory %s"
 msgstr "Ανανεώθηκε η μνήμη %s"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Επαναφόρτωση Οδηγού"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Επαναφόρτωση Οδηγού και Αρχείου"
 
@@ -1868,30 +1881,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Αναφορές ενεργοποιημένες"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr "Απαιτείται επανεκκίνηση"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Επαναφορά %i καρτελών"
 msgstr[1] "Επαναφορά %i καρτελών"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Επαναφορά %i καρτελών"
@@ -1900,15 +1913,15 @@ msgstr "Επαναφορά %i καρτελών"
 msgid "Retrieved settings"
 msgstr "Ρυθμίσεις ανακτήθηκαν"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr "Αποθήκευση"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr "Αποθήκευση πριν το κλείσιμο;"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr "Αποθήκευση αρχείου"
 
@@ -1932,25 +1945,25 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Επιλογή χάρτη συχνοτήτων"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Select Bands"
 msgstr "Επιλογή Μπαντών"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "Επιλογή Μπαντών"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Select Modes"
 msgstr ""
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr "Επιλογή χάρτη συνοτήτων"
 
@@ -1966,57 +1979,57 @@ msgstr "Ρυθμίσεις"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr ""
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Εμφάνιση τοποθεσίας αρχείου καταγραφής αποσφαλμάτωσης"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Show image backup location"
 msgstr "Εμφάνιση τοποθεσίας αρχείου καταγραφής αποσφαλμάτωσης"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Κάποιες μνήμες δεν είναι συμβατές με αυτόν τον πομποδέκτη"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Κάποιες μνήμες δεν είναι δυνατόν να διαγραφούν"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Αντικατάσταση μνημών;"
@@ -2026,7 +2039,7 @@ msgstr "Αντικατάσταση μνημών;"
 msgid "Sorting"
 msgstr "Εκτύπωση"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr "Πολιτεία"
 
@@ -2034,7 +2047,7 @@ msgstr "Πολιτεία"
 msgid "State/Province"
 msgstr "Πολιτεία / Επαρχία"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr ""
 
@@ -2042,7 +2055,7 @@ msgstr ""
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2078,7 +2091,7 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2088,7 +2101,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Μνήμη DV"
@@ -2113,13 +2126,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2161,12 +2174,12 @@ msgstr ""
 "δυνατοτήτων!\n"
 "Σας προειδοποιήσαμε. Προχωράτε με δική σας ευθύνη!"
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
@@ -2204,7 +2217,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Τόνος"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Τύπος τόνου"
 
@@ -2241,7 +2254,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Βήμα συντονισμού"
 
@@ -2255,16 +2268,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Αδυναμία ανοίγματος του πρόχειρου"
@@ -2294,12 +2307,12 @@ msgstr ""
 msgid "Unable to set %s on this memory"
 msgstr "Πατήστε enter για καταχώρηση στη μνήμη"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Πατήστε enter για καταχώρηση στη μνήμη"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr "Ηνωμένες Πολιτείες"
 
@@ -2316,11 +2329,11 @@ msgstr ""
 msgid "Upload instructions"
 msgstr "Οδηγίες αποστολής"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 msgid "Upload to radio"
 msgstr "Αποστολή Σε Πομποδέκτη"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Αποστολή Σε Πομποδέκτη"
@@ -2330,11 +2343,11 @@ msgstr "Αποστολή Σε Πομποδέκτη"
 msgid "Uploaded memory %s"
 msgstr "Απεστάλη η μνήμη %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr "Χρήση γραμματοσειράς σταθερού πλάτους"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr "Χρήση μεγαλύτερης γραμματοσειράς"
 
@@ -2362,7 +2375,7 @@ msgstr "Η τιμή πρέπει να έιναι ακριβώς %i δεκαδι�
 msgid "Value must be zero or greater"
 msgstr "Η τιμή πρέπει να είναι μηδέν ή μεγαλύτερη"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2370,7 +2383,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Προμηθευτής"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 msgid "View"
 msgstr "Εμφάνιση"
 
@@ -2378,16 +2391,16 @@ msgstr "Εμφάνιση"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr "Προειδοποίηση"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Προειδοποίηση: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr "Καλωσήρθατε"
 
@@ -2411,11 +2424,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "bytes το καθένα"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/en_US.po
+++ b/chirp/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2011-11-29 16:07-0800\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "_Delete"
 msgstr[1] "_Delete"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "_Delete"
 msgstr[1] "_Delete"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "File is modified, save changes before closing?"
@@ -63,7 +63,7 @@ msgstr "File is modified, save changes before closing?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -621,34 +621,34 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr ""
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "CSV Files"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr ""
 
@@ -660,7 +660,7 @@ msgstr ""
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Automatic Repeater Offset"
@@ -669,11 +669,11 @@ msgstr "Automatic Repeater Offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr ""
 
@@ -693,11 +693,11 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr ""
 
@@ -707,13 +707,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -721,21 +721,21 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr ""
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr ""
 
@@ -776,15 +776,15 @@ msgstr "Download From Radio"
 msgid "Cloning to radio"
 msgstr "Upload To Radio"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -815,17 +815,17 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 #, fuzzy
 msgid "Copy"
 msgstr "_Copy"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr ""
 
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 #, fuzzy
 msgid "Cut"
 msgstr "_Cut"
@@ -860,11 +860,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr ""
 
@@ -872,35 +872,35 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 #, fuzzy
 msgid "Delete"
 msgstr "_Delete"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Developer"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr ""
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 msgid "Digital Modes"
 msgstr ""
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr ""
 
@@ -909,7 +909,7 @@ msgid "Disabled"
 msgstr ""
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr ""
 
@@ -926,16 +926,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download From Radio"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download From Radio"
@@ -953,11 +953,11 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -965,17 +965,17 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -987,11 +987,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr ""
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1017,25 +1017,29 @@ msgstr ""
 msgid "Error communicating with radio"
 msgstr ""
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Import from RFinder"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Import from RFinder"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1043,7 +1047,7 @@ msgstr ""
 msgid "FM Radio"
 msgstr ""
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1062,13 +1066,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 #, fuzzy
 msgid "Files"
 msgstr "_File"
@@ -1081,15 +1085,15 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 msgid "Find..."
 msgstr ""
 
@@ -1137,7 +1141,7 @@ msgid ""
 msgstr ""
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1206,7 +1210,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1286,8 +1290,8 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr ""
 
@@ -1295,20 +1299,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Show raw memory"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Help"
 
@@ -1320,7 +1324,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Diff raw memories"
@@ -1330,24 +1334,24 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "Import"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 #, fuzzy
 msgid "Import from file..."
 msgstr "Import from RFinder"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Import from RFinder"
@@ -1360,11 +1364,11 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr ""
 
@@ -1372,7 +1376,7 @@ msgstr ""
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1385,7 +1389,7 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1393,12 +1397,12 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1415,12 +1419,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 msgid "Language"
 msgstr ""
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr ""
 
@@ -1429,7 +1433,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr ""
 
@@ -1437,20 +1441,24 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+msgid "Limit use"
+msgstr ""
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "_Radio"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 msgid "Load Module..."
 msgstr ""
 
@@ -1458,17 +1466,17 @@ msgstr ""
 msgid "Load module from issue"
 msgstr ""
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1491,7 +1499,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr ""
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr ""
 
@@ -1500,7 +1508,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1518,7 +1526,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 msgid "Mode"
 msgstr ""
 
@@ -1526,19 +1534,19 @@ msgstr ""
 msgid "Model"
 msgstr ""
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1547,29 +1555,29 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Move D_n"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Move _Up"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr ""
 
@@ -1586,11 +1594,11 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr ""
 
@@ -1598,7 +1606,7 @@ msgstr ""
 msgid "Offset"
 msgstr ""
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr ""
 
@@ -1610,52 +1618,56 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Recent"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 msgid "Open Stock Config"
 msgstr ""
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 msgid "Open stock config directory"
 msgstr ""
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 msgid "Optional: 100"
 msgstr ""
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1663,7 +1675,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Diff raw memories"
@@ -1679,32 +1691,32 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 #, fuzzy
 msgid "Paste"
 msgstr "_Paste"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1734,7 +1746,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1762,7 +1774,7 @@ msgstr ""
 msgid "Press enter to set this in memory"
 msgstr ""
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr ""
 
@@ -1770,16 +1782,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr ""
 
@@ -1787,7 +1799,7 @@ msgstr ""
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 #, fuzzy
 msgid "Radio"
 msgstr "_Radio"
@@ -1808,11 +1820,11 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1836,11 +1848,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1854,30 +1866,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Reporting is disabled"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1885,15 +1897,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr ""
 
@@ -1917,27 +1929,27 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Select Columns"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 #, fuzzy
 msgid "Select Bands"
 msgstr "Select Columns"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "Select Columns"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Select Modes"
 msgstr "Select Columns"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1953,57 +1965,57 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Show raw memory"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Diff raw memories"
@@ -2012,7 +2024,7 @@ msgstr "Diff raw memories"
 msgid "Sorting"
 msgstr ""
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr ""
 
@@ -2020,7 +2032,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr ""
 
@@ -2028,7 +2040,7 @@ msgstr ""
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2064,7 +2076,7 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2074,7 +2086,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Show raw memory"
@@ -2099,13 +2111,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2140,12 +2152,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "_Delete"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "_Delete"
@@ -2183,7 +2195,7 @@ msgstr ""
 msgid "Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr ""
 
@@ -2219,7 +2231,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr ""
 
@@ -2233,16 +2245,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 msgid "Unable to import while the view is sorted"
 msgstr ""
 
@@ -2271,11 +2283,11 @@ msgstr ""
 msgid "Unable to set %s on this memory"
 msgstr ""
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 msgid "Unable to upload this file"
 msgstr ""
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr ""
 
@@ -2292,12 +2304,12 @@ msgstr ""
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Upload To Radio"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Upload To Radio"
@@ -2307,11 +2319,11 @@ msgstr "Upload To Radio"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr ""
 
@@ -2339,7 +2351,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2347,7 +2359,7 @@ msgstr ""
 msgid "Vendor"
 msgstr ""
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 #, fuzzy
 msgid "View"
 msgstr "_View"
@@ -2356,16 +2368,16 @@ msgstr "_View"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr ""
 
@@ -2389,11 +2401,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/es.po
+++ b/chirp/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2024-05-20 23:31-0400\n"
 "Last-Translator: MELERIX\n"
 "Language-Team: \n"
@@ -43,28 +43,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s debe estar entre %(min)i y %(max)i"
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Memoria y desplazar todo hacia arriba"
 msgstr[1] "%i Memorias y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Memoria"
 msgstr[1] "%i Memorias"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Memoria y desplazar bloque hacia arriba"
 msgstr[1] "%i Memorias y desplazar bloque hacia arriba"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s no ha sido guardado. ¿Guardar antes de cerrar?"
@@ -73,7 +73,7 @@ msgstr "%s no ha sido guardado. ¿Guardar antes de cerrar?"
 msgid "(none)"
 msgstr "(nada)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr "...y %i más"
@@ -994,7 +994,7 @@ msgstr ""
 "\n"
 "Esto podría no funcionar si enciendes la radio con el cable ya conectado"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -1002,27 +1002,27 @@ msgstr ""
 "Una nueva versión de CHIRP está disponible, ¡Por favor visita el sitio web "
 "tan pronto como sea posible para descargarla!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "Acerca de"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr "Acerca de CHIRP"
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Todo"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Todos los archivos"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Todos los formatos soportados|"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr "Aficionado"
 
@@ -1034,7 +1034,7 @@ msgstr "Ha ocurrido un error"
 msgid "Applying settings"
 msgstr "Aplicando ajustes"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 msgid "Automatic from system"
 msgstr "Automático del sistema"
 
@@ -1042,11 +1042,11 @@ msgstr "Automático del sistema"
 msgid "Available modules"
 msgstr "Módulos disponibles"
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr "Plan de banda"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr "Bandas"
 
@@ -1066,11 +1066,11 @@ msgstr "Navegador"
 msgid "Building Radio Browser"
 msgstr "Construyendo navegador de radio"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr "CHIRP debe ser reiniciado para que la nueva selección tome efecto"
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr "Canada"
 
@@ -1082,7 +1082,7 @@ msgstr ""
 "Cambiar este ajuste requiere actualizar los ajustes desde la imagen, lo cual "
 "ocurrirá ahora."
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
@@ -1090,7 +1090,7 @@ msgstr ""
 "Canales con TX y RX equivalentes %s son representados por modo de tono de "
 "\"%s\""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Archivos de imagen Chirp"
 
@@ -1098,21 +1098,21 @@ msgstr "Archivos de imagen Chirp"
 msgid "Choice Required"
 msgstr "Elección requerida"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Elegir %s código DTCS"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Elegir %s tono"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "Elegir modo cruzado"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr "Elegir Dúplex"
 
@@ -1121,7 +1121,7 @@ msgstr "Elegir Dúplex"
 msgid "Choose the module to load from issue %i:"
 msgstr "Elige el módulo para cargar desde problema %i:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr "Ciudad"
 
@@ -1158,15 +1158,15 @@ msgstr "Clonando desde radio"
 msgid "Cloning to radio"
 msgstr "Clonando a radio"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr "Cerrar"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr "Cerrar archivo"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1201,16 +1201,16 @@ msgstr ""
 "Conecta tu cable de interfaz al Puerto de PC en la\n"
 "espalda de la unidad 'TX/RX'. NO el Puerto Com en la cabeza.\n"
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr "Convertir a FM"
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr "País"
 
@@ -1226,7 +1226,7 @@ msgstr "Puerto personalizado"
 msgid "Custom..."
 msgstr "Personalizado..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Cortar"
 
@@ -1246,11 +1246,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Decodificación DTMF"
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "Memoria DV"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr "Peligro adelante"
 
@@ -1258,34 +1258,34 @@ msgstr "Peligro adelante"
 msgid "Dec"
 msgstr "Decimal"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Modo desarrollador"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Estado de desarrollador ahora está %s. CHIRP debe ser reiniciado para que "
 "tome efecto"
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Diferenciar memorias en bruto"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Código digital"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 msgid "Digital Modes"
 msgstr "Modos digitales"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr "Deshabilitar reportes"
 
@@ -1294,7 +1294,7 @@ msgid "Disabled"
 msgstr "Desahbilitado"
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr "Distancia"
 
@@ -1311,15 +1311,15 @@ msgstr "¿Aceptas el riesgo?"
 msgid "Double-click to change bank name"
 msgstr "Doble clic para cambiar nombre de banco"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr "Descargar"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 msgid "Download from radio"
 msgstr "Descargar desde radio"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "Descargar desde radio..."
 
@@ -1335,11 +1335,11 @@ msgstr "Controlador"
 msgid "Driver information"
 msgstr "Información del controlador"
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr "Mensajes del controlador"
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 "Los repetidores digitales de modo dual que soportan análogo se mostrarán "
@@ -1349,17 +1349,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Dúplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Editar detalles para %i memorias"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editar detalles para memoria %i"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Habilitar ediciones automáticas"
 
@@ -1371,11 +1371,11 @@ msgstr "Habilitado"
 msgid "Enter Frequency"
 msgstr "Ingresar frecuencia"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr "Ingresar desplazamiento (MHz)"
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "Ingresar frecuencia TX (MHz)"
 
@@ -1401,23 +1401,27 @@ msgstr "Error aplicando ajustes"
 msgid "Error communicating with radio"
 msgstr "Error comunicándose con la radio"
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr "Controlador experimental"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "Exportar solo puede escribir archivos CSV"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 msgid "Export to CSV"
 msgstr "Exportar a CSV"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 msgid "Export to CSV..."
 msgstr "Exportar a CSV..."
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Extra"
 
@@ -1425,7 +1429,7 @@ msgstr "Extra"
 msgid "FM Radio"
 msgstr "Radio FM"
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1447,13 +1451,13 @@ msgstr "Fallo al analizar el resultado"
 msgid "Features"
 msgstr "Caracteristicas"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr "El archivo no existe: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 msgid "Files"
 msgstr "Archivos"
 
@@ -1465,15 +1469,15 @@ msgstr "Filtrar"
 msgid "Filter results with location matching this string"
 msgstr "Filtrar resultados con ubicación coincidiendo esta cadena"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr "Buscar"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr "Buscar siguiente"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 msgid "Find..."
 msgstr "Buscar..."
 
@@ -1543,7 +1547,7 @@ msgstr ""
 "    audio del lado derecho!\n"
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1650,7 +1654,7 @@ msgstr ""
 "    audio del lado derecho!\n"
 "6 - Apaga y enciende la radio para salir del modo de clonación\n"
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1765,8 +1769,8 @@ msgstr "Frecuencia"
 msgid "Frequency granularity in kHz"
 msgstr "Granularidad de frecuencia en kHz"
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1774,19 +1778,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Obteniendo ajustes"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Ir a memoria"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Ir a memoria:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "Ir a..."
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Ayuda"
 
@@ -1798,7 +1802,7 @@ msgstr "Ayúdame..."
 msgid "Hex"
 msgstr "Hexadecimal"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "Ocultar memorias vacías"
 
@@ -1807,24 +1811,24 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr "Comentario legible para humanos (no almacenado en la radio)"
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Si se establece, ordenar los resultados por distancia desde estas coordenadas"
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "Importar"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 msgid "Import from file..."
 msgstr "Importar desde archivo..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr "Importar mensajes"
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 msgid "Import not recommended"
 msgstr "Importación no recomendada"
 
@@ -1836,11 +1840,11 @@ msgstr "Índice"
 msgid "Info"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Insertar fila arriba"
 
@@ -1848,7 +1852,7 @@ msgstr "Insertar fila arriba"
 msgid "Install desktop icon?"
 msgstr "¿Instalar icono de escritorio?"
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr "Interactuar con controlador"
 
@@ -1861,7 +1865,7 @@ msgstr "Error interno del controlador"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s inválido (usa grados decimales)"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 msgid "Invalid Entry"
 msgstr "Entrada inválida"
 
@@ -1869,12 +1873,12 @@ msgstr "Entrada inválida"
 msgid "Invalid ZIP code"
 msgstr "Código postal inválido"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Edición inválida: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr "Archivo de módulo inválido o no soportado"
 
@@ -1891,12 +1895,12 @@ msgstr "Número de problema:"
 msgid "LIVE"
 msgstr "EN VIVO"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 msgid "Language"
 msgstr "Lenguaje"
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr "Latitud"
 
@@ -1905,7 +1909,7 @@ msgstr "Latitud"
 msgid "Length must be %i"
 msgstr "Largo debe ser %i"
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr "Bandas límite"
 
@@ -1913,19 +1917,24 @@ msgstr "Bandas límite"
 msgid "Limit Modes"
 msgstr "Modos límite"
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr "Estado límite"
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Limitar resultados a esta distancia (km) desde coordenadas"
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Limit use"
+msgstr "Estado límite"
+
+#: ../wxui/main.py:1566
 msgid "Live Radio"
 msgstr "Radio en vivo"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 msgid "Load Module..."
 msgstr "Cargar módulo..."
 
@@ -1933,11 +1942,11 @@ msgstr "Cargar módulo..."
 msgid "Load module from issue"
 msgstr "Cargar módulo desde problema"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 msgid "Load module from issue..."
 msgstr "Cargar módulo desde problema..."
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
@@ -1946,7 +1955,7 @@ msgstr ""
 "que se indique lo contrario) cerrar todas las pestañas antes de cargar un "
 "módulo."
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1975,7 +1984,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr "Cadena del logotipo 2 (12 caracteres)"
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr "Longitud"
 
@@ -1983,7 +1992,7 @@ msgstr "Longitud"
 msgid "Memories"
 msgstr "Memorias"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoria %i no es borrable"
@@ -2001,7 +2010,7 @@ msgstr "La memoria debe estar en un banco para ser editada"
 msgid "Memory {num} not in bank {bank}"
 msgstr "La memoria {num} no está en banco {bank}"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 msgid "Mode"
 msgstr "Modo"
 
@@ -2009,19 +2018,19 @@ msgstr "Modo"
 msgid "Model"
 msgstr "Modelo"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Modes"
 msgstr "Modos"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr "Módulo"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr "Módulo cargado"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr "Módulo cargado exitosamente"
 
@@ -2030,29 +2039,29 @@ msgstr "Módulo cargado exitosamente"
 msgid "More than one port found: %s"
 msgstr "Más de un puerto encontrado: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "Mover abajo"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "Mover arriba"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 "Las operaciones de movimiento están deshabilitadas mientras la vista es "
 "ordenada"
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr "Nueva versión disponible"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "¡No hay filas vacías debajo!"
 
@@ -2069,11 +2078,11 @@ msgstr "No se encontraron módulos en problema %i"
 msgid "No results"
 msgstr "No hay resultados"
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr "¡No hay resultados!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr "Numero"
 
@@ -2081,7 +2090,7 @@ msgstr "Numero"
 msgid "Offset"
 msgstr "Desplazamiento"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr "Solo ciertas bandas"
 
@@ -2093,51 +2102,55 @@ msgstr "Solo ciertos modos"
 msgid "Only memory tabs may be exported"
 msgstr "Solo pestañas de memorias pueden ser exportadas"
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr "Sólo repetidores funcionando"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr "Abrir"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 msgid "Open Recent"
 msgstr "Abrir reciente"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 msgid "Open Stock Config"
 msgstr "Abrir configuración original"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Abrir un archivo"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr "Abrir un módulo"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Abrir registro de depuración"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr "Abrir en nueva ventana"
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 msgid "Open stock config directory"
 msgstr "Abrir directorio de configuración original"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr "Opcional: -122.0000"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 msgid "Optional: 100"
 msgstr "Opcional: 100"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr "Opcional: 45.0000"
 
@@ -2145,7 +2158,7 @@ msgstr "Opcional: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcional: Condado, Hospital, etc."
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "¿Sobrescribir memorias?"
 
@@ -2163,31 +2176,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Analizando"
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Las memorias pegadas sobrescribirán %s memorias existentes"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Las memorias pegadas sobrescribirán memorias %s"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Las memorias pegadas sobrescribirán la memoria %s"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria pegada sobrescribirá la memoria %s"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 "¡Por favor asegúrate de salir de CHIRP antes de instalar la nueva versión!"
@@ -2236,7 +2249,7 @@ msgstr ""
 "4 - Entonces presiona el botón \"A\" en tu radio para iniciar la clonación.\n"
 "    (Al final la radio emitirá un pitido)\n"
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2269,7 +2282,7 @@ msgstr "Potencia"
 msgid "Press enter to set this in memory"
 msgstr "Presiona enter para configurar esto en memoria"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr "Previsualización de impresión"
 
@@ -2277,16 +2290,16 @@ msgstr "Previsualización de impresión"
 msgid "Printing"
 msgstr "Imprimiendo"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Propiedades"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr "Consulta %s"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Consultar fuente"
 
@@ -2294,7 +2307,7 @@ msgstr "Consultar fuente"
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "Radio"
 
@@ -2317,13 +2330,13 @@ msgstr ""
 "el modelo seleccionado no es de EE.UU pero la radio es una de EE.UU. Por "
 "favor elije el modelo correcto e intenta de nuevo."
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 "RadioReference Canadá requiere un inicio de sesión antes de que puedas "
 "consultar"
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -2350,11 +2363,11 @@ msgstr "Actualización requerida"
 msgid "Refreshed memory %s"
 msgstr "Memoria actualizada %s"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Recargar controlador"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Recargar controlador y archivo"
 
@@ -2370,11 +2383,11 @@ msgstr ""
 "RepeaterBook es el directorio GRATUITO de repetidores,\n"
 "mundial, de Radio Aficionados más completo."
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Reportes habilitados"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2384,18 +2397,18 @@ msgstr ""
 "plataformas de SO gastar nuestros limitados esfuerzos. Apreciamos mucho si "
 "lo dejas habilitado. ¿Realmente deshabilitar reportes?"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr "Reinicio requerido"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Restaurar %i pestaña"
 msgstr[1] "Restaurar %i pestañas"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr "Restaurar pestañas al iniciar"
 
@@ -2403,15 +2416,15 @@ msgstr "Restaurar pestañas al iniciar"
 msgid "Retrieved settings"
 msgstr "Ajustes recuperados"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr "Guardar"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr "¿Guardar antes de cerrar?"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr "Guardar archivo"
 
@@ -2435,23 +2448,23 @@ msgstr "Codificador"
 msgid "Security Risk"
 msgstr "Riesgo de seguridad"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "Seleccionar plan de banda..."
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Select Bands"
 msgstr "Seleccionar bandas"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 msgid "Select Language"
 msgstr "Seleccionar lenguaje"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Select Modes"
 msgstr "Seleccionar modos"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr "Seleccionar plan de banda"
 
@@ -2469,56 +2482,56 @@ msgstr ""
 "Cantidad de desplazamiento (o frecuencia de transmisión) controlada por "
 "dúplex"
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Mostrar memoria en bruto"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Mostrar ubicación del registro de depuración"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "Mostrar campos adicionales"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 msgid "Show image backup location"
 msgstr "Mostrar ubicación de la copia de respaldo de la imagen"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Algunas memorias son incompatibles con esta radio"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Algunas memorias no son borrables"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Ordenar %i memoria"
 msgstr[1] "Ordenar %i memorias"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Ordenar %i memoria de forma ascendente"
 msgstr[1] "Ordenar %i memorias de forma ascendente"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Ordenar %i memoria de forma descendente"
 msgstr[1] "Ordenar %i memorias de forma descendente"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "Ordenar por columna:"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "Ordenar memorias"
 
@@ -2526,7 +2539,7 @@ msgstr "Ordenar memorias"
 msgid "Sorting"
 msgstr "Ordenando"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr "Estado"
 
@@ -2534,7 +2547,7 @@ msgstr "Estado"
 msgid "State/Province"
 msgstr "Estado/Provincia"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr "Éxito"
 
@@ -2542,7 +2555,7 @@ msgstr "Éxito"
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr "Polaridad TX-RX CTCS (normal o invertida)"
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr "La red mundial DMR-MARC"
 
@@ -2600,7 +2613,7 @@ msgstr ""
 "recomienda que no cargues este módulo ya que podría poner un riesgo de "
 "seguridad. ¿Proceder de todos modos?"
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2616,7 +2629,7 @@ msgstr ""
 "abrir este archivo para copiar/pegar memorias a través de este, o proceder "
 "con la importación?"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "Esta memoria"
 
@@ -2649,7 +2662,7 @@ msgstr ""
 "descargues una imagen nueva de tu radio y utilizarla en adelante para la "
 "mejor seguridad y compatibilidad."
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
@@ -2657,7 +2670,7 @@ msgstr ""
 "Este es un modo de radio en vivo, lo que significa que los cambios son "
 "enviados a la radio en tiempo real cuando los haces. ¡Cargar no es necesario!"
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2710,11 +2723,11 @@ msgstr ""
 "¡También por favor envía en solicitudes de errores y mejoras!\n"
 "Has sido advertido. ¡Procede bajo tu propio riesgo!"
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "Esta memoria y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "Esta memoria y desplazar bloque hacia arriba"
 
@@ -2766,7 +2779,7 @@ msgstr "Esto va a cargar un módulo desde un problema del sitio web"
 msgid "Tone"
 msgstr "Tono"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Modo de tono"
 
@@ -2806,7 +2819,7 @@ msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 "Tono de transmisión/recepción para el modo TSQL, sino, tono de recepción"
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Paso de sintonización"
 
@@ -2822,16 +2835,16 @@ msgstr ""
 "No se puede determinar puerto para tu cable. Comprueba tus controladores y "
 "conexiones."
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr "No se puede editar memoria antes de que la radio este cargada"
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "No se puede buscar la configuración original %r"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 msgid "Unable to import while the view is sorted"
 msgstr "No se puede importar mientras la vista es ordenada"
 
@@ -2863,11 +2876,11 @@ msgstr "No se puede revelar %s en este sistema"
 msgid "Unable to set %s on this memory"
 msgstr "No se puede establecer %s en esta memoria"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 msgid "Unable to upload this file"
 msgstr "No se puede cargar este archivo"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr "Estados Unidos"
 
@@ -2884,11 +2897,11 @@ msgstr "Modelo no soportado %r"
 msgid "Upload instructions"
 msgstr "Cargar instrucciones"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 msgid "Upload to radio"
 msgstr "Cargar a radio"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "Cargar a radio..."
 
@@ -2897,11 +2910,11 @@ msgstr "Cargar a radio..."
 msgid "Uploaded memory %s"
 msgstr "Memoria cargada %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr "Usar fuente de ancho fijo"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr "Usar fuente más grande"
 
@@ -2929,7 +2942,7 @@ msgstr "Valor debe ser exactamente %i dígitos decimales"
 msgid "Value must be zero or greater"
 msgstr "Valor debe ser cero o superior"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "Valores"
 
@@ -2937,7 +2950,7 @@ msgstr "Valores"
 msgid "Vendor"
 msgstr "Vendedor"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 msgid "View"
 msgstr "Ver"
 
@@ -2945,16 +2958,16 @@ msgstr "Ver"
 msgid "WARNING!"
 msgstr "¡ADVERTENCIA!"
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Advertencia: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr "Bienvenido"
 
@@ -2978,11 +2991,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "bytes cada"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr "habilitado"
 

--- a/chirp/locale/fr.po
+++ b/chirp/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-22 16:01-0400\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2024-05-22 16:39-0400\n"
 "Last-Translator: Alexandre J. Raymond <alexandre.j.raymond@gmail.com>\n"
 "Language-Team: French\n"
@@ -62,7 +62,7 @@ msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Mémoire et décaler le bloc vers le haut"
 msgstr[1] "%i Mémoires et décaler le bloc vers le haut"
 
-#: ../wxui/main.py:1369
+#: ../wxui/main.py:1373
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s n'a pas été enregistré. Enregistrer avant de fermer ?"
@@ -994,7 +994,7 @@ msgstr ""
 "Cela peut ne pas fonctionner si vous allumez la radio avec le câble déjà "
 "branché"
 
-#: ../wxui/main.py:1859
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -1002,27 +1002,27 @@ msgstr ""
 "Une nouvelle version de CHIRP est disponible. Visitez le site internet dès "
 "que possible pour la télécharger!"
 
-#: ../wxui/main.py:915
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "À propos"
 
-#: ../wxui/main.py:1718
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr "À propos de CHIRP"
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Tout"
 
-#: ../wxui/main.py:1199
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Tous les fichiers"
 
-#: ../wxui/main.py:1210
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Tous les formats supportés|"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr "Amateur"
 
@@ -1034,7 +1034,7 @@ msgstr "Une erreur s'est produite"
 msgid "Applying settings"
 msgstr "Application des préférences"
 
-#: ../wxui/main.py:1465
+#: ../wxui/main.py:1469
 msgid "Automatic from system"
 msgstr "Selon le système"
 
@@ -1042,11 +1042,11 @@ msgstr "Selon le système"
 msgid "Available modules"
 msgstr "Modules disponibles"
 
-#: ../wxui/main.py:1802
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr "Plan de fréquences"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr "Bandes"
 
@@ -1066,12 +1066,12 @@ msgstr "Navigateur"
 msgid "Building Radio Browser"
 msgstr "Établissement navigateur radio"
 
-#: ../wxui/main.py:1494
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 "CHIRP doit être redémarré pour que la nouvelle sélection soit prise en compte"
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr "Canada"
 
@@ -1091,7 +1091,7 @@ msgstr ""
 "Les canaux avec TX et RX équivalents %s sont représentés par le mode de "
 "tonalité de \"%s\""
 
-#: ../wxui/main.py:1198
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Fichiers image Chirp"
 
@@ -1122,7 +1122,7 @@ msgstr "Choisir duplex"
 msgid "Choose the module to load from issue %i:"
 msgstr "Choisir le module à charger pour le problème %i:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr "Ville"
 
@@ -1150,19 +1150,19 @@ msgstr "Clonage terminé, vérification des octets erronés"
 msgid "Cloning"
 msgstr "Clonage"
 
-#: ../drivers/bj9900.py:134 ../drivers/ft817.py:342 ../drivers/ft450d.py:508
+#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
 msgid "Cloning from radio"
 msgstr "Téléchargement depuis la radio - Lire"
 
-#: ../drivers/bj9900.py:166 ../drivers/ft817.py:380 ../drivers/ft450d.py:537
+#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
 msgid "Cloning to radio"
 msgstr "Téléchargement vers la radio - Écrire"
 
-#: ../wxui/main.py:998
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr "Fermer"
 
-#: ../wxui/main.py:999
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr "Fermer fichier"
 
@@ -1201,7 +1201,7 @@ msgstr ""
 "Connectez votre câble d'interface au port PC à l'arrière\n"
 "de l'unité 'TX/RX'. PAS au port de communication de la façade.\n"
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr "Convertir en FM"
 
@@ -1209,8 +1209,8 @@ msgstr "Convertir en FM"
 msgid "Copy"
 msgstr "Copier"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr "Pays"
 
@@ -1250,7 +1250,7 @@ msgstr "Décodage DTMF"
 msgid "DV Memory"
 msgstr "Mémoire DV"
 
-#: ../wxui/main.py:1732
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr "Danger"
 
@@ -1262,18 +1262,18 @@ msgstr "Dec"
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../wxui/main.py:920
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Mode développeur"
 
-#: ../wxui/main.py:1738
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Le mode développement est maintenant %s. CHIRP doit être redémarré pour que "
 "ceci prenne effet"
 
-#: ../wxui/developer.py:88 ../wxui/memedit.py:1817
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Comparaison mémoires brutes"
 
@@ -1281,11 +1281,11 @@ msgstr "Comparaison mémoires brutes"
 msgid "Digital Code"
 msgstr "Code numérique"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 msgid "Digital Modes"
 msgstr "Modes numériques"
 
-#: ../wxui/main.py:1750
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr "Désactiver le rapport d'utilisation"
 
@@ -1294,7 +1294,7 @@ msgid "Disabled"
 msgstr "Désactivé"
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr "Distance"
 
@@ -1311,15 +1311,15 @@ msgstr "Acceptez-vous les risques?"
 msgid "Double-click to change bank name"
 msgstr "Double-cliquer pour modifier le nom de la banque"
 
-#: ../wxui/main.py:1000
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr "Télécharger"
 
-#: ../wxui/main.py:1001
+#: ../wxui/main.py:1005
 msgid "Download from radio"
 msgstr "Télécharger depuis la radio"
 
-#: ../wxui/main.py:827
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "Télécharger depuis la radio..."
 
@@ -1335,11 +1335,11 @@ msgstr "Pilote"
 msgid "Driver information"
 msgstr "Informations sur les pilotes"
 
-#: ../wxui/main.py:544
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr "Messages du pilote"
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 "Les répéteurs numériques bimodes supportant l'analogique seront présentés "
@@ -1359,7 +1359,7 @@ msgstr "Éditer les details pour %i mémoires"
 msgid "Edit details for memory %i"
 msgstr "Editer les details pour la mémoire %i"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Activer l'édition automatique"
 
@@ -1401,6 +1401,10 @@ msgstr "Erreur lors de l'application des préférences"
 msgid "Error communicating with radio"
 msgstr "Erreur de communication avec la radio"
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr "Pilote expérimental"
@@ -1409,11 +1413,11 @@ msgstr "Pilote expérimental"
 msgid "Export can only write CSV files"
 msgstr "L'exportation ne peut écrire que des fichiers CSV"
 
-#: ../wxui/main.py:1354
+#: ../wxui/main.py:1358
 msgid "Export to CSV"
 msgstr "Exporter vers un fichier CSV"
 
-#: ../wxui/main.py:702
+#: ../wxui/main.py:706
 msgid "Export to CSV..."
 msgstr "Exporter vers un fichier CSV..."
 
@@ -1425,7 +1429,7 @@ msgstr "Extra"
 msgid "FM Radio"
 msgstr "Radio FM"
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1447,13 +1451,13 @@ msgstr "Échec d'analyse des résultats"
 msgid "Features"
 msgstr "Caracteristiques"
 
-#: ../wxui/main.py:549
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Fichier inexistant: %s"
 
-#: ../wxui/main.py:1202 ../wxui/main.py:1282 ../wxui/main.py:1292
-#: ../wxui/main.py:1350 ../wxui/main.py:1684 ../wxui/main.py:1685
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 msgid "Files"
 msgstr "Fichiers"
 
@@ -1467,15 +1471,15 @@ msgstr ""
 "Filtrer les résultats avec emplacement correspondant a cette chaine de "
 "caractères"
 
-#: ../wxui/main.py:1424
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr "Rechercher"
 
-#: ../wxui/main.py:770
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr "Rechercher le suivant"
 
-#: ../wxui/main.py:756
+#: ../wxui/main.py:760
 msgid "Find..."
 msgstr "Rechercher..."
 
@@ -1544,11 +1548,11 @@ msgstr ""
 "5 - Déconnectez votre câble d'interface! Autrement il n'y aura\n"
 "    pas d'audio du côté droit!\n"
 
-#: ../drivers/uv5x3.py:418 ../drivers/tdxone_tdq8a.py:455
-#: ../drivers/gmrsuv1.py:392 ../drivers/bf_t1.py:483 ../drivers/gmrsv2.py:364
-#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/mursv1.py:342
-#: ../drivers/uv6r.py:340 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1653,7 +1657,7 @@ msgstr ""
 "    pas d'audio du côté droit!\n"
 "6 - Éteignez puis rallumez votre radio pour sortir du mode de clonage\n"
 
-#: ../drivers/bf_t1.py:489 ../drivers/btech.py:694
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1696,7 +1700,7 @@ msgstr ""
 "3 - Allumez votre radio\n"
 "4 - Cliquez sur OK pour démarrer\n"
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1724,11 +1728,11 @@ msgstr ""
 "3 - Allumez votre radio\n"
 "4 - Téléchargez les données depuis votre radio\n"
 
-#: ../drivers/uv5x3.py:424 ../drivers/tdxone_tdq8a.py:461
-#: ../drivers/gmrsuv1.py:398 ../drivers/gmrsv2.py:370 ../drivers/lt725uv.py:503
-#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/mursv1.py:348
-#: ../drivers/uv6r.py:346 ../drivers/vgc.py:605
-#: ../drivers/baofeng_wp970i.py:334
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:447
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1769,8 +1773,8 @@ msgstr "Fréquence"
 msgid "Frequency granularity in kHz"
 msgstr "Granularité fréquence en kHz"
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1790,7 +1794,7 @@ msgstr "Aller à la mémoire:"
 msgid "Goto..."
 msgstr "Aller..."
 
-#: ../wxui/main.py:966
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Aide"
 
@@ -1811,24 +1815,24 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr "Commentaire pour humains (pas stocké dans la radio)"
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Si sélectionné, trier les résultats selon la distance depuis ces coordonnées"
 
-#: ../wxui/main.py:1337
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "Importer"
 
-#: ../wxui/main.py:696
+#: ../wxui/main.py:700
 msgid "Import from file..."
 msgstr "Importer depuis un fichier..."
 
-#: ../wxui/main.py:1341
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr "Importer les messages"
 
-#: ../wxui/main.py:1335
+#: ../wxui/main.py:1339
 msgid "Import not recommended"
 msgstr "Import non recommandé"
 
@@ -1852,7 +1856,7 @@ msgstr "Insérer une ligne avant"
 msgid "Install desktop icon?"
 msgstr "Installer une icône sur le bureau?"
 
-#: ../wxui/main.py:904
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr "Intéragir avec le pilote"
 
@@ -1865,7 +1869,7 @@ msgstr "Erreur interne du pilote"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Invalide %(value)s (utiliser degrés decimaux)"
 
-#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 msgid "Invalid Entry"
 msgstr "Entrée invalide"
 
@@ -1878,7 +1882,7 @@ msgstr "Code postal invalide"
 msgid "Invalid edit: %s"
 msgstr "Édition invalide: %s"
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr "Fichier module invalide ou pas supporté"
 
@@ -1895,12 +1899,12 @@ msgstr "Problème numero:"
 msgid "LIVE"
 msgstr "LIVE"
 
-#: ../wxui/main.py:813 ../wxui/main.py:1479
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 msgid "Language"
 msgstr "Changer la langue"
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr "Latitude"
 
@@ -1909,7 +1913,7 @@ msgstr "Latitude"
 msgid "Length must be %i"
 msgstr "La longueur doit être %i"
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr "Limiter les bandes"
 
@@ -1917,19 +1921,24 @@ msgstr "Limiter les bandes"
 msgid "Limit Modes"
 msgstr "Limiter les modes"
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr "Limiter les états"
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Limiter les résultats à cette distance (km) depuis les coordonnées"
 
-#: ../wxui/main.py:1562
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Limit use"
+msgstr "Limiter les états"
+
+#: ../wxui/main.py:1566
 msgid "Live Radio"
 msgstr "Radio en direct"
 
-#: ../wxui/main.py:708
+#: ../wxui/main.py:712
 msgid "Load Module..."
 msgstr "Chargement module..."
 
@@ -1937,11 +1946,11 @@ msgstr "Chargement module..."
 msgid "Load module from issue"
 msgstr "Chargement module pour un problème"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:961
 msgid "Load module from issue..."
 msgstr "Chargement module pour un problème..."
 
-#: ../wxui/main.py:1777
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
@@ -1950,7 +1959,7 @@ msgstr ""
 "(sauf instructions contraires) de fermer tous les onglets avant de charger "
 "un module."
 
-#: ../wxui/main.py:1688
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1979,7 +1988,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr "Texte logo 2 (12 caractères)"
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr "Longitude"
 
@@ -2005,7 +2014,7 @@ msgstr "La mémoire doit être dans une banque pour être éditée"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Mémoire {num} pas dans la banque {bank}"
 
-#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 msgid "Mode"
 msgstr "Mode"
 
@@ -2013,19 +2022,19 @@ msgstr "Mode"
 msgid "Model"
 msgstr "Modèle"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Modes"
 msgstr "Modes"
 
-#: ../wxui/main.py:1685
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr "Module"
 
-#: ../wxui/main.py:1657
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr "Module chargé"
 
-#: ../wxui/main.py:1788
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr "Module chargé avec succès"
 
@@ -2046,11 +2055,11 @@ msgstr "Monter"
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Les déplacements sont désactivés lorsque la vue est triée"
 
-#: ../wxui/main.py:654
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
-#: ../wxui/main.py:1861
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr "Nouvelle version disponible"
 
@@ -2071,11 +2080,11 @@ msgstr "Aucun module trouvé pour le problème %i"
 msgid "No results"
 msgstr "Aucun résultat"
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr "Aucun résultat!"
 
-#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr "Nombre"
 
@@ -2083,7 +2092,7 @@ msgstr "Nombre"
 msgid "Offset"
 msgstr "Décalage"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr "Seulement certaines bandes"
 
@@ -2095,51 +2104,55 @@ msgstr "Seulement certains modes"
 msgid "Only memory tabs may be exported"
 msgstr "Seuls les onglets des mémoires peuvent être exportés"
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr "Uniquement les répéteurs en fonctionnement"
 
-#: ../wxui/main.py:994 ../wxui/main.py:1337
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr "Ouvrir"
 
-#: ../wxui/main.py:683
+#: ../wxui/main.py:687
 msgid "Open Recent"
 msgstr "Ouvrir récent"
 
-#: ../wxui/main.py:665
+#: ../wxui/main.py:669
 msgid "Open Stock Config"
 msgstr "Ouvrir base de données"
 
-#: ../wxui/main.py:995 ../wxui/main.py:1213
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Ouvrir un fichier"
 
-#: ../wxui/main.py:1703
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr "Ouvrir un module"
 
-#: ../wxui/main.py:941
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Ouvrir le fichier de débogage"
 
-#: ../wxui/main.py:519
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr "Ouvrir dans une nouvelle fenêtre"
 
-#: ../wxui/main.py:612
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 msgid "Open stock config directory"
 msgstr "Ouvrir le repertoire de base de données"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr "Optionnel: -122.0000"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 msgid "Optional: 100"
 msgstr "Optionnel: 100"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr "Optionnel: 45.0000"
 
@@ -2189,7 +2202,7 @@ msgstr "Les mémoires collées vont écraser la mémoire %s"
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La mémoire collee va écraser la mémoire %s"
 
-#: ../wxui/main.py:1865
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Soyez certain de quitter CHIRP avant d'installer la nouvelle version!"
 
@@ -2238,7 +2251,7 @@ msgstr ""
 "clonage\n"
 "    (À la fin la radio va sonner)\n"
 
-#: ../wxui/main.py:1726
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2271,7 +2284,7 @@ msgstr "Puissance"
 msgid "Press enter to set this in memory"
 msgstr "Appuyez sur entrée pour inscrire ceci en mémoire"
 
-#: ../wxui/main.py:719
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr "Apercu avant impression"
 
@@ -2283,12 +2296,12 @@ msgstr "Impression"
 msgid "Properties"
 msgstr "Propriétés"
 
-#: ../wxui/main.py:1816
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr "Interroger %s"
 
-#: ../wxui/main.py:841
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Interroger source web"
 
@@ -2296,11 +2309,11 @@ msgstr "Interroger source web"
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:965
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "Radio"
 
-#: ../drivers/ft60.py:85 ../drivers/ft817.py:407 ../drivers/ft450d.py:569
+#: ../drivers/ft60.py:85 ../drivers/ft450d.py:569 ../drivers/ft817.py:407
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr "La radio n'a pas accusé reception du bloc %i"
@@ -2319,11 +2332,11 @@ msgstr ""
 "quand le modèle sélectionné n'est pas US mais que la radio est US. "
 "Sélectionnez le bon modèle et réessayez."
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr "RadioReference Canada nécessite une connexion avant une requête"
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -2350,11 +2363,11 @@ msgstr "Rafraîchissement nécessaire"
 msgid "Refreshed memory %s"
 msgstr "Mémoire %s rafraîchie"
 
-#: ../wxui/main.py:881
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Recharger pilote"
 
-#: ../wxui/main.py:890
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Recharger pilote et fichier"
 
@@ -2370,11 +2383,11 @@ msgstr ""
 "RepeaterBook est l'annuaire GRATUIT de radio amateur\n"
 "le plus complet du monde."
 
-#: ../wxui/main.py:929
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Rapport d'utilisation activé"
 
-#: ../wxui/main.py:1746
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2385,18 +2398,18 @@ msgstr ""
 "là. Nous apprécierions vraiment que vous le laissiez actif. Êtes-vous "
 "certain de vouloir désactiver le rapport d'utilisation?"
 
-#: ../wxui/main.py:1496 ../wxui/main.py:1740
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr "Redémarrage nécessaire"
 
-#: ../wxui/main.py:677
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Restaurer %i onglets"
 msgstr[1] "Restaurer %i onglets"
 
-#: ../wxui/main.py:806
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr "Restaurer les onglets au démarrage"
 
@@ -2404,15 +2417,15 @@ msgstr "Restaurer les onglets au démarrage"
 msgid "Retrieved settings"
 msgstr "Préférences récupérées"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr "Enregistrer"
 
-#: ../wxui/main.py:1371
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr "Enregistrer avant de fermer?"
 
-#: ../wxui/main.py:997 ../wxui/main.py:1296
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr "Enregistrer fichier"
 
@@ -2436,23 +2449,23 @@ msgstr "Brouilleur"
 msgid "Security Risk"
 msgstr "Risque de sécurité"
 
-#: ../wxui/main.py:871
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "Choix d'un plan de fréquences..."
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Select Bands"
 msgstr "Choisir bandes"
 
-#: ../wxui/main.py:1479
+#: ../wxui/main.py:1483
 msgid "Select Language"
 msgstr "Choisir langue"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Select Modes"
 msgstr "Choisir modes"
 
-#: ../wxui/main.py:1801
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr "Choisir un plan de fréquences"
 
@@ -2468,11 +2481,11 @@ msgstr "Préférences"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Décalage (ou fréquence de transmission) contrôlée par duplex"
 
-#: ../wxui/developer.py:91 ../wxui/memedit.py:1810
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Afficher les données de mémoires brutes"
 
-#: ../wxui/main.py:947
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Montrer l'emplacement du fichier de débogage"
 
@@ -2480,7 +2493,7 @@ msgstr "Montrer l'emplacement du fichier de débogage"
 msgid "Show extra fields"
 msgstr "Montrer les champs supplémentaires"
 
-#: ../wxui/main.py:952
+#: ../wxui/main.py:956
 msgid "Show image backup location"
 msgstr "Montrer l'emplacement du fichier de débogage"
 
@@ -2525,7 +2538,7 @@ msgstr "Tri des mémoires"
 msgid "Sorting"
 msgstr "Tri"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr "État"
 
@@ -2533,7 +2546,7 @@ msgstr "État"
 msgid "State/Province"
 msgstr "État/Province"
 
-#: ../wxui/main.py:1789
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr "Réussi"
 
@@ -2541,7 +2554,7 @@ msgstr "Réussi"
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr "Polarité DTCS TX-RX (normale ou inversée)"
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr "Le réseau mondial DMR-MARC"
 
@@ -2601,7 +2614,7 @@ msgstr ""
 "comporter un risque de sécurité, il est recommandé de ne pas importer ce "
 "module. Importer tout de même?"
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2650,7 +2663,7 @@ msgstr ""
 "est recommandé de télécharger une nouvelle image fraîche depuis la radio et "
 "de l'utiliser à l'avenir pour une meilleure sécurité et compatibilité."
 
-#: ../wxui/main.py:1559
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
@@ -2659,7 +2672,7 @@ msgstr ""
 "sont envoyés à la radio en temps réel dès qu'ils sont faits. Un "
 "téléchargement vers la radio n'est pas nécessaire!"
 
-#: ../wxui/main.py:1565
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2830,7 +2843,7 @@ msgstr ""
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Impossible d'éditer une mémoire avant téléchargement de la radio"
 
-#: ../wxui/main.py:1254
+#: ../wxui/main.py:1258
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Impossible de trouver la configuration de base %r"
@@ -2867,11 +2880,11 @@ msgstr "Impossible de montrer %s sur ce système"
 msgid "Unable to set %s on this memory"
 msgstr "Impossible de régler %s dans cette mémoire"
 
-#: ../wxui/main.py:1569
+#: ../wxui/main.py:1573
 msgid "Unable to upload this file"
 msgstr "Impossible de télécharger ce fichier"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr "Etats-Unis"
 
@@ -2888,11 +2901,11 @@ msgstr "Modèle non supporté %r"
 msgid "Upload instructions"
 msgstr "Instruction de téléchargement"
 
-#: ../wxui/main.py:1003
+#: ../wxui/main.py:1007
 msgid "Upload to radio"
 msgstr "Télécharger vers la radio"
 
-#: ../wxui/main.py:835
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "Télécharger vers la radio..."
 
@@ -2901,11 +2914,11 @@ msgstr "Télécharger vers la radio..."
 msgid "Uploaded memory %s"
 msgstr "Memoire %s téléchargée"
 
-#: ../wxui/main.py:791
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr "Utiliser une police à largeur fixe"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr "Utiliser une plus grande police"
 
@@ -2941,7 +2954,7 @@ msgstr "Valeurs"
 msgid "Vendor"
 msgstr "Fabricant"
 
-#: ../wxui/main.py:964
+#: ../wxui/main.py:968
 msgid "View"
 msgstr "Voir"
 
@@ -2949,7 +2962,7 @@ msgstr "Voir"
 msgid "WARNING!"
 msgstr "ATTENTION!"
 
-#: ../wxui/main.py:1781 ../wxui/memedit.py:1542
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr "Attention"
 
@@ -2958,7 +2971,7 @@ msgstr "Attention"
 msgid "Warning: %s"
 msgstr "Attention: %s"
 
-#: ../wxui/main.py:437
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr "Bienvenue"
 
@@ -2982,11 +2995,11 @@ msgstr "octets"
 msgid "bytes each"
 msgstr "octets chacun"
 
-#: ../wxui/main.py:1723
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr "desactivé"
 
-#: ../wxui/main.py:1723
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr "activé"
 

--- a/chirp/locale/hu.po
+++ b/chirp/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2015-01-28 13:47+0100\n"
 "Last-Translator: Attila Joubert <joubert.attila@gmail.com>\n"
 "Language-Team: English\n"
@@ -34,28 +34,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "... és a tömböt felfelé lépteti"
 msgstr[1] "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memória"
 msgstr[1] "Memória"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "... és a tömböt felfelé lépteti"
 msgstr[1] "... és a tömböt felfelé lépteti"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "A fájl megváltozott! Menti bezárás előtt?"
@@ -64,7 +64,7 @@ msgstr "A fájl megváltozott! Menti bezárás előtt?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, fuzzy, python-format
 msgid "...and %i more"
 msgstr "...és minden memória felfelé lép"
@@ -622,34 +622,34 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Mind"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "CSV fájlok"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr ""
 
@@ -661,7 +661,7 @@ msgstr "Hiba történt"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Automatic Repeater Offset"
@@ -670,11 +670,11 @@ msgstr "Automatic Repeater Offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr ""
 
@@ -694,11 +694,11 @@ msgstr "Böngésző"
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr ""
 
@@ -708,13 +708,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -722,22 +722,22 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "RX DTCS kód"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Kereszt-üzem"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Válasszon egy importálandót:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr ""
 
@@ -778,15 +778,15 @@ msgstr "Letöltés a rádióról"
 msgid "Cloning to radio"
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -818,16 +818,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Másolás"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr ""
 
@@ -844,7 +844,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Kivágás"
 
@@ -864,12 +864,12 @@ msgstr "DTCS pol."
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 #, fuzzy
 msgid "DV Memory"
 msgstr "ez a memória"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr ""
 
@@ -878,34 +878,34 @@ msgstr ""
 msgid "Dec"
 msgstr "Érzékelés"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Fejlesztői"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Digitális kód"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 #, fuzzy
 msgid "Digital Modes"
 msgstr "Digitális kód"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr ""
 
@@ -915,7 +915,7 @@ msgid "Disabled"
 msgstr "Engedélyezve"
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr ""
 
@@ -932,16 +932,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 #, fuzzy
 msgid "Download from radio"
 msgstr "Letöltés a rádióról"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Letöltés a rádióról"
@@ -959,11 +959,11 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -971,17 +971,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, fuzzy, python-format
 msgid "Edit details for %i memories"
 msgstr "Több memória szerkesztése"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -995,11 +995,11 @@ msgstr "Engedélyezve"
 msgid "Enter Frequency"
 msgstr "Frekvencia"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1026,26 +1026,30 @@ msgstr "Hiba a(z) %s érték beállításakor"
 msgid "Error communicating with radio"
 msgstr ""
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 #, fuzzy
 msgid "Experimental driver"
 msgstr "Folytassam kísérleti driver-rel?"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Export fájlba"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Export fájlba"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1053,7 +1057,7 @@ msgstr ""
 msgid "FM Radio"
 msgstr ""
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1072,13 +1076,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 #, fuzzy
 msgid "Files"
 msgstr "_Fájl"
@@ -1091,17 +1095,17 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 #, fuzzy
 msgid "Find Next"
 msgstr "RFinder"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 #, fuzzy
 msgid "Find..."
 msgstr "RFinder"
@@ -1150,7 +1154,7 @@ msgid ""
 msgstr ""
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1219,7 +1223,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1299,8 +1303,8 @@ msgstr "Frekvencia"
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr ""
 
@@ -1309,21 +1313,21 @@ msgstr ""
 msgid "Getting settings"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "ez a memória"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 #, fuzzy
 msgid "Goto Memory:"
 msgstr "ez a memória"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Súgó"
 
@@ -1335,7 +1339,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Felülírja?"
@@ -1345,24 +1349,24 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "Importálás"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importálás fájlból"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 msgid "Import not recommended"
 msgstr ""
 
@@ -1374,12 +1378,12 @@ msgstr "Sorszám"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 #, fuzzy
 msgid "Information"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Memória beszúrása fölé"
@@ -1388,7 +1392,7 @@ msgstr "Memória beszúrása fölé"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1402,7 +1406,7 @@ msgstr "Belső hiba"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Érvénytelen érték! Egész szám kell legyen."
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Érvénytelen érték %s"
@@ -1411,12 +1415,12 @@ msgstr "Érvénytelen érték %s"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "Érvénytelen érték %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1433,13 +1437,13 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 #, fuzzy
 msgid "Language"
 msgstr "Nyelv választás"
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr ""
 
@@ -1448,7 +1452,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr ""
 
@@ -1456,20 +1460,24 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+msgid "Limit use"
+msgstr ""
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "Rádió"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Load Module..."
 msgstr "Modul betöltése"
@@ -1479,18 +1487,18 @@ msgstr "Modul betöltése"
 msgid "Load module from issue"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1513,7 +1521,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr ""
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr ""
 
@@ -1521,7 +1529,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Memória"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1539,7 +1547,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 #, fuzzy
 msgid "Mode"
 msgstr "Mód"
@@ -1548,22 +1556,22 @@ msgstr "Mód"
 msgid "Model"
 msgstr "Modell"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Modes"
 msgstr "Mód"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 #, fuzzy
 msgid "Module"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 #, fuzzy
 msgid "Module Loaded"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1572,30 +1580,30 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Lefel_é"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Fe_lfelé"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 #, fuzzy
 msgid "New version available"
 msgstr "A CHIRP egy új verziója érhető el:"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Memória beszúrása alá"
@@ -1613,11 +1621,11 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr ""
 
@@ -1625,7 +1633,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Offszet"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr ""
 
@@ -1637,55 +1645,59 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 #, fuzzy
 msgid "Open Recent"
 msgstr "Leg_utóbbi"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "A csoportos beállítás megnyitása"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "A(z) {name} konfigurációs készlet megnyitása"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Beállítások"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1693,7 +1705,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Felülírja?"
@@ -1709,31 +1721,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1763,7 +1775,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1792,7 +1804,7 @@ msgstr "Teljesítmény"
 msgid "Press enter to set this in memory"
 msgstr "Memória beállítási hiba"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr ""
 
@@ -1800,16 +1812,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, fuzzy, python-format
 msgid "Query %s"
 msgstr "Lekérdezés hiba"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 #, fuzzy
 msgid "Query Source"
 msgstr "Lekérd. adatforrása"
@@ -1819,7 +1831,7 @@ msgstr "Lekérd. adatforrása"
 msgid "RX DTCS"
 msgstr "RX DTCS kód"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "Rádió"
 
@@ -1840,11 +1852,11 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1870,11 +1882,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr "ezek a memóriák"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1888,30 +1900,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Listázás letiltva"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1919,15 +1931,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr ""
 
@@ -1952,27 +1964,27 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 #, fuzzy
 msgid "Select Bands"
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Select Modes"
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1988,59 +2000,59 @@ msgstr "Beállítás"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Memóriasor mutatása"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 "A beillesztett {number}. számú memória nem kompatibilis ezzel a rádióval, "
 "mert:"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Felülírja?"
@@ -2050,7 +2062,7 @@ msgstr "Felülírja?"
 msgid "Sorting"
 msgstr "Beállítás"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr ""
 
@@ -2058,7 +2070,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr ""
 
@@ -2066,7 +2078,7 @@ msgstr ""
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2102,7 +2114,7 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2112,7 +2124,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "ez a memória"
@@ -2137,13 +2149,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2178,12 +2190,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "... és a tömböt felfelé lépteti"
@@ -2221,7 +2233,7 @@ msgstr ""
 msgid "Tone"
 msgstr "CTCSS"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Hang (CTCSS) mód"
 
@@ -2259,7 +2271,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Lépésköz"
@@ -2274,16 +2286,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "A csoportos beállítás megnyitása"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Nem érzékelek a {port} porton!"
@@ -2314,12 +2326,12 @@ msgstr "Ennél a modellnél nem változtatható"
 msgid "Unable to set %s on this memory"
 msgstr "Ennél a modellnél nem változtatható"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Ennél a modellnél nem változtatható"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr ""
 
@@ -2337,12 +2349,12 @@ msgstr "Nem támogatott fájltípus"
 msgid "Upload instructions"
 msgstr "{instructions}"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Feltöltés a rádióra"
@@ -2352,11 +2364,11 @@ msgstr "Feltöltés a rádióra"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr ""
 
@@ -2384,7 +2396,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2392,7 +2404,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Gyártó"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 #, fuzzy
 msgid "View"
 msgstr "Né_zet"
@@ -2401,16 +2413,16 @@ msgstr "Né_zet"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr ""
 
@@ -2434,12 +2446,12 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 #, fuzzy
 msgid "disabled"
 msgstr "Engedélyezve"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 #, fuzzy
 msgid "enabled"
 msgstr "Engedélyezve"

--- a/chirp/locale/it.po
+++ b/chirp/locale/it.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-25 11:31+0200\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2024-05-25 11:29+0200\n"
 "Last-Translator: Giovanni Scafora IK5TWZ <scafora.giovanni@gmail.com>\n"
 "Language-Team: CHIRP Italian Translation\n"
@@ -814,7 +814,7 @@ msgstr ""
 "attività.\n"
 "6. Fare clic su OK per caricare l'immagine sul dispositivo.\n"
 
-#: ../drivers/tg_uv2p.py:233 ../drivers/wouxun.py:214 ../drivers/uvb5.py:288
+#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:214 ../drivers/tg_uv2p.py:233
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -831,7 +831,7 @@ msgstr ""
 "attività.\n"
 "6. Fare clic su OK per scaricare l'immagine dal dispositivo.\n"
 
-#: ../drivers/tg_uv2p.py:241 ../drivers/wouxun.py:222 ../drivers/uvb5.py:296
+#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:222 ../drivers/tg_uv2p.py:241
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -1020,7 +1020,7 @@ msgstr "Informazioni"
 msgid "About CHIRP"
 msgstr "Informazioni su CHIRP"
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Tutto"
 
@@ -1032,7 +1032,7 @@ msgstr "Tutti i file"
 msgid "All supported formats|"
 msgstr "Tutti i formati supportati|"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr "Radioamatore"
 
@@ -1056,7 +1056,7 @@ msgstr "Moduli disponibili"
 msgid "Bandplan"
 msgstr "Bandplan"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr "Bande"
 
@@ -1080,7 +1080,7 @@ msgstr "Creazione del browser della radio"
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr "Per rendere effettiva la nuova selezione, è necessario riavviare CHIRP"
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr "Canada"
 
@@ -1131,7 +1131,7 @@ msgstr "Scegliere il duplex"
 msgid "Choose the module to load from issue %i:"
 msgstr "Scegliere il modulo da caricare dal sito %i:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr "Città"
 
@@ -1159,11 +1159,11 @@ msgstr "Clonazione completata, controllo dei byte spuri"
 msgid "Cloning"
 msgstr "Clonazione"
 
-#: ../drivers/ft450d.py:508 ../drivers/bj9900.py:134 ../drivers/ft817.py:342
+#: ../drivers/bj9900.py:134 ../drivers/ft450d.py:508 ../drivers/ft817.py:342
 msgid "Cloning from radio"
 msgstr "Clonazione dalla radio"
 
-#: ../drivers/ft450d.py:537 ../drivers/bj9900.py:166 ../drivers/ft817.py:380
+#: ../drivers/bj9900.py:166 ../drivers/ft450d.py:537 ../drivers/ft817.py:380
 msgid "Cloning to radio"
 msgstr "Clonazione verso la radio"
 
@@ -1211,7 +1211,7 @@ msgstr ""
 "situata sul retro dell'unita 'TX/RX'. NON alla porta COM del pannello "
 "frontale.\n"
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr "Converti in FM"
 
@@ -1219,8 +1219,8 @@ msgstr "Converti in FM"
 msgid "Copy"
 msgstr "Copia"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr "Nazione"
 
@@ -1291,7 +1291,7 @@ msgstr "Diff memorie raw"
 msgid "Digital Code"
 msgstr "Codice digitale"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 msgid "Digital Modes"
 msgstr "Modi digitali"
 
@@ -1304,7 +1304,7 @@ msgid "Disabled"
 msgstr "Disabilitata"
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr "Distanza"
 
@@ -1349,7 +1349,7 @@ msgstr "Informazioni sul driver"
 msgid "Driver messages"
 msgstr "Messaggi del driver"
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 "I ripetitori digitali dual-mode che supportano l'analogico saranno mostrati "
@@ -1411,6 +1411,10 @@ msgstr "Si è verificato un errore durante l'applicazione delle impostazioni"
 msgid "Error communicating with radio"
 msgstr "Errore durante la comunicazione con la radio"
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr "Driver sperimentale"
@@ -1435,7 +1439,7 @@ msgstr "Extra"
 msgid "FM Radio"
 msgstr "Radio FM"
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1553,11 +1557,11 @@ msgstr ""
 "sarà\n"
 "    l'audio del lato destro!\n"
 
-#: ../drivers/bf_t1.py:483 ../drivers/mursv1.py:342
-#: ../drivers/baofeng_wp970i.py:328 ../drivers/baofeng_uv17Pro.py:441
-#: ../drivers/gmrsuv1.py:392 ../drivers/btech.py:689 ../drivers/uv6r.py:340
-#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv5x3.py:418
-#: ../drivers/gmrsv2.py:364
+#: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
+#: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
+#: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
+#: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1661,7 +1665,7 @@ msgstr ""
 "    l'audio del lato destro!\n"
 "6 - Accendere la radio per uscire dalla modalità clone.\n"
 
-#: ../drivers/bf_t1.py:489 ../drivers/btech.py:695
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1703,7 +1707,7 @@ msgstr ""
 "3 - Accendere la radio\n"
 "4 - Fare clic su OK per iniziare\n"
 
-#: ../drivers/lt725uv.py:497 ../drivers/vgc.py:599
+#: ../drivers/vgc.py:599 ../drivers/lt725uv.py:497
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1731,11 +1735,11 @@ msgstr ""
 "3 - Accendere la radio\n"
 "4 - Effettuare il download dei dati dalla radio\n"
 
-#: ../drivers/mursv1.py:348 ../drivers/baofeng_wp970i.py:334
-#: ../drivers/baofeng_uv17Pro.py:447 ../drivers/gmrsuv1.py:398
-#: ../drivers/lt725uv.py:503 ../drivers/vgc.py:605 ../drivers/uv6r.py:346
-#: ../drivers/tdxone_tdq8a.py:461 ../drivers/uv5x3.py:424
-#: ../drivers/gmrsv2.py:370
+#: ../drivers/vgc.py:605 ../drivers/mursv1.py:348
+#: ../drivers/baofeng_wp970i.py:334 ../drivers/gmrsuv1.py:398
+#: ../drivers/lt725uv.py:503 ../drivers/tdxone_tdq8a.py:461
+#: ../drivers/uv6r.py:346 ../drivers/uv5x3.py:424 ../drivers/gmrsv2.py:370
+#: ../drivers/baofeng_uv17Pro.py:447
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1776,8 +1780,8 @@ msgstr "Frequenza"
 msgid "Frequency granularity in kHz"
 msgstr "Granularità della frequenza in kHz"
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1818,7 +1822,7 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr "Commento leggibile dall'essere umano (non memorizzato nella radio)"
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Se impostata, ordina i risultati secondo la distanza da tali coordinate"
@@ -1872,7 +1876,7 @@ msgstr "Errore interno del driver"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Il valore %(value)s non è valido (usare i gradi decimali)"
 
-#: ../wxui/memedit.py:1536 ../wxui/query_sources.py:66
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 msgid "Invalid Entry"
 msgstr "Valore non valido"
 
@@ -1907,7 +1911,7 @@ msgid "Language"
 msgstr "Lingua"
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr "Latitudine"
 
@@ -1916,7 +1920,7 @@ msgstr "Latitudine"
 msgid "Length must be %i"
 msgstr "La lunghezza deve essere %i"
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr "Limita bande"
 
@@ -1924,13 +1928,18 @@ msgstr "Limita bande"
 msgid "Limit Modes"
 msgstr "Limita modi"
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr "Limita stato"
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Limita i risultati a questa distanza (km) dalle coordinate"
+
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Limit use"
+msgstr "Limita stato"
 
 #: ../wxui/main.py:1566
 msgid "Live Radio"
@@ -1986,7 +1995,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr "Stringa del logo 2 (12 caratteri)"
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr "Longitudine"
 
@@ -2012,7 +2021,7 @@ msgstr "La memoria deve trovarsi in un banco per essere modificata"
 msgid "Memory {num} not in bank {bank}"
 msgstr "La memoria {num} non è presente nel banco {bank}"
 
-#: ../wxui/memedit.py:590 ../wxui/query_sources.py:525
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 msgid "Mode"
 msgstr "Modalità"
 
@@ -2020,7 +2029,7 @@ msgstr "Modalità"
 msgid "Model"
 msgstr "Modello"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Modes"
 msgstr "Modalità"
 
@@ -2080,11 +2089,11 @@ msgstr "Nessun modulo trovato nel sito %i"
 msgid "No results"
 msgstr "Nessun risultato"
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr "Nessun risultato!"
 
-#: ../wxui/memedit.py:954 ../wxui/query_sources.py:41
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr "Numero"
 
@@ -2092,7 +2101,7 @@ msgstr "Numero"
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr "Solo alcune bande"
 
@@ -2104,7 +2113,7 @@ msgstr "Solo alcune modalità"
 msgid "Only memory tabs may be exported"
 msgstr "È possibile esportare solo le schede di memoria"
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr "Solo ripetitori funzionanti"
 
@@ -2136,19 +2145,23 @@ msgstr "Apri il registro di debug"
 msgid "Open in new window"
 msgstr "Apri in nuova finestra"
 
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
 #: ../wxui/main.py:616
 msgid "Open stock config directory"
 msgstr "Apri la directory delle configurazioni standard"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr "Opzionale: -122.0000"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 msgid "Optional: 100"
 msgstr "Opzionale: 100"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr "Opzionale: 45.0000"
 
@@ -2328,13 +2341,13 @@ msgstr ""
 "modello selezionato non è statunitense ma la radio è statunitense. Scegliere "
 "il modello corretto e riprovare."
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 "RadioReference Canada richiede un login prima di poter effettuare le "
 "interrogazioni"
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -2450,7 +2463,7 @@ msgstr "Rischio di sicurezza"
 msgid "Select Bandplan..."
 msgstr "Seleziona bandplan..."
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Select Bands"
 msgstr "Seleziona le bande"
 
@@ -2458,7 +2471,7 @@ msgstr "Seleziona le bande"
 msgid "Select Language"
 msgstr "Seleziona la lingua"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Select Modes"
 msgstr "Seleziona le modalità"
 
@@ -2535,7 +2548,7 @@ msgstr "Ordina memorie"
 msgid "Sorting"
 msgstr "Ordinamento"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr "Stato"
 
@@ -2551,7 +2564,7 @@ msgstr "Successo"
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr "Polarità DTCS TX-RX (normale o invertita)"
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr "La rete mondiale DMR-MARC"
 
@@ -2878,7 +2891,7 @@ msgstr "Impossibile impostare %s su questa memoria"
 msgid "Unable to upload this file"
 msgstr "Impossibile caricare questo file"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr "Stati Uniti"
 

--- a/chirp/locale/ja_JP.po
+++ b/chirp/locale/ja_JP.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2023-12-03 11:04+0900\n"
 "Last-Translator: weboo <weboo@users.noreply.github.com>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i 件削除して全体を上方向にシフト"
 msgstr[1] "%i 件削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i 件の内容を削除"
 msgstr[1] "%i 件の内容を削除"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i 件削除してグループを上方向にシフト"
 msgstr[1] "%i 件削除してグループを上方向にシフト"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s は保存されていません。保存しますか？"
@@ -63,7 +63,7 @@ msgstr "%s は保存されていません。保存しますか？"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -633,7 +633,7 @@ msgstr ""
 "\n"
 "ケーブルを接続した状態で電源オンにするとうまく動かない場合があります。"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -641,27 +641,27 @@ msgstr ""
 "新しいバージョンのCHIRPが利用可能です。できるだけ早く更新されることをお勧めし"
 "ます。今すぐ更新しますか？"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "このアプリについて"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr "CHIRP について"
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "すべて"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr ""
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 msgid "Automatic from system"
 msgstr ""
 
@@ -681,11 +681,11 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr "バンドプラン"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr "バンド"
 
@@ -705,11 +705,11 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr ""
 
@@ -719,13 +719,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -733,21 +733,21 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr ""
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -756,7 +756,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr ""
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr ""
 
@@ -786,15 +786,15 @@ msgstr ""
 msgid "Cloning to radio"
 msgstr ""
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr "閉じる"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr "ファイルを閉じる"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -825,16 +825,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "コピー"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr "国"
 
@@ -851,7 +851,7 @@ msgstr "ポートを手動で設定"
 msgid "Custom..."
 msgstr "カスタム..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "切り取り"
 
@@ -869,11 +869,11 @@ msgstr "DTCS極性"
 msgid "DTMF decode"
 msgstr "DTMF デコード"
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr ""
 
@@ -881,32 +881,32 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "削除"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "開発者モード"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr ""
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 msgid "Digital Modes"
 msgstr ""
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr "診断レポート送信を停止"
 
@@ -915,7 +915,7 @@ msgid "Disabled"
 msgstr ""
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr ""
 
@@ -932,15 +932,15 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr "ダウンロード"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 msgid "Download from radio"
 msgstr "無線機からダウンロード"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "無線機からダウンロード..."
 
@@ -956,11 +956,11 @@ msgstr ""
 msgid "Driver information"
 msgstr "ドライバー情報"
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -968,17 +968,17 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "値を自動設定"
 
@@ -990,11 +990,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "周波数を入力"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1020,23 +1020,27 @@ msgstr ""
 msgid "Error communicating with radio"
 msgstr "無線機との通信エラー"
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr "実験的ドライバー"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 msgid "Export to CSV"
 msgstr "CSVにエクスポート"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 msgid "Export to CSV..."
 msgstr "CSVにエクスポート..."
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1044,7 +1048,7 @@ msgstr ""
 msgid "FM Radio"
 msgstr "FMラジオ"
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1063,13 +1067,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 msgid "Files"
 msgstr ""
 
@@ -1081,15 +1085,15 @@ msgstr "フィルター"
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr "検索"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr "次を検索"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 msgid "Find..."
 msgstr "検索..."
 
@@ -1137,7 +1141,7 @@ msgid ""
 msgstr ""
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1206,7 +1210,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1286,8 +1290,8 @@ msgstr "周波数(MHz)"
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr ""
 
@@ -1295,19 +1299,19 @@ msgstr ""
 msgid "Getting settings"
 msgstr "設定を取得しています"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "行移動"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "指定した行に移動:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "行移動..."
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "ヘルプ"
 
@@ -1319,7 +1323,7 @@ msgstr "ポートが不明の場合..."
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "空のメモリーを非表示"
 
@@ -1328,23 +1332,23 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "インポート"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 msgid "Import from file..."
 msgstr "ファイルからインポート..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 msgid "Import not recommended"
 msgstr "インポートは推奨されません"
 
@@ -1356,11 +1360,11 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "上に1行追加"
 
@@ -1368,7 +1372,7 @@ msgstr "上に1行追加"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1381,7 +1385,7 @@ msgstr "内部ドライバーエラー"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1389,12 +1393,12 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1411,12 +1415,12 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 msgid "Language"
 msgstr ""
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr "緯度"
 
@@ -1425,7 +1429,7 @@ msgstr "緯度"
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr ""
 
@@ -1433,20 +1437,24 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+msgid "Limit use"
+msgstr ""
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "FMラジオ"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 msgid "Load Module..."
 msgstr ""
 
@@ -1454,17 +1462,17 @@ msgstr ""
 msgid "Load module from issue"
 msgstr ""
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1487,7 +1495,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr "起動メッセージ２（半角12文字）"
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr "軽度"
 
@@ -1495,7 +1503,7 @@ msgstr "軽度"
 msgid "Memories"
 msgstr "メモリー"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "メモリー %i は削除できません"
@@ -1513,7 +1521,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 msgid "Mode"
 msgstr "受信モード"
 
@@ -1521,19 +1529,19 @@ msgstr "受信モード"
 msgid "Model"
 msgstr "モデル"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Modes"
 msgstr ""
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1542,27 +1550,27 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr "2つ以上のポートが見つかりました: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "下に移動"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "上に移動"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr "新規ウィンドウ"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr "新しいバージョンが利用可能です"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "空の行が見つかりません"
 
@@ -1579,11 +1587,11 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr "行"
 
@@ -1591,7 +1599,7 @@ msgstr "行"
 msgid "Offset"
 msgstr "オフセット"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr ""
 
@@ -1603,51 +1611,55 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr "メモリータブのみエクスポートできます"
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr "開く"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 msgid "Open Recent"
 msgstr "最近使ったファイル"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 msgid "Open Stock Config"
 msgstr "テンプレートを開く"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "ファイルを開く"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr "新しいウィンドウで開く"
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 msgid "Open stock config directory"
 msgstr "テンプレートディレクトリを開く"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 msgid "Optional: 100"
 msgstr ""
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1655,7 +1667,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "メモリーを上書きしますか？"
 
@@ -1670,31 +1682,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "ペースト"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "ペーストすると %s 件のメモリーが上書きされます"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "新しいバージョンをインストールする前に必ずCHIRPを終了してください。"
 
@@ -1724,7 +1736,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1752,7 +1764,7 @@ msgstr "出力"
 msgid "Press enter to set this in memory"
 msgstr ""
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr "印刷プレビュー"
 
@@ -1760,16 +1772,16 @@ msgstr "印刷プレビュー"
 msgid "Printing"
 msgstr "印刷"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "プロパティ"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr ""
 
@@ -1777,7 +1789,7 @@ msgstr ""
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "無線機"
 
@@ -1797,11 +1809,11 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1826,11 +1838,11 @@ msgstr "更新が必要です"
 msgid "Refreshed memory %s"
 msgstr "%s 件のメモリーを取得しました"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1844,11 +1856,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "診断レポート送信"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -1858,18 +1870,18 @@ msgstr ""
 "かを判断するのに役立ちます。このまま有効にしておいていただけると有り難いで"
 "す。本当に無効にしますか？"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr "再起動が必要です"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "最近閉じた%i個のタブを開く"
 msgstr[1] "最近閉じた%i個のタブを開く"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr "起動時にタブを復元"
 
@@ -1877,15 +1889,15 @@ msgstr "起動時にタブを復元"
 msgid "Retrieved settings"
 msgstr "設定を取得しました"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr "保存"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr "保存しますか？"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr "ファイルに保存"
 
@@ -1909,24 +1921,24 @@ msgstr "スクランブル"
 msgid "Security Risk"
 msgstr "セキュリティリスク"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "バンドプランを選択..."
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Select Bands"
 msgstr ""
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "バンドプラン選択"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Select Modes"
 msgstr ""
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr "バンドプラン選択"
 
@@ -1942,56 +1954,56 @@ msgstr "設定"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr ""
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "追加フィールドを表示"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 msgid "Show image backup location"
 msgstr "イメージのバックアップを表示"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "並び替え（%i 件）"
 msgstr[1] "並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "昇順に並び替え（%i 件）"
 msgstr[1] "昇順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "降順に並び替え（%i 件）"
 msgstr[1] "降順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "カラムを選択"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "並び替え"
 
@@ -1999,7 +2011,7 @@ msgstr "並び替え"
 msgid "Sorting"
 msgstr "並び替え中"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr ""
 
@@ -2007,7 +2019,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr "成功"
 
@@ -2015,7 +2027,7 @@ msgstr "成功"
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2051,7 +2063,7 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2066,7 +2078,7 @@ msgstr ""
 "に置き換えます。このファイルを開いて「メモリ」をコピー＆ペーストしますか？そ"
 "れともインポートを続けますか？"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "この行の内容を削除"
 
@@ -2093,13 +2105,13 @@ msgstr ""
 "タムバージョンのCHIRPで作成された可能性があります。データ保全と互換性のために"
 "新たに無線機からダウンロードし直すことをお勧めします。"
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2142,11 +2154,11 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "この行を削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "この行を削除してグループを上方向にシフト"
 
@@ -2183,7 +2195,7 @@ msgstr ""
 msgid "Tone"
 msgstr "トーン(Hz)"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "トーンモード"
 
@@ -2220,7 +2232,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "ステップ(kHz)"
 
@@ -2236,16 +2248,16 @@ msgstr ""
 "ポートを検出できませんでした。ドライバーがインストールされているかと接続状態"
 "をもう一度確認してください。"
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 msgid "Unable to import while the view is sorted"
 msgstr ""
 
@@ -2274,11 +2286,11 @@ msgstr ""
 msgid "Unable to set %s on this memory"
 msgstr ""
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 msgid "Unable to upload this file"
 msgstr ""
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr ""
 
@@ -2295,11 +2307,11 @@ msgstr ""
 msgid "Upload instructions"
 msgstr "アップロード手順"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 msgid "Upload to radio"
 msgstr "無線機にアップロード"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "無線機にアップロード..."
 
@@ -2308,11 +2320,11 @@ msgstr "無線機にアップロード..."
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr "固定幅フォントを使用"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr "大きいフォントを使用"
 
@@ -2340,7 +2352,7 @@ msgstr "値は %i 桁にしてください"
 msgid "Value must be zero or greater"
 msgstr "値は 0 以上にしてください"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "値"
 
@@ -2348,7 +2360,7 @@ msgstr "値"
 msgid "Vendor"
 msgstr "メーカー"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 msgid "View"
 msgstr "表示"
 
@@ -2356,16 +2368,16 @@ msgstr "表示"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr "ようこそ"
 
@@ -2389,11 +2401,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr "無効"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr "有効"
 

--- a/chirp/locale/nl.po
+++ b/chirp/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2012-03-18 12:01+0100\n"
 "Last-Translator: Michael Tel <m.tel@xs4all.nl>\n"
 "Language-Team: Dutch\n"
@@ -34,28 +34,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Verwijderen (en naar boven verplaatsen)"
 msgstr[1] "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Kanalen"
 msgstr[1] "Kanalen"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Verwijderen (en naar boven verplaatsen)"
 msgstr[1] "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Het bestand is aangepast. Wilt u de wijzigingen opslaan?"
@@ -64,7 +64,7 @@ msgstr "Het bestand is aangepast. Wilt u de wijzigingen opslaan?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -622,34 +622,34 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Alles"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "Komma gescheiden bestanden"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr ""
 
@@ -661,7 +661,7 @@ msgstr "Er is een fout opgetreden"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Automatische repeater offset"
@@ -670,11 +670,11 @@ msgstr "Automatische repeater offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr ""
 
@@ -694,11 +694,11 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr ""
 
@@ -708,13 +708,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -722,22 +722,22 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS code"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross-mode"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Kies n om vanuit te importeren:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr ""
 
@@ -778,15 +778,15 @@ msgstr "Download van radio"
 msgid "Cloning to radio"
 msgstr "Naar radio uploaden"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -818,16 +818,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr ""
 
@@ -844,7 +844,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Knippen"
 
@@ -864,11 +864,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr ""
 
@@ -877,34 +877,34 @@ msgstr ""
 msgid "Dec"
 msgstr "Detecteren"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Ontwerper"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Digitale code"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 #, fuzzy
 msgid "Digital Modes"
 msgstr "Digitale code"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr ""
 
@@ -913,7 +913,7 @@ msgid "Disabled"
 msgstr ""
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr ""
 
@@ -930,16 +930,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 #, fuzzy
 msgid "Download from radio"
 msgstr "Download van radio"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Download van radio"
@@ -957,11 +957,11 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -969,17 +969,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -992,11 +992,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Frequentie"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1023,25 +1023,29 @@ msgstr "Fout bij het instellen van het geheugen"
 msgid "Error communicating with radio"
 msgstr ""
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Exporteren naar bestand"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Exporteren naar bestand"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1049,7 +1053,7 @@ msgstr ""
 msgid "FM Radio"
 msgstr ""
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1068,13 +1072,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 #, fuzzy
 msgid "Files"
 msgstr "_Bestanden"
@@ -1087,15 +1091,15 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 msgid "Find..."
 msgstr ""
 
@@ -1143,7 +1147,7 @@ msgid ""
 msgstr ""
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1212,7 +1216,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1292,8 +1296,8 @@ msgstr "Frequentie"
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr ""
 
@@ -1301,20 +1305,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Toon ruw kanaal"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Help"
 
@@ -1326,7 +1330,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Overschrijven?"
@@ -1336,24 +1340,24 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "Importeren"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importeren van bestand"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Importeren uit RFinder"
@@ -1366,11 +1370,11 @@ msgstr "Index"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Regel hierboven invoegen"
@@ -1379,7 +1383,7 @@ msgstr "Regel hierboven invoegen"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1393,7 +1397,7 @@ msgstr "Interne fout"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ongeldige waarde. Het moet een integer zijn."
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ongeldige waarde voor dit veld"
@@ -1402,12 +1406,12 @@ msgstr "Ongeldige waarde voor dit veld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1424,13 +1428,13 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 #, fuzzy
 msgid "Language"
 msgstr "Taal wijzigen"
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr ""
 
@@ -1439,7 +1443,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr ""
 
@@ -1447,20 +1451,24 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+msgid "Limit use"
+msgstr ""
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "Radio"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Load Module..."
 msgstr "Toonmodus"
@@ -1470,18 +1478,18 @@ msgstr "Toonmodus"
 msgid "Load module from issue"
 msgstr "Toonmodus"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Toonmodus"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1504,7 +1512,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr ""
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr ""
 
@@ -1512,7 +1520,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Kanalen"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1530,7 +1538,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1539,20 +1547,20 @@ msgstr "Mode"
 msgid "Model"
 msgstr "Model"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Modes"
 msgstr "Mode"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1561,29 +1569,29 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Verplaats omlaa_g"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Verplaats om_hoog"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Regel hieronder invoegen"
@@ -1601,11 +1609,11 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr ""
 
@@ -1613,7 +1621,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr ""
 
@@ -1625,55 +1633,59 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Recent"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Openen aanwezige configuratie"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Openen van aanwezige configuratie {name}"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Opties"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1681,7 +1693,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Overschrijven?"
@@ -1697,31 +1709,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Plakken"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1751,7 +1763,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1780,7 +1792,7 @@ msgstr "Vermogen"
 msgid "Press enter to set this in memory"
 msgstr "Fout bij het instellen van het geheugen"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr ""
 
@@ -1788,16 +1800,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr ""
 
@@ -1805,7 +1817,7 @@ msgstr ""
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "Radio"
 
@@ -1826,11 +1838,11 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1855,11 +1867,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1874,30 +1886,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Rapportering is uitgeschakeld"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1905,15 +1917,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr ""
 
@@ -1937,27 +1949,27 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Kolommen selecteren"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 #, fuzzy
 msgid "Select Bands"
 msgstr "Kolommen selecteren"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "Kolommen selecteren"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Select Modes"
 msgstr "Kolommen selecteren"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1973,57 +1985,57 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Toon ruw kanaal"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Geplakt kanaal {number} is niet compatibel met deze radio omdat:"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Overschrijven?"
@@ -2032,7 +2044,7 @@ msgstr "Overschrijven?"
 msgid "Sorting"
 msgstr ""
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr ""
 
@@ -2040,7 +2052,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr ""
 
@@ -2048,7 +2060,7 @@ msgstr ""
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2084,7 +2096,7 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2094,7 +2106,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Toon ruw kanaal"
@@ -2119,13 +2131,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2160,12 +2172,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
@@ -2203,7 +2215,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Toon"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Toonmodus"
 
@@ -2241,7 +2253,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Kanaal-afstand"
@@ -2256,16 +2268,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Openen aanwezige configuratie"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Niet in staat om de radio op {port} te detecteren"
@@ -2296,12 +2308,12 @@ msgstr "Niet in staat om wijzigingen voor dit model te maken"
 msgid "Unable to set %s on this memory"
 msgstr "Niet in staat om wijzigingen voor dit model te maken"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Niet in staat om wijzigingen voor dit model te maken"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr ""
 
@@ -2318,12 +2330,12 @@ msgstr "Niet-ondersteunende bestandstype"
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Naar radio uploaden"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Naar radio uploaden"
@@ -2333,11 +2345,11 @@ msgstr "Naar radio uploaden"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr ""
 
@@ -2365,7 +2377,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2373,7 +2385,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Merk"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 #, fuzzy
 msgid "View"
 msgstr "Bee_ld"
@@ -2382,16 +2394,16 @@ msgstr "Bee_ld"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr ""
 
@@ -2415,11 +2427,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/pl.po
+++ b/chirp/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2023-07-12 21:21+0200\n"
 "Last-Translator: szporwolik\n"
 "Language-Team: Polish\n"
@@ -35,7 +35,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s muszą być pomiędzy %(min)i oraz %(max)i"
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -43,7 +43,7 @@ msgstr[0] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[1] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[2] "%i pamięci oraz przesuń wszystkie do góry"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -51,7 +51,7 @@ msgstr[0] "%i pamięci"
 msgstr[1] "%i pamięci"
 msgstr[2] "%i pamięci"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -59,7 +59,7 @@ msgstr[0] "%i pamięci oraz przesuń blok do góry"
 msgstr[1] "%i pamięci oraz przesuń blok do góry"
 msgstr[2] "%i pamięci oraz przesuń blok do góry"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s nie został zapisany. Zapisać przed zamknięciem?"
@@ -68,7 +68,7 @@ msgstr "%s nie został zapisany. Zapisać przed zamknięciem?"
 msgid "(none)"
 msgstr "(brak)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr "...oraz %i więcej"
@@ -638,7 +638,7 @@ msgstr ""
 "\n"
 "Obraz może nie działać, jeśli radio zostanie włączone z podłączonym kablem"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -646,27 +646,27 @@ msgstr ""
 "Nowa wersja programu CHIRP jest dostępna. Odwiedź stronę internetową "
 "projektu i pobierz ją!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "O programie"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr "O programie CHIRP"
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Wszystkie"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Wszystkie pliki"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Wszystkie wspierane formaty|"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr "Amatorska"
 
@@ -678,7 +678,7 @@ msgstr "Wystąpił błąd"
 msgid "Applying settings"
 msgstr "Stosowanie ustawień"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Automatyczny offset repeatera"
@@ -687,11 +687,11 @@ msgstr "Automatyczny offset repeatera"
 msgid "Available modules"
 msgstr "Dostępne moduły"
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr "Bandplan"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr "Pasma"
 
@@ -711,14 +711,14 @@ msgstr "Przeglądarka"
 msgid "Building Radio Browser"
 msgstr "Budowanie przeglądarki radiostacji"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 #, fuzzy
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 "Tryb developera jest teraz %s. CHIRP musi zostać ponowie uruchomiony, aby "
 "zmiany przyniosły efekt"
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr "Kanada"
 
@@ -730,14 +730,14 @@ msgstr ""
 "Zmiana tego ustawienia wymaga odświeżenia z obrazu, co zostanie teraz "
 "wykonane."
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 "Kanały z takim samym TX oraz RX %s są reprezentowane trybem tonu \"%s\""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Pliki obrazu CHIRP"
 
@@ -745,21 +745,21 @@ msgstr "Pliki obrazu CHIRP"
 msgid "Choice Required"
 msgstr "Wymagany wybór"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Wybierz %s kod DTCS "
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Wybierz %s ton"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "Wybierz tryb krzyżowy"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr "Wybierz duplex"
 
@@ -768,7 +768,7 @@ msgstr "Wybierz duplex"
 msgid "Choose the module to load from issue %i:"
 msgstr "Wybierz moduł do zaimportowania ze zgłoszenia %i:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr "Miasto"
 
@@ -798,15 +798,15 @@ msgstr "Pobieranie z radiostacji"
 msgid "Cloning to radio"
 msgstr "Wysyłanie do radiostacji"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr "Zamknij"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr "Zamknij plik"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -838,16 +838,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr "Kraj"
 
@@ -865,7 +865,7 @@ msgstr "Wprowadź port:"
 msgid "Custom..."
 msgstr "Nietypowy..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Wytnij"
 
@@ -885,11 +885,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "Pamięć DV"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr "Niebezpieczeństwo"
 
@@ -897,35 +897,35 @@ msgstr "Niebezpieczeństwo"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Tryb dewelopera"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Tryb developera jest teraz %s. CHIRP musi zostać ponowie uruchomiony, aby "
 "zmiany przyniosły efekt"
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Porównaj surowe pamięci"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Kod cyfrowy"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 #, fuzzy
 msgid "Digital Modes"
 msgstr "Kod cyfrowy"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr "Wyłącz raportowanie"
 
@@ -934,7 +934,7 @@ msgid "Disabled"
 msgstr "Wyłączony"
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr "Dystans"
 
@@ -951,15 +951,15 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr "Kliknij podwójnie w celu zmiany nazwy banku"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr "Pobierz"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 msgid "Download from radio"
 msgstr "Pobierz z radiostacji"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Pobierz z radiostacji"
@@ -977,11 +977,11 @@ msgstr "Przeładuj sterownik"
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -989,17 +989,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Dupleks"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Zmień szczegóły dla %i pamięci"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Zmień szczególy dla pamięci %i"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Zezwól na automatyczną edycję"
 
@@ -1011,11 +1011,11 @@ msgstr "Włączony"
 msgid "Enter Frequency"
 msgstr "Wprowadź częstotliwość"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr "Wprowadź przesunięcie (MHz)"
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "Wprowadź częstotliwość nadawania (MHz)"
 
@@ -1041,24 +1041,28 @@ msgstr "Błąd stosowania ustawień"
 msgid "Error communicating with radio"
 msgstr "Błąd komunikacji z radiostacją"
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr "Sterownik eksperymentalny"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "Eksport może tylko zapisywać pliki CSV"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 msgid "Export to CSV"
 msgstr "Eksportuj do pliku CSV"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Eksportuj do pliku CSV"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Dodatkowa"
 
@@ -1066,7 +1070,7 @@ msgstr "Dodatkowa"
 msgid "FM Radio"
 msgstr ""
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1088,13 +1092,13 @@ msgstr "Parsowanie wyniku nie udało się"
 msgid "Features"
 msgstr "Funkcje"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Plik nie istnieje: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 msgid "Files"
 msgstr "Pliki"
 
@@ -1106,15 +1110,15 @@ msgstr "Filtr"
 msgid "Filter results with location matching this string"
 msgstr "Filtruj wyniki z lokalizacją pasująco do tej wartości tekstowej"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr "Wyszukaj"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr "Wyszukaj następny"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 #, fuzzy
 msgid "Find..."
 msgstr "Wyszukaj"
@@ -1163,7 +1167,7 @@ msgid ""
 msgstr ""
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1232,7 +1236,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1312,8 +1316,8 @@ msgstr "Częstotliwość"
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1321,20 +1325,20 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Pobieranie ustawień"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Idź do pamięci"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Idź do pamięci:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 #, fuzzy
 msgid "Goto..."
 msgstr "Idź do"
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Pomoc"
 
@@ -1346,7 +1350,7 @@ msgstr "Pomocy..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "Ukrywaj puste pamięci"
 
@@ -1355,24 +1359,24 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr "Jeśli ustawiono, sortuje wyniki po odległości od tych współrzędnych"
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "Importuj"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importuj z pliku"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 msgid "Import not recommended"
 msgstr "Importuj nie jest zalecany"
 
@@ -1384,11 +1388,11 @@ msgstr "Indeks"
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Informacja"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Umieść wiersz wyżej"
 
@@ -1396,7 +1400,7 @@ msgstr "Umieść wiersz wyżej"
 msgid "Install desktop icon?"
 msgstr "Utworzyć skrót pulpitu?"
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr "Interakcja ze sterownikiem"
 
@@ -1410,7 +1414,7 @@ msgstr "Błąd wewnętrzny"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Niewłaściwe %(value)s (używaj stopni dziesiętnych)"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 msgid "Invalid Entry"
 msgstr "Niewłaściwy wpis: %s"
 
@@ -1418,12 +1422,12 @@ msgstr "Niewłaściwy wpis: %s"
 msgid "Invalid ZIP code"
 msgstr "Niewłaściwy kod pocztowy"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Niewłaściwa edycja: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr "Niewłaściwy lub niespierany plik modułu"
 
@@ -1440,12 +1444,12 @@ msgstr "Numer zgłoszenia:"
 msgid "LIVE"
 msgstr "Na żywo"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 msgid "Language"
 msgstr ""
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr "Szerokość geograficzna"
 
@@ -1454,7 +1458,7 @@ msgstr "Szerokość geograficzna"
 msgid "Length must be %i"
 msgstr "Długość musi wynosić %i"
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr "Ogranicz pasma"
 
@@ -1462,20 +1466,25 @@ msgstr "Ogranicz pasma"
 msgid "Limit Modes"
 msgstr "Ogranicz tryby"
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr "Ogranicz status"
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Ogranicz wyniki do odległości (km) od współrzędnych"
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Limit use"
+msgstr "Ogranicz status"
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "Radiostacja"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Load Module..."
 msgstr "Załaduj moduł"
@@ -1484,18 +1493,18 @@ msgstr "Załaduj moduł"
 msgid "Load module from issue"
 msgstr "Załaduj moduł ze zgłoszenia"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Załaduj moduł ze zgłoszenia"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1524,7 +1533,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr ""
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr "Długość geograficzna"
 
@@ -1532,7 +1541,7 @@ msgstr "Długość geograficzna"
 msgid "Memories"
 msgstr "Pamięci"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Pamięć %i jest nieusuwalna"
@@ -1550,7 +1559,7 @@ msgstr "Pamięć musi być w banku, aby można ją było edytować"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Pamięć {num} nie jest w banku {bank}"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 msgid "Mode"
 msgstr "Tryb"
 
@@ -1558,19 +1567,19 @@ msgstr "Tryb"
 msgid "Model"
 msgstr "Model"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Modes"
 msgstr "Tryby"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr "Moduł"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr "Załadowano moduł"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr "Pomyślnie załadowano moduł"
 
@@ -1579,27 +1588,27 @@ msgstr "Pomyślnie załadowano moduł"
 msgid "More than one port found: %s"
 msgstr "Znaleziono więcej niż jeden port: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "Przesuń w dół"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "Przesuń w górę"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr "Nowe okno"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr "Nowa wersja jest dostępna"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "Brak pustych wierszy poniżej!"
 
@@ -1616,11 +1625,11 @@ msgstr "Nie znaleziono modułów w zgłoszeniu %i"
 msgid "No results"
 msgstr "Brak wyników"
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr "Brak wyników!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr "Numer"
 
@@ -1628,7 +1637,7 @@ msgstr "Numer"
 msgid "Offset"
 msgstr "Przesunięcie"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr "Tylko konkretne pasma"
 
@@ -1640,51 +1649,55 @@ msgstr "Tylko konkretne tryby"
 msgid "Only memory tabs may be exported"
 msgstr "Tylko zakładki pamięci mogą być wyeksportowane"
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr "Tylko czynne przemienniki"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr "Otwórz"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 msgid "Open Recent"
 msgstr "Otwórz ostatnio używany"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 msgid "Open Stock Config"
 msgstr "Otwórz konfigurację wstępną"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Otwórz plik"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr "Otwórz moduł"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Otwórz log debugowy"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr "Otwórz w nowym oknie"
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 msgid "Open stock config directory"
 msgstr "Otwórz katalog konfiguracji wstępnych"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr "Opcjonalnie: -122.0000"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 msgid "Optional: 100"
 msgstr "Opcjonalnie: 100"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr "Opcjonalnie: 45.0000"
 
@@ -1692,7 +1705,7 @@ msgstr "Opcjonalnie: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcjonalnie: Szpital, Hrabstwo itp."
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "Nadpisać pamięci?"
 
@@ -1707,31 +1720,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Parsowanie"
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Wklej"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Wklejone pamięci nadpisze %s istniejących pamięci"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Wklejone pamięci nadpisze pamięci %s"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Wklejone pamięci nadpiszą pamięć %s"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Wklejona pamięć nadpisze pamięć %s"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Proszę wyjdź z programu CHIRP przed instalacją nowej wersji!"
 
@@ -1761,7 +1774,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1793,7 +1806,7 @@ msgstr "Moc"
 msgid "Press enter to set this in memory"
 msgstr "Naciśnij przycisk enter, aby ustawić to w pamięci"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr "Podgląd wydruku"
 
@@ -1801,16 +1814,16 @@ msgstr "Podgląd wydruku"
 msgid "Printing"
 msgstr "Drukowanie"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Właściwości"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr "Odpytywanie %s"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Źródło zapytań"
 
@@ -1818,7 +1831,7 @@ msgstr "Źródło zapytań"
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "Radiostacja"
 
@@ -1841,11 +1854,11 @@ msgstr ""
 "jest ona przeznaczona na amerykański rynek, a wybrano model na inne regiony. "
 "Należy wybrać właściwy model i spróbować ponownie."
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr "RadioReference Canada wymaga logowania przed wysłaniem zapytań"
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1870,11 +1883,11 @@ msgstr "Wymagane jest odświeżenie"
 msgid "Refreshed memory %s"
 msgstr "Odświeżono pamięć %s"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Przeładuj sterownik"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Przeładuj sterownik oraz plik"
 
@@ -1888,11 +1901,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Raportowanie jest włączone"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -1902,11 +1915,11 @@ msgstr ""
 "oraz systemów operacyjnych należy traktować priorytetowo. Naprawdę doceniamy "
 "zostawienie tej opcji włączonej. Naprawdę wyłączyć raportowanie?"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr "Wymagany jest restart"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
@@ -1914,7 +1927,7 @@ msgstr[0] "Przywrócono %i zakładek"
 msgstr[1] "Przywrócono %i zakładek"
 msgstr[2] "Przywrócono %i zakładek"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Przywrócono %i zakładek"
@@ -1923,15 +1936,15 @@ msgstr "Przywrócono %i zakładek"
 msgid "Retrieved settings"
 msgstr "Pobrano ustawienia"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr "Zapisz"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr "Zapisać przed zamknięciem?"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr "Zapisz plik"
 
@@ -1955,25 +1968,25 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Wybierz bandplan"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Select Bands"
 msgstr "Wybierz pasma"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "Wybierz pasma"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Select Modes"
 msgstr "Wybierz tryby"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr "Wybierz bandplan"
 
@@ -1989,32 +2002,32 @@ msgstr "Ustawienia"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Pokaż surową pamięć"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Pokaż lokalizację pliku debug"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "Pokazuj dodatkowe pola"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Show image backup location"
 msgstr "Pokaż lokalizację pliku debug"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Niektóre pamięci są niekompatybilne z tą radiostacją"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Niektóre pamięci są nieusuwalne"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -2022,7 +2035,7 @@ msgstr[0] "Sortuj %i pamięci"
 msgstr[1] "Sortuj %i pamięci"
 msgstr[2] "Sortuj %i pamięci"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -2030,7 +2043,7 @@ msgstr[0] "Sortuj %i pamięci rosnąco"
 msgstr[1] "Sortuj %i pamięci rosnąco"
 msgstr[2] "Sortuj %i pamięci rosnąco"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -2038,11 +2051,11 @@ msgstr[0] "Sortuj %i pamięci malejąco"
 msgstr[1] "Sortuj %i pamięci malejąco"
 msgstr[2] "Sortuj %i pamięci malejąco"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "Sortuj wg kolumny:"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "Sortuj pamięci"
 
@@ -2050,7 +2063,7 @@ msgstr "Sortuj pamięci"
 msgid "Sorting"
 msgstr "Sortowanie"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr "Stan"
 
@@ -2058,7 +2071,7 @@ msgstr "Stan"
 msgid "State/Province"
 msgstr "Stan/Prowincja"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr "Sukces"
 
@@ -2066,7 +2079,7 @@ msgstr "Sukces"
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2105,7 +2118,7 @@ msgstr ""
 "stwarzać ryzyko, dlatego rekomendujemy nie ładowanie tego modułu. "
 "Kontynuować pomimo tego?"
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2120,7 +2133,7 @@ msgstr ""
 "aktualnie otwartym pliku tymi z %(file)s. Czy chcesz otworzyć ten plik, aby "
 "kopiować/wklejać pamięci lub kontynuować import?"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "Tą pamięć"
 
@@ -2144,13 +2157,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2185,11 +2198,11 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "Tą pamięć i przeusń wszystkie wyżej"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "Tą pamięć i przesuń blok wyżej"
 
@@ -2231,7 +2244,7 @@ msgstr "To załaduje moduł ze strony zgłoszenia"
 msgid "Tone"
 msgstr "Ton TX"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Tryb tonu"
 
@@ -2268,7 +2281,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Krok strojenia"
 
@@ -2283,16 +2296,16 @@ msgid ""
 msgstr ""
 "Nie można wykryć portu kabla. Należy sprawdzić sterowniki oraz połączenie."
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Przed pobraniem pamięci, nie można jej edytować"
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Nie znaleziono konfiguracji wstępnej %r"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Przed pobraniem pamięci, nie można jej edytować"
@@ -2325,12 +2338,12 @@ msgstr "Nie można odkryć %s na tym systemie"
 msgid "Unable to set %s on this memory"
 msgstr "Nie można ustawić %s na tej pamięci"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Nie można odkryć %s na tym systemie"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr "Stany Zjednoczone"
 
@@ -2347,11 +2360,11 @@ msgstr "Nieobsługiwany typ pliku"
 msgid "Upload instructions"
 msgstr "Instrukcje wysyłania"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 msgid "Upload to radio"
 msgstr "Wyślij do radiostacji"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Wyślij do radiostacji"
@@ -2361,11 +2374,11 @@ msgstr "Wyślij do radiostacji"
 msgid "Uploaded memory %s"
 msgstr "Wysłano pamięć %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr "Używaj czcionki o stałej szerokości znaków"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr "Używaj większej czcionki"
 
@@ -2393,7 +2406,7 @@ msgstr "Wartość musi mieć dokładnie %i cyfr dziesiętnych"
 msgid "Value must be zero or greater"
 msgstr "Wartość musi wynosić zero lub więcej"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "Wartości"
 
@@ -2401,7 +2414,7 @@ msgstr "Wartości"
 msgid "Vendor"
 msgstr "Producent"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 msgid "View"
 msgstr "Widok"
 
@@ -2409,16 +2422,16 @@ msgstr "Widok"
 msgid "WARNING!"
 msgstr "UWAGA!"
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr "Uwaga"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Uwaga: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr "Witamy"
 
@@ -2442,11 +2455,11 @@ msgstr "bajtów"
 msgid "bytes each"
 msgstr "bajtów każdy"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr "wyłączony"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr "włączony"
 

--- a/chirp/locale/pt_BR.po
+++ b/chirp/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2013-03-30 22:04-0300\n"
 "Last-Translator: Crezivando <crezivando@gmail.com>\n"
 "Language-Team: Language pt-BR\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Apagar (e deslocar)"
 msgstr[1] "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memórias"
 msgstr[1] "Memórias"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Apagar (e deslocar)"
 msgstr[1] "Apagar (e deslocar)"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Arquivo modificado, salvar alterações antes de fechar?"
@@ -63,7 +63,7 @@ msgstr "Arquivo modificado, salvar alterações antes de fechar?"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -621,34 +621,34 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Tudo"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "Arquivos CSV"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr ""
 
@@ -660,7 +660,7 @@ msgstr "Ocorreu um erro"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Offset Automático Repetidoras"
@@ -669,11 +669,11 @@ msgstr "Offset Automático Repetidoras"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr ""
 
@@ -693,11 +693,11 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr ""
 
@@ -707,13 +707,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -721,22 +721,22 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Modo Cross"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Selecionar um para importar de:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr ""
 
@@ -777,15 +777,15 @@ msgstr "Descarregar a partir do Rádio"
 msgid "Cloning to radio"
 msgstr "Carregar para o Rádio"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -817,16 +817,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr ""
 
@@ -843,7 +843,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Cortar"
 
@@ -863,11 +863,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr ""
 
@@ -876,34 +876,34 @@ msgstr ""
 msgid "Dec"
 msgstr "Detectar"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Desenvolvedor"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Código Digital"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 #, fuzzy
 msgid "Digital Modes"
 msgstr "Código Digital"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr ""
 
@@ -912,7 +912,7 @@ msgid "Disabled"
 msgstr ""
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr ""
 
@@ -929,16 +929,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 #, fuzzy
 msgid "Download from radio"
 msgstr "Descarregar a partir do Rádio"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Descarregar a partir do Rádio"
@@ -956,11 +956,11 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -968,17 +968,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -991,11 +991,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Frequência"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1022,25 +1022,29 @@ msgstr "Erro gravando memória"
 msgid "Error communicating with radio"
 msgstr ""
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Exportar Para Arquivo"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Exportar Para Arquivo"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1048,7 +1052,7 @@ msgstr ""
 msgid "FM Radio"
 msgstr ""
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1067,13 +1071,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 #, fuzzy
 msgid "Files"
 msgstr "_Arquivo"
@@ -1086,15 +1090,15 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 msgid "Find..."
 msgstr ""
 
@@ -1142,7 +1146,7 @@ msgid ""
 msgstr ""
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1211,7 +1215,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1291,8 +1295,8 @@ msgstr "Frequência"
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr ""
 
@@ -1300,20 +1304,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Mostrar Memória Raw"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Ajuda"
 
@@ -1325,7 +1329,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Sobrescrever?"
@@ -1335,24 +1339,24 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "Importar"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 #, fuzzy
 msgid "Import from file..."
 msgstr "Importar do Arquivo"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Importar de RFinder"
@@ -1365,11 +1369,11 @@ msgstr "Índice"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Inserir row acima"
@@ -1378,7 +1382,7 @@ msgstr "Inserir row acima"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1392,7 +1396,7 @@ msgstr "Erro Interno"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Valor inválido. Deve ser um número inteiro."
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Valor Inválido para este campo"
@@ -1401,12 +1405,12 @@ msgstr "Valor Inválido para este campo"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1423,13 +1427,13 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 #, fuzzy
 msgid "Language"
 msgstr "Mudar idioma"
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr ""
 
@@ -1438,7 +1442,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr ""
 
@@ -1446,20 +1450,24 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+msgid "Limit use"
+msgstr ""
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "Rádio"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Load Module..."
 msgstr "Modo Tom"
@@ -1469,18 +1477,18 @@ msgstr "Modo Tom"
 msgid "Load module from issue"
 msgstr "Modo Tom"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Modo Tom"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1503,7 +1511,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr ""
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr ""
 
@@ -1511,7 +1519,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Memórias"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1529,7 +1537,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 #, fuzzy
 msgid "Mode"
 msgstr "Modo"
@@ -1538,20 +1546,20 @@ msgstr "Modo"
 msgid "Model"
 msgstr "Modelo"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Modes"
 msgstr "Modo"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1560,29 +1568,29 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Mover Abaix_o"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Mover _Acima"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Inserir row abaixo"
@@ -1600,11 +1608,11 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr ""
 
@@ -1612,7 +1620,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Offset"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr ""
 
@@ -1624,55 +1632,59 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 #, fuzzy
 msgid "Open Recent"
 msgstr "_Recente"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Abrir config do estoque"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Abrir configuração de estoque {name}"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Opções"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1680,7 +1692,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Sobrescrever?"
@@ -1696,31 +1708,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Colar"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1750,7 +1762,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1779,7 +1791,7 @@ msgstr "Power"
 msgid "Press enter to set this in memory"
 msgstr "Erro gravando memória"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr ""
 
@@ -1787,16 +1799,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr ""
 
@@ -1804,7 +1816,7 @@ msgstr ""
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "Rádio"
 
@@ -1825,11 +1837,11 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1854,11 +1866,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1873,30 +1885,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Emissão de Relatórios desabilitada"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1904,15 +1916,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr ""
 
@@ -1936,27 +1948,27 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Selecionar Colunas"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 #, fuzzy
 msgid "Select Bands"
 msgstr "Selecionar Colunas"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "Selecionar Colunas"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Select Modes"
 msgstr "Selecionar Colunas"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1972,57 +1984,57 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Mostrar Memória Raw"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Memória colada {number} não é compatível com este rádio porque:"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Sobrescrever?"
@@ -2031,7 +2043,7 @@ msgstr "Sobrescrever?"
 msgid "Sorting"
 msgstr ""
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr ""
 
@@ -2039,7 +2051,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr ""
 
@@ -2047,7 +2059,7 @@ msgstr ""
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2083,7 +2095,7 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2093,7 +2105,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Mostrar Memória Raw"
@@ -2118,13 +2130,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2159,12 +2171,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Apagar (e deslocar)"
@@ -2202,7 +2214,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Tom"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Modo Tom"
 
@@ -2240,7 +2252,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Tune Step"
@@ -2255,16 +2267,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Abrir config do estoque"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Incapaz de detectar rádio na {port}"
@@ -2295,12 +2307,12 @@ msgstr "Incapaz de efetuar alterações para este modelo"
 msgid "Unable to set %s on this memory"
 msgstr "Incapaz de efetuar alterações para este modelo"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Incapaz de efetuar alterações para este modelo"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr ""
 
@@ -2317,12 +2329,12 @@ msgstr "Tipo de arquivo não-suportado"
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Carregar para o Rádio"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Carregar para o Rádio"
@@ -2332,11 +2344,11 @@ msgstr "Carregar para o Rádio"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr ""
 
@@ -2364,7 +2376,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2372,7 +2384,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Fornecedor"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 #, fuzzy
 msgid "View"
 msgstr "_Visualizar"
@@ -2381,16 +2393,16 @@ msgstr "_Visualizar"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr ""
 
@@ -2414,11 +2426,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/ru.po
+++ b/chirp/locale/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2023-10-11 16:47+0300\n"
 "Last-Translator: Olesya Gerasimenko <translation-team@basealt.ru>\n"
 "Language-Team: Basealt Translation Team\n"
@@ -38,7 +38,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s должно находиться в диапазоне от %(min)i до %(max)i"
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -46,7 +46,7 @@ msgstr[0] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[1] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[2] "Ячейки памяти (%i) и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -54,7 +54,7 @@ msgstr[0] "Ячейки памяти (%i)"
 msgstr[1] "Ячейки памяти (%i)"
 msgstr[2] "Ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -62,7 +62,7 @@ msgstr[0] "Ячейки памяти (%i) и сдвинуть блок ввер�
 msgstr[1] "Ячейки памяти (%i) и сдвинуть блок вверх"
 msgstr[2] "Ячейки памяти (%i) и сдвинуть блок вверх"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Сохранение %s не было выполнено. Сохранить перед закрытием?"
@@ -71,7 +71,7 @@ msgstr "Сохранение %s не было выполнено. Сохрани
 msgid "(none)"
 msgstr "(нет)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr "...и ещё %i"
@@ -967,7 +967,7 @@ msgstr ""
 "Отправка может не получиться, если вы включите станцию, когда кабель уже "
 "подключён"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -975,27 +975,27 @@ msgstr ""
 "Доступная новая версия программы CHIRP. Как можно скорее загрузите её на веб-"
 "сайте!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "О программе"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr "О программе CHIRP"
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Все"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Все файлы"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Все поддерживаемые форматы|"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr "Любительская радиосвязь"
 
@@ -1007,7 +1007,7 @@ msgstr "Ошибка"
 msgid "Applying settings"
 msgstr "Применение параметров"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Авторазнос для репитера"
@@ -1016,11 +1016,11 @@ msgstr "Авторазнос для репитера"
 msgid "Available modules"
 msgstr "Доступные модули"
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr "Частотный план"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr "Полосы частот"
 
@@ -1040,14 +1040,14 @@ msgstr "Браузер"
 msgid "Building Radio Browser"
 msgstr "Браузер станций"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 #, fuzzy
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 "Режим разработчика теперь %s. Для применения изменений необходимо "
 "перезапустить CHIRP"
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr "Канада"
 
@@ -1059,13 +1059,13 @@ msgstr ""
 "Для изменения этого параметра требуется обновить параметры из образа, что и "
 "будет сейчас выполнено."
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Каналы с эквивалентными TX и RX %s представлены видом субтона «%s»."
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Файлы образов Chirp"
 
@@ -1073,21 +1073,21 @@ msgstr "Файлы образов Chirp"
 msgid "Choice Required"
 msgstr "Необходимо сделать выбор"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Выберите код DTCS %s"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Выберите тон %s"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "Выберите кросс-режим"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr "Выберите дуплекс"
 
@@ -1096,7 +1096,7 @@ msgstr "Выберите дуплекс"
 msgid "Choose the module to load from issue %i:"
 msgstr "Выберите модуль для загрузки из задачи %i:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr "Город"
 
@@ -1132,15 +1132,15 @@ msgstr "Клонирование из станции"
 msgid "Cloning to radio"
 msgstr "Клонирование на станцию"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr "Закрыть"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr "Закрыть файл"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1174,16 +1174,16 @@ msgstr ""
 "Подключите ваш интерфейсный кабель к PC-порту на\n"
 "задней стороне модуля «TX/RX». НЕ к COM-порту на головке.\n"
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Копировать"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr "Страна"
 
@@ -1200,7 +1200,7 @@ msgstr "Пользовательский порт"
 msgid "Custom..."
 msgstr "Пользовательский..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Вырезать"
 
@@ -1220,11 +1220,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "DV-память"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr "Впереди опасность"
 
@@ -1232,35 +1232,35 @@ msgstr "Впереди опасность"
 msgid "Dec"
 msgstr "Десятичный"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Режим разработчика"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Режим разработчика теперь %s. Для применения изменений необходимо "
 "перезапустить CHIRP"
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Сравнить необработанные ячейки памяти"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Цифровой код"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 #, fuzzy
 msgid "Digital Modes"
 msgstr "Цифровой код"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr "Отключить отправку отчётов"
 
@@ -1269,7 +1269,7 @@ msgid "Disabled"
 msgstr "Отключено"
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr "Расстояние"
 
@@ -1286,15 +1286,15 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr "Сделайте двойной щелчок, чтобы изменить имя банка"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr "Загрузить"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 msgid "Download from radio"
 msgstr "Загрузить из станции"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "Загрузить из станции..."
 
@@ -1311,11 +1311,11 @@ msgstr "Перезагрузить драйвер"
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -1323,17 +1323,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Редактировать сведения о ячейках памяти (%i)"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Редактировать сведения о ячейке памяти (%i)"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Включить автоматическое редактирование"
 
@@ -1345,11 +1345,11 @@ msgstr "Включено"
 msgid "Enter Frequency"
 msgstr "Введите частоту"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr "Введите смещение (МГц)"
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "Введите частоту TX (МГц)"
 
@@ -1375,23 +1375,27 @@ msgstr "Ошибка применения параметров"
 msgid "Error communicating with radio"
 msgstr "Ошибка обмена данными со станцией"
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr "Экспериментальный драйвер"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "При экспорте можно выполнять запись только в файлы CSV"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 msgid "Export to CSV"
 msgstr "Экспорт в CSV"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 msgid "Export to CSV..."
 msgstr "Экспорт в CSV..."
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Дополнительно"
 
@@ -1399,7 +1403,7 @@ msgstr "Дополнительно"
 msgid "FM Radio"
 msgstr ""
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1421,13 +1425,13 @@ msgstr "Не удалось проанализировать результат"
 msgid "Features"
 msgstr "Функции"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Файл не существует: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 msgid "Files"
 msgstr "Файлы"
 
@@ -1439,15 +1443,15 @@ msgstr "Фильтр"
 msgid "Filter results with location matching this string"
 msgstr "Фильтровать результаты с расположением, соответствующим этой строке"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr "Найти"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr "Найти далее"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 msgid "Find..."
 msgstr "Найти..."
 
@@ -1518,7 +1522,7 @@ msgstr ""
 "    не будет звука!\n"
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1627,7 +1631,7 @@ msgstr ""
 "6 - Выключите и снова включите питание станции, чтобы выйти\n"
 "    из режима клонирования\n"
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1742,8 +1746,8 @@ msgstr "Частота"
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1751,19 +1755,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Получение параметров"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Перейти к ячейке памяти"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Переход к ячейке памяти:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "Переход..."
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Справка"
 
@@ -1775,7 +1779,7 @@ msgstr "Помощь..."
 msgid "Hex"
 msgstr "Шестнадцатеричный"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "Скрыть пустые ячейки памяти"
 
@@ -1784,24 +1788,24 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 "Если установлено, упорядочить результаты по расстоянию от этих координат"
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "Импорт"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 msgid "Import from file..."
 msgstr "Импорт из файла..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 msgid "Import not recommended"
 msgstr "Импорт не рекомендуется"
 
@@ -1813,11 +1817,11 @@ msgstr "Индекс"
 msgid "Info"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Вставить строку выше"
 
@@ -1825,7 +1829,7 @@ msgstr "Вставить строку выше"
 msgid "Install desktop icon?"
 msgstr "Создать значок на рабочем столе?"
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr "Обмен данными с драйвером"
 
@@ -1839,7 +1843,7 @@ msgstr "Ошибка"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s — неверно (используйте десятичные градусы)"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 msgid "Invalid Entry"
 msgstr "Некорректная запись"
 
@@ -1847,12 +1851,12 @@ msgstr "Некорректная запись"
 msgid "Invalid ZIP code"
 msgstr "Неверный почтовый индекс"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Некорректное изменение: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr "Некорректный или неподдерживаемый файл модуля"
 
@@ -1869,13 +1873,13 @@ msgstr "Номер задачи:"
 msgid "LIVE"
 msgstr "В ЭФИРЕ"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 #, fuzzy
 msgid "Language"
 msgstr "Изменить язык"
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr "Широта"
 
@@ -1884,7 +1888,7 @@ msgstr "Широта"
 msgid "Length must be %i"
 msgstr "Длина должна составлять %i"
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr "Ограничение полос частот"
 
@@ -1892,20 +1896,25 @@ msgstr "Ограничение полос частот"
 msgid "Limit Modes"
 msgstr "Ограничение режимов"
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr "Ограничение состояния"
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Ограничить результаты этим расстоянием (км) от координат"
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Limit use"
+msgstr "Ограничение состояния"
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "Станция"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 msgid "Load Module..."
 msgstr "Загрузить модуль..."
 
@@ -1913,17 +1922,17 @@ msgstr "Загрузить модуль..."
 msgid "Load module from issue"
 msgstr "Загрузить модуль из задачи"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 msgid "Load module from issue..."
 msgstr "Загрузить модуль из задачи..."
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1952,7 +1961,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr ""
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr "Долгота"
 
@@ -1960,7 +1969,7 @@ msgstr "Долгота"
 msgid "Memories"
 msgstr "Ячейки памяти"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Ячейку памяти %i нельзя удалить"
@@ -1978,7 +1987,7 @@ msgstr "Чтобы редактировать ячейку памяти, нео�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Ячейка памяти {num} отсутствует в банке {bank}"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 msgid "Mode"
 msgstr "Режим"
 
@@ -1986,19 +1995,19 @@ msgstr "Режим"
 msgid "Model"
 msgstr "Модель"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Modes"
 msgstr "Режимы"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr "Модуль"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr "Модуль загружен"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr "Модуль успешно загружен"
 
@@ -2007,27 +2016,27 @@ msgstr "Модуль успешно загружен"
 msgid "More than one port found: %s"
 msgstr "Найдено более одного порта: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "Переместить вниз"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "Переместить вверх"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr "Новое окно"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr "Доступна новая версия"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "Ниже нет пустых строк!"
 
@@ -2044,11 +2053,11 @@ msgstr "В задаче %i не найдены модули"
 msgid "No results"
 msgstr "Нет результатов"
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr "Нет результатов!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr "Число"
 
@@ -2056,7 +2065,7 @@ msgstr "Число"
 msgid "Offset"
 msgstr "Смещение"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr "Только некоторые полосы частот"
 
@@ -2068,51 +2077,55 @@ msgstr "Только некоторые режимы"
 msgid "Only memory tabs may be exported"
 msgstr "Можно экспортировать только вкладки памяти"
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr "Только работающие репитеры"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr "Открыть"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 msgid "Open Recent"
 msgstr "Открыть недавние"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 msgid "Open Stock Config"
 msgstr "Открыть предустановленную конфигурацию"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Открыть файл"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr "Открыть модуль"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Открыть журнал отладки"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr "Открыть в новом окне"
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 msgid "Open stock config directory"
 msgstr "Открыть каталог предустановленной конфигурации"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr "Опционально: -122.0000"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 msgid "Optional: 100"
 msgstr "Опционально: 100"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr "Опционально: 45.0000"
 
@@ -2120,7 +2133,7 @@ msgstr "Опционально: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Опционально: округ, больница и т.д."
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "Перезаписать ячейки памяти?"
 
@@ -2138,31 +2151,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Анализ"
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Вставить"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Вставленные ячейки памяти перезапишут существующие ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейку памяти %s"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Вставленная ячейка памяти перезапишет ячейку памяти %s"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Обязательно выйдите из программы CHIRP перед установкой новой версии!"
 
@@ -2210,7 +2223,7 @@ msgstr ""
 "4 - Затем нажмите кнопку «A» на вашей станции для начала клонирования.\n"
 "    (По завершении станция подаст звуковой сигнал.)\n"
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2243,7 +2256,7 @@ msgstr "Мощность"
 msgid "Press enter to set this in memory"
 msgstr "Нажмите «Ввод» для добавления в память"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr "Предпросмотр"
 
@@ -2251,16 +2264,16 @@ msgstr "Предпросмотр"
 msgid "Printing"
 msgstr "Печать"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Свойства"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr "Запрос %s"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Запрос источника"
 
@@ -2268,7 +2281,7 @@ msgstr "Запрос источника"
 msgid "RX DTCS"
 msgstr "DTCS RX"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "Станция"
 
@@ -2291,11 +2304,11 @@ msgstr ""
 "когда выбранная модель не является американской, а станция является. "
 "Выберите правильную модель и повторите попытку."
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr "RadioReference Canada запрашивает вход перед выполнением запроса"
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -2320,11 +2333,11 @@ msgstr "Требуется обновление"
 msgid "Refreshed memory %s"
 msgstr "Обновлена ячейки памяти %s"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Перезагрузить драйвер"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Перезагрузить драйвер и файл"
 
@@ -2338,11 +2351,11 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Отправка отчётов включена"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2353,11 +2366,11 @@ msgstr ""
 "признательны, если вы оставите эту функцию включённой. Действительно "
 "отключить отправку отчётов?"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr "Требуется перезапуск"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, fuzzy, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
@@ -2365,7 +2378,7 @@ msgstr[0] "Восстановить вкладки (%i)"
 msgstr[1] "Восстановить вкладки (%i)"
 msgstr[2] "Восстановить вкладки (%i)"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 #, fuzzy
 msgid "Restore tabs on start"
 msgstr "Восстановить вкладки (%i)"
@@ -2374,15 +2387,15 @@ msgstr "Восстановить вкладки (%i)"
 msgid "Retrieved settings"
 msgstr "Полученные параметры"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr "Сохранить"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr "Сохранить перед закрытием?"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr "Сохранить файл"
 
@@ -2406,24 +2419,24 @@ msgstr ""
 msgid "Security Risk"
 msgstr "Угроза безопасности"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "Выбрать частотный план..."
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Select Bands"
 msgstr "Выбор полос частот"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "Выбор полос частот"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Select Modes"
 msgstr "Выбор режимов"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr "Выбор частотного плана"
 
@@ -2439,32 +2452,32 @@ msgstr "Параметры"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Показать необработанную ячейку памяти"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Показать расположение журнала отладки"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "Показать дополнительные поля"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Show image backup location"
 msgstr "Показать расположение журнала отладки"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Некоторые ячейки памяти несовместимы с этой станцией"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Некоторые ячейки памяти нельзя удалить"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -2472,7 +2485,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i)"
 msgstr[1] "Упорядочить ячейки памяти (%i)"
 msgstr[2] "Упорядочить ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -2480,7 +2493,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по возра
 msgstr[1] "Упорядочить ячейки памяти (%i) по возрастанию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по возрастанию"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -2488,11 +2501,11 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по убыва
 msgstr[1] "Упорядочить ячейки памяти (%i) по убыванию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по убыванию"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "Сортировать по столбцу:"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "Упорядочить ячейки памяти"
 
@@ -2500,7 +2513,7 @@ msgstr "Упорядочить ячейки памяти"
 msgid "Sorting"
 msgstr "Сортировка"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr "Область"
 
@@ -2508,7 +2521,7 @@ msgstr "Область"
 msgid "State/Province"
 msgstr "Область/регион"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr "Успешно"
 
@@ -2516,7 +2529,7 @@ msgstr "Успешно"
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2571,7 +2584,7 @@ msgstr ""
 "загружать этот модуль, так как возможна угроза безопасности. Всё равно "
 "продолжить?"
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2586,7 +2599,7 @@ msgstr ""
 "текущем открытом файле на ячейки из %(file)s. Открыть этот файл для "
 "копирования/вставки ячеек памяти или продолжить импорт?"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "Эта ячейка памяти"
 
@@ -2613,13 +2626,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2658,11 +2671,11 @@ msgstr ""
 "Также присылайте отчёты об ошибках и предложения по улучшению.\n"
 "Вы были предупреждены; продолжайте на свой страх и риск!"
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "Эта ячейка памяти и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "Эта ячейка памяти и сдвинуть блок вверх"
 
@@ -2709,7 +2722,7 @@ msgstr "Будет выполнена загрузка модуля из зад�
 msgid "Tone"
 msgstr "ТонПРД"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Вид субтона"
 
@@ -2746,7 +2759,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Шаг настройки"
 
@@ -2762,16 +2775,16 @@ msgstr ""
 "Не удалось определить порт для вашего кабеля. Проверьте драйверы и "
 "подключения."
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Перед редактированием ячейки памяти необходимо загрузить станцию"
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Не удалось найти предустановленную конфигурацию %r"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Перед редактированием ячейки памяти необходимо загрузить станцию"
@@ -2804,12 +2817,12 @@ msgstr "Невозможно обнаружить %s в этой системе"
 msgid "Unable to set %s on this memory"
 msgstr "Невозможно установить %s для этой ячейки памяти"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Невозможно обнаружить %s в этой системе"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr "Соединённые Штаты"
 
@@ -2826,11 +2839,11 @@ msgstr "Неподдерживаемый тип файла"
 msgid "Upload instructions"
 msgstr "Отправка инструкций"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 msgid "Upload to radio"
 msgstr "Отправка на станцию"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "Отправка на станцию..."
 
@@ -2839,11 +2852,11 @@ msgstr "Отправка на станцию..."
 msgid "Uploaded memory %s"
 msgstr "Отправлена ячейка памяти %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr "Использовать моноширинный шрифт"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr "Использовать более крупный шрифт"
 
@@ -2871,7 +2884,7 @@ msgstr "Значение должно содержать десятичные ц
 msgid "Value must be zero or greater"
 msgstr "Значение должно быть больше или равно нулю"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "Значения"
 
@@ -2879,7 +2892,7 @@ msgstr "Значения"
 msgid "Vendor"
 msgstr "Изготовитель"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 msgid "View"
 msgstr "Вид"
 
@@ -2887,16 +2900,16 @@ msgstr "Вид"
 msgid "WARNING!"
 msgstr "ПРЕДУПРЕЖДЕНИЕ!"
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Предупреждение: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr "Добро пожаловать"
 
@@ -2920,11 +2933,11 @@ msgstr "байт"
 msgid "bytes each"
 msgstr "байт каждый"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr "отключён"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr "включён"
 

--- a/chirp/locale/tr_TR.po
+++ b/chirp/locale/tr_TR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2024-03-02 00:22+0300\n"
 "Last-Translator: Abdullah YILMAZ (TA1AUB) <h.abdullahyilmaz@hotmail.com>\n"
 "Language-Team: TURKISH\n"
@@ -42,28 +42,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s, %(min)i ile %(max)i arasında olmalıdır"
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Kaydı ve hepsini yukarı kaydır"
 msgstr[1] "%i Kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Kaydı"
 msgstr[1] "%i Kaydı"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i Kaydı ve bloğu yukarı kaydır"
 msgstr[1] "%i Kaydı ve bloğu yukarı kaydır"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s kaydedilmedi. Kapanmadan önce kaydedilsin mi?"
@@ -72,7 +72,7 @@ msgstr "%s kaydedilmedi. Kapanmadan önce kaydedilsin mi?"
 msgid "(none)"
 msgstr "(hiçbiri)"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr "...ve %i daha"
@@ -963,7 +963,7 @@ msgstr ""
 "\n"
 "Kablo takılıyken telsizi açarsanız çalışmayabilir"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
@@ -971,27 +971,27 @@ msgstr ""
 "Yeni bir CHIRP sürümü mevcut. İndirmek için lütfen en kısa zamanda web "
 "sitesini ziyaret edin!"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr "Hakkında"
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr "CHIRP Hakkında"
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Tümü"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "Tüm Dosyalar"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr "Desteklenen tüm biçimler|"
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr "Amatör"
 
@@ -1003,7 +1003,7 @@ msgstr "Bir hata oluştu"
 msgid "Applying settings"
 msgstr "Ayarlar uygulanıyor"
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Otomatik Tekrarlama Ofseti"
@@ -1012,11 +1012,11 @@ msgstr "Otomatik Tekrarlama Ofseti"
 msgid "Available modules"
 msgstr "Mevcut modüller"
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr "Bant planı"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr "Bantlar"
 
@@ -1036,13 +1036,13 @@ msgstr "Tarayıcı"
 msgid "Building Radio Browser"
 msgstr "Telsiz Tarayıcısı oluşturuluyor"
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 #, fuzzy
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 "Geliştirici durumu artık %s. Etkili olması için CHIRP yeniden başlatılmalıdır"
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr "Kanada"
 
@@ -1054,14 +1054,14 @@ msgstr ""
 "Bu ayarın değiştirilmesi, imajdaki ayarların yenilenmesini gerektirir, bu "
 "işlem şimdi gerçekleşecektir."
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 "Eşdeğer TX ve RX %s'ye sahip kanallar, \"%s\" ton modu ile temsil edilir"
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr "Chirp İmaj Dosyaları"
 
@@ -1069,21 +1069,21 @@ msgstr "Chirp İmaj Dosyaları"
 msgid "Choice Required"
 msgstr "Seçim Gerekli"
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "%s DTCS Kodunu Seç"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr "%s Tonunu Seç"
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "Çapraz Modu Seç"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr "Dubleks seç"
 
@@ -1092,7 +1092,7 @@ msgstr "Dubleks seç"
 msgid "Choose the module to load from issue %i:"
 msgstr "Sorun %i'den yüklenecek modülü seçin:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr "Şehir"
 
@@ -1128,15 +1128,15 @@ msgstr "Telsizden klonlanıyor"
 msgid "Cloning to radio"
 msgstr "Telsize klonlanıyor"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr "Kapat"
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr "Dosyayı kapat"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1171,16 +1171,16 @@ msgstr ""
 "Arayüz kablonuzu 'TX/RX' ünitesinin arkasındaki\n"
 "PC Bağlantı Noktasına bağlayın. Kafadaki Com Portu DEĞİL.\n"
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr "FM'e dönüştür"
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "Kopyala"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr "Ülke"
 
@@ -1196,7 +1196,7 @@ msgstr "Özel Bağlantı Noktası"
 msgid "Custom..."
 msgstr "Özel..."
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "Kes"
 
@@ -1216,11 +1216,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "DTMF kod çöz"
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "DV Kaydı"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr "İleride Tehlike"
 
@@ -1228,33 +1228,33 @@ msgstr "İleride Tehlike"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "Sil"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "Geliştirici Modu"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 "Geliştirici durumu artık %s. Etkili olması için CHIRP yeniden başlatılmalıdır"
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Farklı Ham Kayıtlar"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Dijital Kod"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 msgid "Digital Modes"
 msgstr "Dijital Modlar"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr "Raporlamayı devre dışı bırak"
 
@@ -1263,7 +1263,7 @@ msgid "Disabled"
 msgstr "Devre dışı"
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr "Mesafe"
 
@@ -1280,15 +1280,15 @@ msgstr "Riski kabul ediyor musun?"
 msgid "Double-click to change bank name"
 msgstr "Banka adını değiştirmek için çift tıklayın"
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr "İndir"
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 msgid "Download from radio"
 msgstr "Telsizden indir"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "Telsizden indir..."
 
@@ -1304,11 +1304,11 @@ msgstr "Sürücü"
 msgid "Driver information"
 msgstr "Sürücü bilgileri"
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr "Sürücü mesajları"
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 "Analogu destekleyen çift modlu dijital tekrarlayıcılar(röleler) FM olarak "
@@ -1318,17 +1318,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "%i kaydı için ayrıntıları düzenle"
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "%i kaydı için ayrıntıları düzenle"
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr "Otomatik Düzenlemeleri Etkinleştir"
 
@@ -1340,11 +1340,11 @@ msgstr "Etkin"
 msgid "Enter Frequency"
 msgstr "Frekans Gir"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr "Ofset girin (MHz)"
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr "TX Frekansını girin (MHz)"
 
@@ -1370,23 +1370,27 @@ msgstr "Ayarlar uygulanırken hata oluştu"
 msgid "Error communicating with radio"
 msgstr "Telsizle iletişim hatası"
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr "Deneysel sürücü"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr "Dışa aktarma yalnızca CSV dosyalarını yazabilir"
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 msgid "Export to CSV"
 msgstr "CSV'ye aktar"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 msgid "Export to CSV..."
 msgstr "CSV'ye aktar..."
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -1394,7 +1398,7 @@ msgstr "Ekstra"
 msgid "FM Radio"
 msgstr "FM Radyo"
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1416,13 +1420,13 @@ msgstr "Sonuç ayrıştırılamadı"
 msgid "Features"
 msgstr "Özellikler"
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Dosya mevcut değil: %s"
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 msgid "Files"
 msgstr "Dosyalar"
 
@@ -1434,15 +1438,15 @@ msgstr "Filtre"
 msgid "Filter results with location matching this string"
 msgstr "Bu dizeyle eşleşen konuma sahip sonuçları filtrele"
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr "Bul"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr "Sonraki Bul"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 msgid "Find..."
 msgstr "Bul..."
 
@@ -1509,7 +1513,7 @@ msgstr ""
 "5 - Arayüz kablosunu çıkarın! Aksi takdirde, sağ taraf sesi olmayacaktır!\n"
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1613,7 +1617,7 @@ msgstr ""
 "5 - Arayüz kablosunu çıkarın, aksi takdirde sağ tarafta ses olmayacaktır!\n"
 "6 - Klon modundan çıkmak için telsizi kapatıp açın\n"
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1728,8 +1732,8 @@ msgstr "Frekans"
 msgid "Frequency granularity in kHz"
 msgstr "kHz cinsinden frekans ayrıntı düzeyi"
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr "GMRS"
 
@@ -1737,19 +1741,19 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Ayarlar alınıyor"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "Kayda Git"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "Kayda Git:"
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "Git..."
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Yardım"
 
@@ -1761,7 +1765,7 @@ msgstr "Bana Yardım Et..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "Boş kayıtları gizle"
 
@@ -1770,23 +1774,23 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr "İnsan tarafından okunabilen yorum (telsizde saklanmaz)"
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr "Ayarlanırsa, sonuçları bu koordinatlardan uzaklığa göre sırala"
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 msgid "Import from file..."
 msgstr "Dosyadan İçe Aktar..."
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr "Mesajları içe aktar"
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 msgid "Import not recommended"
 msgstr "İçe aktarma önerilmez"
 
@@ -1798,11 +1802,11 @@ msgstr "Dizin"
 msgid "Info"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "Yukarıya Satır Ekle"
 
@@ -1810,7 +1814,7 @@ msgstr "Yukarıya Satır Ekle"
 msgid "Install desktop icon?"
 msgstr "Masaüstü simgesi yüklensin mi?"
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr "Sürücü ile etkileşim"
 
@@ -1823,7 +1827,7 @@ msgstr "Dahili sürücü hatası"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Geçersiz %(value)s (ondalık basamak kullanın)"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 msgid "Invalid Entry"
 msgstr "Geçersiz Girdi"
 
@@ -1831,12 +1835,12 @@ msgstr "Geçersiz Girdi"
 msgid "Invalid ZIP code"
 msgstr "Geçersiz Posta kodu"
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Geçersiz düzenleme: %s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr "Geçersiz veya desteklenmeyen modül dosyası"
 
@@ -1853,12 +1857,12 @@ msgstr "Kayıt numarası:"
 msgid "LIVE"
 msgstr "CANLI"
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 msgid "Language"
 msgstr ""
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr "Enlem"
 
@@ -1867,7 +1871,7 @@ msgstr "Enlem"
 msgid "Length must be %i"
 msgstr "Uzunluk %i olmalıdır"
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr "Bantları Sınırla"
 
@@ -1875,19 +1879,24 @@ msgstr "Bantları Sınırla"
 msgid "Limit Modes"
 msgstr "Modları Sınırla"
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr "Durum Sınırla"
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Sonuçları koordinatlardan bu mesafeye (km) sınırla"
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+#, fuzzy
+msgid "Limit use"
+msgstr "Durum Sınırla"
+
+#: ../wxui/main.py:1566
 msgid "Live Radio"
 msgstr "Canlı Radyo"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 msgid "Load Module..."
 msgstr "Modül Yükle..."
 
@@ -1895,17 +1904,17 @@ msgstr "Modül Yükle..."
 msgid "Load module from issue"
 msgstr "Kayıttan modül yükle"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 msgid "Load module from issue..."
 msgstr "Kayıttan modül yükle..."
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1935,7 +1944,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr "Logo dizesi 2 (12 karakter)"
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr "Boylam"
 
@@ -1943,7 +1952,7 @@ msgstr "Boylam"
 msgid "Memories"
 msgstr "Kayıtlar"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Kayıt %i silinemez"
@@ -1961,7 +1970,7 @@ msgstr "Hafızanın düzenlenebilmesi için bir bankada olması gerekir"
 msgid "Memory {num} not in bank {bank}"
 msgstr "{num} kaydı {bank} bankasında değil"
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 msgid "Mode"
 msgstr "Mod"
 
@@ -1969,19 +1978,19 @@ msgstr "Mod"
 msgid "Model"
 msgstr "Model"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Modes"
 msgstr "Modlar"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr "Modül"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr "Modül Yüklendi"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr "Modül başarıyla yüklendi"
 
@@ -1990,27 +1999,27 @@ msgstr "Modül başarıyla yüklendi"
 msgid "More than one port found: %s"
 msgstr "Birden fazla bağlantı noktası bulundu: %s"
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "Aşağı Taşı"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "Yukarı Taşı"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr "Yeni Pencere"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr "Yeni sürüm mevcut"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr "Aşağıda boş satır yok!"
 
@@ -2027,11 +2036,11 @@ msgstr "%i kadında modül bulunamadı"
 msgid "No results"
 msgstr "Sonuç yok"
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr "Sonuç yok!"
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr "Numara"
 
@@ -2039,7 +2048,7 @@ msgstr "Numara"
 msgid "Offset"
 msgstr "Ofset"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr "Sadece belirli gruplar"
 
@@ -2051,51 +2060,55 @@ msgstr "Yalnızca belirli modlar"
 msgid "Only memory tabs may be exported"
 msgstr "Yalnızca kayıt sekmeleri dışa aktarılabilir"
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr "Yalnızca çalışan tekrarlayıcılar (röleler)"
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr "Aç"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 msgid "Open Recent"
 msgstr "Son Kullanılanları Aç"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 msgid "Open Stock Config"
 msgstr "Hazır Yapılandırma Aç"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr "Bir dosya aç"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr "Bir modül aç"
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "Hata ayıklama günlüğünü aç"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr "Yeni pencerede aç"
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 msgid "Open stock config directory"
 msgstr "Hazır yapılandırma dizinini aç"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr "İsteğe bağlı: -122.0000"
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 msgid "Optional: 100"
 msgstr "İsteğe bağlı: 100"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr "İsteğe bağlı: 45.0000"
 
@@ -2103,7 +2116,7 @@ msgstr "İsteğe bağlı: 45.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "İsteğe bağlı: bölge, Hastane vb."
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "Kayıtların üzerine yazılsın mı?"
 
@@ -2121,31 +2134,31 @@ msgstr ""
 msgid "Parsing"
 msgstr "Ayrıştırılıyor"
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Yapıştırılan kayıtlar, mevcut %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Yapıştırılan kayıtlar %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Yapıştırılan kayıtlar, %s kaydının üzerine yazılacak"
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Yapıştırılan kayıt, %s kaydının üzerine yazacak"
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Lütfen yeni sürümü yüklemeden önce CHIRP'den çıktığınızdan emin olun!"
 
@@ -2193,7 +2206,7 @@ msgstr ""
 "4 - Ardından klonlamaya başlamak için telsizinizdeki \"A\" tuşuna basın.\n"
 "     (Sonunda telsiz bip sesi çıkaracaktır)\n"
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -2226,7 +2239,7 @@ msgstr "Güç"
 msgid "Press enter to set this in memory"
 msgstr "Bu kayda almak için enter tuşuna basın"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr "Baskı Önizleme"
 
@@ -2234,16 +2247,16 @@ msgstr "Baskı Önizleme"
 msgid "Printing"
 msgstr "Baskı"
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "Özellikler"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr "%s sorgusu"
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "Kaynaktan Sorgula"
 
@@ -2251,7 +2264,7 @@ msgstr "Kaynaktan Sorgula"
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "Telsiz"
 
@@ -2274,12 +2287,12 @@ msgstr ""
 "dışındaysa gerçekleşir ama telsiz bir ABD telsizi. Lütfen doğru modeli seçin "
 "ve tekrar deneyin."
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 "RadioReference Kanada, sorgulayabilmeniz için önce oturum açmanız gerekir"
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -2306,11 +2319,11 @@ msgstr "Yeniden Başlatma Gerekli"
 msgid "Refreshed memory %s"
 msgstr "Yenilenmiş %s kaydı"
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "Sürücüyü Yeniden Yükle"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "Sürücüyü ve Dosyayı Yeniden Yükle"
 
@@ -2326,11 +2339,11 @@ msgstr ""
 "RepeaterBook, Amatör Telsiz için dünya çapında en kapsamlı \n"
 "ÜCRETSİZ röle rehberidir."
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "Raporlama etkinleştirildi"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
@@ -2341,18 +2354,18 @@ msgstr ""
 "bırakırsanız gerçekten minnettar oluruz. Raporlama gerçekten devre dışı "
 "bırakılsın mı?"
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr "Yeniden Başlatma Gerekiyor"
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "%i sekmeyi geri yükle"
 msgstr[1] "%i sekmeyi geri yükle"
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr "Başlangıçta sekmeleri geri yükle"
 
@@ -2360,15 +2373,15 @@ msgstr "Başlangıçta sekmeleri geri yükle"
 msgid "Retrieved settings"
 msgstr "Alınan ayarlar"
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr "Kaydet"
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr "Kapanmadan önce kaydedilsin mi?"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr "Dosyayı kaydet"
 
@@ -2392,24 +2405,24 @@ msgstr "Karıştırıcı"
 msgid "Security Risk"
 msgstr "Güvenlik Riski"
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr "Bant Planı Seç..."
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Select Bands"
 msgstr "Bantları Seç"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "Bantları Seç"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Select Modes"
 msgstr "Modları Seç"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr "Bir bant planı seçin"
 
@@ -2426,56 +2439,56 @@ msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 "Çift yönlü tarafından kontrol edilen kaydırma miktarı (veya iletim frekansı)"
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Ham Kaydı Göster"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "Hata ayıklama günlüğü konumunu göster"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "Ekstra alanları göster"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 msgid "Show image backup location"
 msgstr "İmaj yedekleme konumunu göster"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "Bazı kayıtlar bu telsizle uyumlu değil"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "Bazı anılar silinemez"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "%i kaydı sırala"
 msgstr[1] "%i kaydı sırala"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "%i kaydı artan şekilde sırala"
 msgstr[1] "%i kaydı artan şekilde sırala"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "%i kaydı azalan şekilde sırala"
 msgstr[1] "%i kaydı azalan şekilde sırala"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr "Sütuna göre sırala:"
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr "Kayıtları sırala"
 
@@ -2483,7 +2496,7 @@ msgstr "Kayıtları sırala"
 msgid "Sorting"
 msgstr "Sıralama"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr "Devlet"
 
@@ -2491,7 +2504,7 @@ msgstr "Devlet"
 msgid "State/Province"
 msgstr "Eyalet/İl"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr "Başarılı"
 
@@ -2499,7 +2512,7 @@ msgstr "Başarılı"
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr "TX-RX DTCS polaritesi (normal veya ters)"
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr "DMR-MARC Dünya Çapında iletişim Ağı"
 
@@ -2553,7 +2566,7 @@ msgstr ""
 "oluşturabileceğinden bu modülü yüklememeniz önerilir. Yine de devam edilsin "
 "mi?"
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2569,7 +2582,7 @@ msgstr ""
 "yapıştırmak için bu dosyayı açmak mı yoksa içe aktarma işlemine devam etmek "
 "mi istiyorsunuz?"
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "Bu kaydı"
 
@@ -2601,7 +2614,7 @@ msgstr ""
 "telsizinizden yeni bir imaj indirmeniz ve bunu ileriye doğru kullanmanız "
 "önerilir."
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
@@ -2609,7 +2622,7 @@ msgstr ""
 "Bu, canlı modlu bir telsizdir; bu, değişiklik yaptığınızda gerçek zamanlı "
 "olarak radyoya gönderildiği anlamına gelir. Yükleme gerekli değildir!"
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 #, fuzzy
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
@@ -2660,11 +2673,11 @@ msgstr ""
 "Ayrıca lütfen hata raporu ve geliştirme istekleri gönderin!\n"
 "Uyarıldınız. Kendi sorumluluğunuzda ilerleyin!"
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 msgid "This memory and shift all up"
 msgstr "Bu kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 msgid "This memory and shift block up"
 msgstr "Bu kaydı ve bloğu yukarı kaydır"
 
@@ -2715,7 +2728,7 @@ msgstr "Bu, bir web sitesi kaydından bir modül yükleyecektir"
 msgid "Tone"
 msgstr "Ton"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Ton Modu"
 
@@ -2751,7 +2764,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr "TSQL modu için gönderme/alma tonu, aksi takdirde ton al"
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "Ayarlama Adımı"
 
@@ -2767,16 +2780,16 @@ msgstr ""
 "Kablonuz için bağlantı noktası belirlenemiyor. Sürücülerinizi ve "
 "bağlantılarınızı kontrol edin."
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Radyo yüklenmeden önce kayıt düzenlenemiyor"
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "%r stok yapılandırması bulunamadı"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Radyo yüklenmeden önce kayıt düzenlenemiyor"
@@ -2809,11 +2822,11 @@ msgstr "%s bu sistemde gösterilemiyor"
 msgid "Unable to set %s on this memory"
 msgstr "Bu kayıtta %s ayarlanamıyor"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 msgid "Unable to upload this file"
 msgstr "Bu dosya yüklenemiyor"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr "Amerika Birleşik Devletleri"
 
@@ -2830,11 +2843,11 @@ msgstr "Desteklenmeyen model %r"
 msgid "Upload instructions"
 msgstr "Yükleme talimatları"
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 msgid "Upload to radio"
 msgstr "Telsize yükle"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "Telsize yükle..."
 
@@ -2843,11 +2856,11 @@ msgstr "Telsize yükle..."
 msgid "Uploaded memory %s"
 msgstr "Yüklenen kayıt %s"
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr "Sabit genişlikte yazı tipi kullan"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr "Daha büyük yazı tipi kullan"
 
@@ -2875,7 +2888,7 @@ msgstr "Değer tam olarak %i ondalık basamak olmalıdır"
 msgid "Value must be zero or greater"
 msgstr "Değer sıfır veya daha büyük olmalıdır"
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr "Değerler"
 
@@ -2883,7 +2896,7 @@ msgstr "Değerler"
 msgid "Vendor"
 msgstr "Tedarikçi"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 msgid "View"
 msgstr "Göster"
 
@@ -2891,16 +2904,16 @@ msgstr "Göster"
 msgid "WARNING!"
 msgstr "UYARI!"
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr "Uyarı"
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr "Uyarı: %s"
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr "Hoşgeldiniz"
 
@@ -2924,11 +2937,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "her biri bayt"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr "devre dışı bırakıldı"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr "etkinleştirildi"
 

--- a/chirp/locale/uk_UA.po
+++ b/chirp/locale/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2015-11-30 10:36+0200\n"
 "Last-Translator: laser <student.laser@gmail.com>\n"
 "Language-Team: laser <student.laser@gmail.com>\n"
@@ -33,28 +33,28 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Видалити (та зсунути вгору)"
 msgstr[1] "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Пам'ять"
 msgstr[1] "Пам'ять"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "Видалити (та зсунути вгору)"
 msgstr[1] "Видалити (та зсунути вгору)"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, fuzzy, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "Файл змінено, зберегти зміни перед закриттям?"
@@ -63,7 +63,7 @@ msgstr "Файл змінено, зберегти зміни перед закр
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -621,34 +621,34 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr ""
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "Все"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 #, fuzzy
 msgid "All Files"
 msgstr "CSV-файли"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr ""
 
@@ -660,7 +660,7 @@ msgstr "Сталася помилка"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 #, fuzzy
 msgid "Automatic from system"
 msgstr "Автоматичний рознос репітера"
@@ -669,11 +669,11 @@ msgstr "Автоматичний рознос репітера"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr ""
 
@@ -693,11 +693,11 @@ msgstr ""
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr ""
 
@@ -707,13 +707,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -721,22 +721,22 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS код"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Кросрежим"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -745,7 +745,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "Виберіть один для Імпорту з:"
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr ""
 
@@ -777,15 +777,15 @@ msgstr "Скопіювати з радіостанції"
 msgid "Cloning to radio"
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr ""
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -817,17 +817,17 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 #, fuzzy
 msgid "Copy"
 msgstr "Копіювати"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr ""
 
@@ -844,7 +844,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 #, fuzzy
 msgid "Cut"
 msgstr "Вирізати"
@@ -865,11 +865,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr ""
 
@@ -878,36 +878,36 @@ msgstr ""
 msgid "Dec"
 msgstr "Визначити"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 #, fuzzy
 msgid "Delete"
 msgstr "Видалити"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 #, fuzzy
 msgid "Developer Mode"
 msgstr "Розробник"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "Цифровий код"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 #, fuzzy
 msgid "Digital Modes"
 msgstr "Цифровий код"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr ""
 
@@ -916,7 +916,7 @@ msgid "Disabled"
 msgstr ""
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr ""
 
@@ -933,16 +933,16 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 #, fuzzy
 msgid "Download from radio"
 msgstr "Скопіювати з радіостанції"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 #, fuzzy
 msgid "Download from radio..."
 msgstr "Скопіювати з радіостанції"
@@ -960,11 +960,11 @@ msgstr ""
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -972,17 +972,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -995,11 +995,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Частота"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1026,25 +1026,29 @@ msgstr "Помилка настройки пам'яті"
 msgid "Error communicating with radio"
 msgstr ""
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 #, fuzzy
 msgid "Export to CSV"
 msgstr "Експорт до файлу"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 #, fuzzy
 msgid "Export to CSV..."
 msgstr "Експорт до файлу"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1052,7 +1056,7 @@ msgstr ""
 msgid "FM Radio"
 msgstr ""
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1071,13 +1075,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 #, fuzzy
 msgid "Files"
 msgstr "_Файл"
@@ -1090,15 +1094,15 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 msgid "Find"
 msgstr ""
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 msgid "Find Next"
 msgstr ""
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 msgid "Find..."
 msgstr ""
 
@@ -1146,7 +1150,7 @@ msgid ""
 msgstr ""
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1215,7 +1219,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1295,8 +1299,8 @@ msgstr "Частота"
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr ""
 
@@ -1304,20 +1308,20 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Показати Raw пам'ять"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr ""
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "Довідка"
 
@@ -1329,7 +1333,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Перезаписати?"
@@ -1339,24 +1343,24 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "Імпорт"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 #, fuzzy
 msgid "Import from file..."
 msgstr "Імпортувати з файлу"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 #, fuzzy
 msgid "Import not recommended"
 msgstr "Імпорт з RFinder"
@@ -1369,11 +1373,11 @@ msgstr "Зміст"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Додати рядок зверху"
@@ -1382,7 +1386,7 @@ msgstr "Додати рядок зверху"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1396,7 +1400,7 @@ msgstr "Внутрішня помилка"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Неприпустиме значення. Повинно бути цілим числом."
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Неприпустиме значення для цього поля"
@@ -1405,12 +1409,12 @@ msgstr "Неприпустиме значення для цього поля"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1427,13 +1431,13 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 #, fuzzy
 msgid "Language"
 msgstr "Змінити мову"
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr ""
 
@@ -1442,7 +1446,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr ""
 
@@ -1450,20 +1454,24 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+msgid "Limit use"
+msgstr ""
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "Радіостанція"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 #, fuzzy
 msgid "Load Module..."
 msgstr "Тоновий режим"
@@ -1473,18 +1481,18 @@ msgstr "Тоновий режим"
 msgid "Load module from issue"
 msgstr "Тоновий режим"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "Тоновий режим"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1507,7 +1515,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr ""
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr ""
 
@@ -1516,7 +1524,7 @@ msgstr ""
 msgid "Memories"
 msgstr "Пам'ять"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1534,7 +1542,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 #, fuzzy
 msgid "Mode"
 msgstr "Режим"
@@ -1543,20 +1551,20 @@ msgstr "Режим"
 msgid "Model"
 msgstr "Модель"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Modes"
 msgstr "Режим"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr ""
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1565,29 +1573,29 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 #, fuzzy
 msgid "Move Down"
 msgstr "Перемістити В_низ"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 #, fuzzy
 msgid "Move Up"
 msgstr "Перемістити В_гору"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Додати рядок знизу"
@@ -1605,11 +1613,11 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr ""
 
@@ -1617,7 +1625,7 @@ msgstr ""
 msgid "Offset"
 msgstr "Зсув"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr ""
 
@@ -1629,55 +1637,59 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr ""
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 #, fuzzy
 msgid "Open Recent"
 msgstr "Ос_танні"
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 #, fuzzy
 msgid "Open Stock Config"
 msgstr "Відкрити заводські конфігурації"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 msgid "Open a file"
 msgstr ""
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr ""
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 #, fuzzy
 msgid "Open stock config directory"
 msgstr "Відкрите заводські конфігурації {name}"
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 #, fuzzy
 msgid "Optional: 100"
 msgstr "Опції"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1685,7 +1697,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Перезаписати?"
@@ -1701,32 +1713,32 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 #, fuzzy
 msgid "Paste"
 msgstr "Вставити"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1756,7 +1768,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1785,7 +1797,7 @@ msgstr "Потужність"
 msgid "Press enter to set this in memory"
 msgstr "Помилка настройки пам'яті"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr ""
 
@@ -1793,16 +1805,16 @@ msgstr ""
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr ""
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr ""
 
@@ -1810,7 +1822,7 @@ msgstr ""
 msgid "RX DTCS"
 msgstr ""
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 #, fuzzy
 msgid "Radio"
 msgstr "Радіостанція"
@@ -1832,11 +1844,11 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1861,11 +1873,11 @@ msgstr ""
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr ""
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr ""
 
@@ -1880,30 +1892,30 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 #, fuzzy
 msgid "Reporting enabled"
 msgstr "Звіти вимкнуто"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1911,15 +1923,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr ""
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr ""
 
@@ -1943,27 +1955,27 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 #, fuzzy
 msgid "Select Bandplan..."
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 #, fuzzy
 msgid "Select Bands"
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Select Modes"
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1979,58 +1991,58 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Показати Raw пам'ять"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr ""
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Вставлена пам'ять {number} несумісна із цією радіостанцією тому що:"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 #, fuzzy
 msgid "Sort memories"
 msgstr "Перезаписати?"
@@ -2039,7 +2051,7 @@ msgstr "Перезаписати?"
 msgid "Sorting"
 msgstr ""
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr ""
 
@@ -2047,7 +2059,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr ""
 
@@ -2055,7 +2067,7 @@ msgstr ""
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2091,7 +2103,7 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2101,7 +2113,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 #, fuzzy
 msgid "This Memory"
 msgstr "Показати Raw пам'ять"
@@ -2126,13 +2138,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2167,12 +2179,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Видалити (та зсунути вгору)"
@@ -2210,7 +2222,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Тон"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "Тоновий режим"
 
@@ -2248,7 +2260,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Крок настройки"
@@ -2263,16 +2275,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, fuzzy, python-format
 msgid "Unable to find stock config %r"
 msgstr "Відкрити заводські конфігурації"
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Не вдалося виявити радіо на {port}"
@@ -2303,12 +2315,12 @@ msgstr "Не вдається внести зміни до цієї моделі
 msgid "Unable to set %s on this memory"
 msgstr "Не вдається внести зміни до цієї моделі"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "Не вдається внести зміни до цієї моделі"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr ""
 
@@ -2325,12 +2337,12 @@ msgstr "Файл непідтримуваного типу"
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 #, fuzzy
 msgid "Upload to radio"
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 #, fuzzy
 msgid "Upload to radio..."
 msgstr "Записати в радіостанцію"
@@ -2340,11 +2352,11 @@ msgstr "Записати в радіостанцію"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr ""
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr ""
 
@@ -2372,7 +2384,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2380,7 +2392,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "Виробник"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 #, fuzzy
 msgid "View"
 msgstr "В_игляд"
@@ -2389,16 +2401,16 @@ msgstr "В_игляд"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr ""
 
@@ -2422,11 +2434,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/zh_CN.po
+++ b/chirp/locale/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-16 15:11-0700\n"
+"POT-Creation-Date: 2024-05-30 17:16-0700\n"
 "PO-Revision-Date: 2024-01-26 13:30+0800\n"
 "Last-Translator: DuckSoft, BH2UEP <realducksoft@gmail.com>\n"
 "Language-Team: \n"
@@ -33,25 +33,25 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1720
+#: ../wxui/memedit.py:1722
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "...并将区块上移"
 
-#: ../wxui/memedit.py:1711
+#: ../wxui/memedit.py:1713
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "存储"
 
-#: ../wxui/memedit.py:1715
+#: ../wxui/memedit.py:1717
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "...并将区块上移"
 
-#: ../wxui/main.py:1362
+#: ../wxui/main.py:1373
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr "%s 还没有被保存。要在关闭程序前保存吗？"
@@ -60,7 +60,7 @@ msgstr "%s 还没有被保存。要在关闭程序前保存吗？"
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2057
 #, fuzzy, python-format
 msgid "...and %i more"
 msgstr "...并将所有存储上移"
@@ -630,33 +630,33 @@ msgstr ""
 "\n"
 "如果在已连接数据线的情况下打开电台，则可能无法进行"
 
-#: ../wxui/main.py:1852
+#: ../wxui/main.py:1872
 msgid ""
 "A new CHIRP version is available. Please visit the website as soon as "
 "possible to download it!"
 msgstr "新的 CHIRP 版本已经推出。请尽快访问网站下载！"
 
-#: ../wxui/main.py:908
+#: ../wxui/main.py:919
 msgid "About"
 msgstr ""
 
-#: ../wxui/main.py:1711
+#: ../wxui/main.py:1722
 msgid "About CHIRP"
 msgstr "关于CHIRP"
 
-#: ../wxui/query_sources.py:362
+#: ../wxui/query_sources.py:367
 msgid "All"
 msgstr "全选"
 
-#: ../wxui/main.py:1192
+#: ../wxui/main.py:1203
 msgid "All Files"
 msgstr "全部文件"
 
-#: ../wxui/main.py:1203
+#: ../wxui/main.py:1214
 msgid "All supported formats|"
 msgstr ""
 
-#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:354
+#: ../wxui/query_sources.py:284 ../wxui/query_sources.py:359
 msgid "Amateur"
 msgstr ""
 
@@ -668,7 +668,7 @@ msgstr "发生错误"
 msgid "Applying settings"
 msgstr ""
 
-#: ../wxui/main.py:1458
+#: ../wxui/main.py:1469
 msgid "Automatic from system"
 msgstr ""
 
@@ -676,11 +676,11 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:1795
+#: ../wxui/main.py:1815
 msgid "Bandplan"
 msgstr ""
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 msgid "Bands"
 msgstr ""
 
@@ -700,11 +700,11 @@ msgstr "数据浏览器"
 msgid "Building Radio Browser"
 msgstr ""
 
-#: ../wxui/main.py:1487
+#: ../wxui/main.py:1498
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr ""
 
-#: ../wxui/query_sources.py:692
+#: ../wxui/query_sources.py:699
 msgid "Canada"
 msgstr ""
 
@@ -714,13 +714,13 @@ msgid ""
 "will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1371
+#: ../wxui/memedit.py:1373
 #, python-format
 msgid ""
 "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
 
-#: ../wxui/main.py:1191
+#: ../wxui/main.py:1202
 msgid "Chirp Image Files"
 msgstr ""
 
@@ -728,21 +728,21 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1350
+#: ../wxui/memedit.py:1352
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "选择 %s DTCS 接收代码"
 
-#: ../wxui/memedit.py:1347
+#: ../wxui/memedit.py:1349
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1381
+#: ../wxui/memedit.py:1383
 msgid "Choose Cross Mode"
 msgstr "收发使用不同亚音频"
 
-#: ../wxui/memedit.py:1411
+#: ../wxui/memedit.py:1413
 msgid "Choose duplex"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Choose the module to load from issue %i:"
 msgstr "选择一个来导入："
 
-#: ../wxui/query_sources.py:462
+#: ../wxui/query_sources.py:469
 msgid "City"
 msgstr ""
 
@@ -781,15 +781,15 @@ msgstr "从电台下载"
 msgid "Cloning to radio"
 msgstr "上传到电台"
 
-#: ../wxui/main.py:991
+#: ../wxui/main.py:1002
 msgid "Close"
 msgstr ""
 
-#: ../wxui/main.py:992
+#: ../wxui/main.py:1003
 msgid "Close file"
 msgstr "全部文件"
 
-#: ../wxui/memedit.py:1779
+#: ../wxui/memedit.py:1781
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -819,16 +819,16 @@ msgid ""
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
 msgstr ""
 
-#: ../wxui/query_sources.py:332
+#: ../wxui/query_sources.py:337
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1696
+#: ../wxui/memedit.py:1698
 msgid "Copy"
 msgstr "复制"
 
-#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:468
-#: ../wxui/query_sources.py:558
+#: ../wxui/query_sources.py:282 ../wxui/query_sources.py:475
+#: ../wxui/query_sources.py:565
 msgid "Country"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1692
+#: ../wxui/memedit.py:1694
 msgid "Cut"
 msgstr "剪切"
 
@@ -865,11 +865,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2321
+#: ../wxui/memedit.py:2323
 msgid "DV Memory"
 msgstr "该存储"
 
-#: ../wxui/main.py:1725
+#: ../wxui/main.py:1736
 msgid "Danger Ahead"
 msgstr ""
 
@@ -877,32 +877,32 @@ msgstr ""
 msgid "Dec"
 msgstr "探测"
 
-#: ../wxui/memedit.py:1705
+#: ../wxui/memedit.py:1707
 msgid "Delete"
 msgstr "删除"
 
-#: ../wxui/main.py:913
+#: ../wxui/main.py:924
 msgid "Developer Mode"
 msgstr "开发者模式"
 
-#: ../wxui/main.py:1731
+#: ../wxui/main.py:1742
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1815 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1817 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "对比原始存储"
 
-#: ../wxui/memedit.py:2246
+#: ../wxui/memedit.py:2248
 msgid "Digital Code"
 msgstr "数字代码"
 
-#: ../wxui/query_sources.py:336
+#: ../wxui/query_sources.py:341
 msgid "Digital Modes"
 msgstr "数字代码"
 
-#: ../wxui/main.py:1743
+#: ../wxui/main.py:1754
 msgid "Disable reporting"
 msgstr ""
 
@@ -911,7 +911,7 @@ msgid "Disabled"
 msgstr "已禁用"
 
 #: ../wxui/query_sources.py:100 ../wxui/query_sources.py:313
-#: ../wxui/query_sources.py:581
+#: ../wxui/query_sources.py:588
 msgid "Distance"
 msgstr ""
 
@@ -928,15 +928,15 @@ msgstr ""
 msgid "Double-click to change bank name"
 msgstr ""
 
-#: ../wxui/main.py:993
+#: ../wxui/main.py:1004
 msgid "Download"
 msgstr ""
 
-#: ../wxui/main.py:994
+#: ../wxui/main.py:1005
 msgid "Download from radio"
 msgstr "从电台下载"
 
-#: ../wxui/main.py:820
+#: ../wxui/main.py:831
 msgid "Download from radio..."
 msgstr "从电台下载……"
 
@@ -953,11 +953,11 @@ msgstr "重新加载驱动程序"
 msgid "Driver information"
 msgstr ""
 
-#: ../wxui/main.py:537
+#: ../wxui/main.py:548
 msgid "Driver messages"
 msgstr ""
 
-#: ../wxui/query_sources.py:334
+#: ../wxui/query_sources.py:339
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr ""
 
@@ -965,17 +965,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "差频方向"
 
-#: ../wxui/memedit.py:2276
+#: ../wxui/memedit.py:2278
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2274
+#: ../wxui/memedit.py:2276
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
 
-#: ../wxui/main.py:857
+#: ../wxui/main.py:868
 msgid "Enable Automatic Edits"
 msgstr ""
 
@@ -987,11 +987,11 @@ msgstr "已启用"
 msgid "Enter Frequency"
 msgstr "频率"
 
-#: ../wxui/memedit.py:1398
+#: ../wxui/memedit.py:1400
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1390
+#: ../wxui/memedit.py:1392
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1017,24 +1017,28 @@ msgstr "设置值有误：%s"
 msgid "Error communicating with radio"
 msgstr ""
 
+#: ../wxui/query_sources.py:334
+msgid "Exclude private and closed repeaters"
+msgstr ""
+
 #: ../wxui/clone.py:543
 #, fuzzy
 msgid "Experimental driver"
 msgstr "继续使用不稳定的驱动？"
 
-#: ../wxui/memedit.py:2199
+#: ../wxui/memedit.py:2201
 msgid "Export can only write CSV files"
 msgstr ""
 
-#: ../wxui/main.py:1347
+#: ../wxui/main.py:1358
 msgid "Export to CSV"
 msgstr "以CSV文件格式导出"
 
-#: ../wxui/main.py:695
+#: ../wxui/main.py:706
 msgid "Export to CSV..."
 msgstr "以CSV文件格式导出……"
 
-#: ../wxui/memedit.py:2310
+#: ../wxui/memedit.py:2312
 msgid "Extra"
 msgstr ""
 
@@ -1042,7 +1046,7 @@ msgstr ""
 msgid "FM Radio"
 msgstr ""
 
-#: ../wxui/query_sources.py:613
+#: ../wxui/query_sources.py:620
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1061,13 +1065,13 @@ msgstr ""
 msgid "Features"
 msgstr ""
 
-#: ../wxui/main.py:542
+#: ../wxui/main.py:553
 #, python-format
 msgid "File does not exist: %s"
 msgstr ""
 
-#: ../wxui/main.py:1195 ../wxui/main.py:1275 ../wxui/main.py:1285
-#: ../wxui/main.py:1343 ../wxui/main.py:1677 ../wxui/main.py:1678
+#: ../wxui/main.py:1206 ../wxui/main.py:1286 ../wxui/main.py:1296
+#: ../wxui/main.py:1354 ../wxui/main.py:1688 ../wxui/main.py:1689
 msgid "Files"
 msgstr "文件"
 
@@ -1079,17 +1083,17 @@ msgstr ""
 msgid "Filter results with location matching this string"
 msgstr ""
 
-#: ../wxui/main.py:1417
+#: ../wxui/main.py:1428
 #, fuzzy
 msgid "Find"
 msgstr "RFinder"
 
-#: ../wxui/main.py:763
+#: ../wxui/main.py:774
 #, fuzzy
 msgid "Find Next"
 msgstr "RFinder"
 
-#: ../wxui/main.py:749
+#: ../wxui/main.py:760
 #, fuzzy
 msgid "Find..."
 msgstr "寻找……"
@@ -1138,7 +1142,7 @@ msgid ""
 msgstr ""
 
 #: ../drivers/mursv1.py:342 ../drivers/baofeng_wp970i.py:328
-#: ../drivers/btech.py:688 ../drivers/gmrsuv1.py:392
+#: ../drivers/btech.py:689 ../drivers/gmrsuv1.py:392
 #: ../drivers/tdxone_tdq8a.py:455 ../drivers/uv6r.py:340
 #: ../drivers/uv5x3.py:418 ../drivers/gmrsv2.py:364
 #: ../drivers/baofeng_uv17Pro.py:441 ../drivers/bf_t1.py:483
@@ -1207,7 +1211,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:694 ../drivers/bf_t1.py:489
+#: ../drivers/btech.py:695 ../drivers/bf_t1.py:489
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1317,8 +1321,8 @@ msgstr "频率"
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:345
-#: ../wxui/query_sources.py:437
+#: ../wxui/query_sources.py:285 ../wxui/query_sources.py:350
+#: ../wxui/query_sources.py:443
 msgid "GMRS"
 msgstr ""
 
@@ -1326,19 +1330,19 @@ msgstr ""
 msgid "Getting settings"
 msgstr "正在获取设置"
 
-#: ../wxui/memedit.py:953
+#: ../wxui/memedit.py:955
 msgid "Goto Memory"
 msgstr "前往数据"
 
-#: ../wxui/memedit.py:952
+#: ../wxui/memedit.py:954
 msgid "Goto Memory:"
 msgstr "前往数据："
 
-#: ../wxui/memedit.py:921
+#: ../wxui/memedit.py:923
 msgid "Goto..."
 msgstr "前往……"
 
-#: ../wxui/main.py:959
+#: ../wxui/main.py:970
 msgid "Help"
 msgstr "帮助"
 
@@ -1350,7 +1354,7 @@ msgstr "帮助..."
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:930
+#: ../wxui/memedit.py:932
 msgid "Hide empty memories"
 msgstr "隐藏无数据的内容"
 
@@ -1359,23 +1363,23 @@ msgid "Human-readable comment (not stored in radio)"
 msgstr ""
 
 #: ../wxui/query_sources.py:296 ../wxui/query_sources.py:302
-#: ../wxui/query_sources.py:565 ../wxui/query_sources.py:571
+#: ../wxui/query_sources.py:572 ../wxui/query_sources.py:578
 msgid "If set, sort results by distance from these coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1330
+#: ../wxui/main.py:1341
 msgid "Import"
 msgstr "导入"
 
-#: ../wxui/main.py:689
+#: ../wxui/main.py:700
 msgid "Import from file..."
 msgstr "从文件导入……"
 
-#: ../wxui/main.py:1334
+#: ../wxui/main.py:1345
 msgid "Import messages"
 msgstr ""
 
-#: ../wxui/main.py:1328
+#: ../wxui/main.py:1339
 msgid "Import not recommended"
 msgstr ""
 
@@ -1387,11 +1391,11 @@ msgstr "索引"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1373
+#: ../wxui/memedit.py:1375
 msgid "Information"
 msgstr "{information}"
 
-#: ../wxui/memedit.py:1686
+#: ../wxui/memedit.py:1688
 msgid "Insert Row Above"
 msgstr "上方插入一行"
 
@@ -1399,7 +1403,7 @@ msgstr "上方插入一行"
 msgid "Install desktop icon?"
 msgstr ""
 
-#: ../wxui/main.py:897
+#: ../wxui/main.py:908
 msgid "Interact with driver"
 msgstr ""
 
@@ -1413,7 +1417,7 @@ msgstr "内部错误"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "无效值。必须为整数。"
 
-#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1534
+#: ../wxui/query_sources.py:66 ../wxui/memedit.py:1536
 msgid "Invalid Entry"
 msgstr "设置值无效：%s"
 
@@ -1421,12 +1425,12 @@ msgstr "设置值无效：%s"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1533 ../wxui/memedit.py:2401
+#: ../wxui/memedit.py:1535 ../wxui/memedit.py:2403
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "设置值无效：%s"
 
-#: ../wxui/main.py:1674
+#: ../wxui/main.py:1685
 msgid "Invalid or unsupported module file"
 msgstr ""
 
@@ -1443,13 +1447,13 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../wxui/main.py:806 ../wxui/main.py:1472
+#: ../wxui/main.py:817 ../wxui/main.py:1483
 #, fuzzy
 msgid "Language"
 msgstr "更改语言 (Change Language)"
 
 #: ../wxui/query_sources.py:88 ../wxui/query_sources.py:304
-#: ../wxui/query_sources.py:573
+#: ../wxui/query_sources.py:580
 msgid "Latitude"
 msgstr ""
 
@@ -1458,7 +1462,7 @@ msgstr ""
 msgid "Length must be %i"
 msgstr ""
 
-#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:533
+#: ../wxui/query_sources.py:325 ../wxui/query_sources.py:540
 msgid "Limit Bands"
 msgstr ""
 
@@ -1466,20 +1470,24 @@ msgstr ""
 msgid "Limit Modes"
 msgstr ""
 
-#: ../wxui/query_sources.py:548
+#: ../wxui/query_sources.py:555
 msgid "Limit Status"
 msgstr ""
 
-#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:579
+#: ../wxui/query_sources.py:311 ../wxui/query_sources.py:586
 msgid "Limit results to this distance (km) from coordinates"
 msgstr ""
 
-#: ../wxui/main.py:1555
+#: ../wxui/query_sources.py:335
+msgid "Limit use"
+msgstr ""
+
+#: ../wxui/main.py:1566
 #, fuzzy
 msgid "Live Radio"
 msgstr "电台"
 
-#: ../wxui/main.py:701
+#: ../wxui/main.py:712
 msgid "Load Module..."
 msgstr "加载模块……"
 
@@ -1488,18 +1496,18 @@ msgstr "加载模块……"
 msgid "Load module from issue"
 msgstr "加载模块"
 
-#: ../wxui/main.py:950
+#: ../wxui/main.py:961
 #, fuzzy
 msgid "Load module from issue..."
 msgstr "加载模块"
 
-#: ../wxui/main.py:1770
+#: ../wxui/main.py:1790
 msgid ""
 "Loading a module will not affect open tabs. It is recommended (unless "
 "instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
-#: ../wxui/main.py:1681
+#: ../wxui/main.py:1692
 msgid ""
 "Loading modules can be extremely dangerous, leading to damage to your "
 "computer, radio, or both. NEVER load a module from a source you do not "
@@ -1522,7 +1530,7 @@ msgid "Logo string 2 (12 characters)"
 msgstr ""
 
 #: ../wxui/query_sources.py:94 ../wxui/query_sources.py:305
-#: ../wxui/query_sources.py:574
+#: ../wxui/query_sources.py:581
 msgid "Longitude"
 msgstr ""
 
@@ -1530,7 +1538,7 @@ msgstr ""
 msgid "Memories"
 msgstr "存储"
 
-#: ../wxui/memedit.py:1573
+#: ../wxui/memedit.py:1575
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1548,7 +1556,7 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:525 ../wxui/memedit.py:590
+#: ../wxui/query_sources.py:532 ../wxui/memedit.py:590
 msgid "Mode"
 msgstr "制式"
 
@@ -1556,19 +1564,19 @@ msgstr "制式"
 msgid "Model"
 msgstr "型号"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 msgid "Modes"
 msgstr "制式"
 
-#: ../wxui/main.py:1678
+#: ../wxui/main.py:1689
 msgid "Module"
 msgstr "模块"
 
-#: ../wxui/main.py:1650
+#: ../wxui/main.py:1661
 msgid "Module Loaded"
 msgstr "模块加载"
 
-#: ../wxui/main.py:1781
+#: ../wxui/main.py:1801
 msgid "Module loaded successfully"
 msgstr ""
 
@@ -1577,27 +1585,27 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:917
+#: ../wxui/memedit.py:919
 msgid "Move Down"
 msgstr "下移"
 
-#: ../wxui/memedit.py:907
+#: ../wxui/memedit.py:909
 msgid "Move Up"
 msgstr "上移"
 
-#: ../wxui/memedit.py:2111
+#: ../wxui/memedit.py:2113
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
-#: ../wxui/main.py:647
+#: ../wxui/main.py:658
 msgid "New Window"
 msgstr "创建一个新的窗口"
 
-#: ../wxui/main.py:1854
+#: ../wxui/main.py:1874
 msgid "New version available"
 msgstr "有新版本"
 
-#: ../wxui/memedit.py:1852
+#: ../wxui/memedit.py:1854
 msgid "No empty rows below!"
 msgstr ""
 
@@ -1614,11 +1622,11 @@ msgstr ""
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:293
+#: ../sources/repeaterbook.py:300
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:41 ../wxui/memedit.py:952
+#: ../wxui/query_sources.py:41 ../wxui/memedit.py:954
 msgid "Number"
 msgstr ""
 
@@ -1626,7 +1634,7 @@ msgstr ""
 msgid "Offset"
 msgstr "频差"
 
-#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:531
+#: ../wxui/query_sources.py:323 ../wxui/query_sources.py:538
 msgid "Only certain bands"
 msgstr ""
 
@@ -1638,53 +1646,57 @@ msgstr ""
 msgid "Only memory tabs may be exported"
 msgstr ""
 
-#: ../wxui/query_sources.py:542
+#: ../wxui/query_sources.py:549
 msgid "Only working repeaters"
 msgstr ""
 
-#: ../wxui/main.py:987 ../wxui/main.py:1330
+#: ../wxui/main.py:998 ../wxui/main.py:1341
 msgid "Open"
 msgstr "打开"
 
-#: ../wxui/main.py:676
+#: ../wxui/main.py:687
 msgid "Open Recent"
 msgstr ""
 
-#: ../wxui/main.py:658
+#: ../wxui/main.py:669
 msgid "Open Stock Config"
 msgstr "打开预留配置"
 
-#: ../wxui/main.py:988 ../wxui/main.py:1206
+#: ../wxui/main.py:999 ../wxui/main.py:1217
 #, fuzzy
 msgid "Open a file"
 msgstr "打开最近的文件"
 
-#: ../wxui/main.py:1696
+#: ../wxui/main.py:1707
 msgid "Open a module"
 msgstr ""
 
-#: ../wxui/main.py:934
+#: ../wxui/main.py:945
 msgid "Open debug log"
 msgstr "打开调试日志"
 
-#: ../wxui/main.py:512
+#: ../wxui/main.py:523
 msgid "Open in new window"
 msgstr ""
 
-#: ../wxui/main.py:605
+#: ../wxui/query_sources.py:332
+msgid "Open repeaters only"
+msgstr ""
+
+#: ../wxui/main.py:616
 msgid "Open stock config directory"
 msgstr ""
 
-#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:570
+#: ../wxui/query_sources.py:301 ../wxui/query_sources.py:577
 msgid "Optional: -122.0000"
 msgstr ""
 
-#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:578
+#: ../wxui/query_sources.py:310 ../wxui/query_sources.py:585
 #, fuzzy
 msgid "Optional: 100"
 msgstr "选项"
 
-#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:564
+#: ../wxui/query_sources.py:295 ../wxui/query_sources.py:571
 msgid "Optional: 45.0000"
 msgstr ""
 
@@ -1692,7 +1704,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:1986
+#: ../wxui/memedit.py:1988
 msgid "Overwrite memories?"
 msgstr "要覆盖吗？"
 
@@ -1707,31 +1719,31 @@ msgstr ""
 msgid "Parsing"
 msgstr ""
 
-#: ../wxui/memedit.py:1700
+#: ../wxui/memedit.py:1702
 msgid "Paste"
 msgstr "粘贴"
 
-#: ../wxui/memedit.py:1980
+#: ../wxui/memedit.py:1982
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:1983
+#: ../wxui/memedit.py:1985
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1977
+#: ../wxui/memedit.py:1979
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:1974
+#: ../wxui/memedit.py:1976
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:1858
+#: ../wxui/main.py:1878
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -1761,7 +1773,7 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1719
+#: ../wxui/main.py:1730
 msgid ""
 "Please note that developer mode is intended for use by developers of the "
 "CHIRP project, or under the direction of a developer. It enables behaviors "
@@ -1789,7 +1801,7 @@ msgstr "功率"
 msgid "Press enter to set this in memory"
 msgstr "设置存储时出错"
 
-#: ../wxui/main.py:712
+#: ../wxui/main.py:723
 msgid "Print Preview"
 msgstr "打印预览"
 
@@ -1797,16 +1809,16 @@ msgstr "打印预览"
 msgid "Printing"
 msgstr ""
 
-#: ../wxui/memedit.py:1679
+#: ../wxui/memedit.py:1681
 msgid "Properties"
 msgstr "属性"
 
-#: ../wxui/main.py:1809
+#: ../wxui/main.py:1829
 #, python-format
 msgid "Query %s"
 msgstr ""
 
-#: ../wxui/main.py:834
+#: ../wxui/main.py:845
 msgid "Query Source"
 msgstr "查询数据源"
 
@@ -1814,7 +1826,7 @@ msgstr "查询数据源"
 msgid "RX DTCS"
 msgstr "DTCS 接收代码"
 
-#: ../wxui/main.py:958
+#: ../wxui/main.py:969
 msgid "Radio"
 msgstr "电台"
 
@@ -1834,11 +1846,11 @@ msgid ""
 "and try again."
 msgstr ""
 
-#: ../wxui/query_sources.py:839
+#: ../wxui/query_sources.py:846
 msgid "RadioReference Canada requires a login before you can query"
 msgstr ""
 
-#: ../wxui/query_sources.py:650
+#: ../wxui/query_sources.py:657
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1865,11 +1877,11 @@ msgstr "需要刷新"
 msgid "Refreshed memory %s"
 msgstr ""
 
-#: ../wxui/main.py:874
+#: ../wxui/main.py:885
 msgid "Reload Driver"
 msgstr "重新加载驱动程序"
 
-#: ../wxui/main.py:883
+#: ../wxui/main.py:894
 msgid "Reload Driver and File"
 msgstr "重新加载驱动程序和文件"
 
@@ -1883,28 +1895,28 @@ msgid ""
 "worldwide, FREE repeater directory."
 msgstr ""
 
-#: ../wxui/main.py:922
+#: ../wxui/main.py:933
 msgid "Reporting enabled"
 msgstr "启用报告功能"
 
-#: ../wxui/main.py:1739
+#: ../wxui/main.py:1750
 msgid ""
 "Reporting helps the CHIRP project know which radio models and OS platforms "
 "to spend our limited efforts on. We would really appreciate if you left it "
 "enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1489 ../wxui/main.py:1733
+#: ../wxui/main.py:1500 ../wxui/main.py:1744
 msgid "Restart Required"
 msgstr ""
 
-#: ../wxui/main.py:670
+#: ../wxui/main.py:681
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] ""
 
-#: ../wxui/main.py:799
+#: ../wxui/main.py:810
 msgid "Restore tabs on start"
 msgstr ""
 
@@ -1912,15 +1924,15 @@ msgstr ""
 msgid "Retrieved settings"
 msgstr ""
 
-#: ../wxui/main.py:989
+#: ../wxui/main.py:1000
 msgid "Save"
 msgstr ""
 
-#: ../wxui/main.py:1364
+#: ../wxui/main.py:1375
 msgid "Save before closing?"
 msgstr "在保存前关闭？"
 
-#: ../wxui/main.py:990 ../wxui/main.py:1289
+#: ../wxui/main.py:1001 ../wxui/main.py:1300
 msgid "Save file"
 msgstr "保存文件"
 
@@ -1945,26 +1957,26 @@ msgstr ""
 msgid "Security Risk"
 msgstr ""
 
-#: ../wxui/main.py:864
+#: ../wxui/main.py:875
 msgid "Select Bandplan..."
 msgstr ""
 
-#: ../wxui/query_sources.py:384 ../wxui/query_sources.py:599
+#: ../wxui/query_sources.py:389 ../wxui/query_sources.py:606
 #, fuzzy
 msgid "Select Bands"
 msgstr "选择列"
 
-#: ../wxui/main.py:1472
+#: ../wxui/main.py:1483
 #, fuzzy
 msgid "Select Language"
 msgstr "更改语言 (Change Language)"
 
-#: ../wxui/query_sources.py:405
+#: ../wxui/query_sources.py:410
 #, fuzzy
 msgid "Select Modes"
 msgstr "选择列"
 
-#: ../wxui/main.py:1794
+#: ../wxui/main.py:1814
 msgid "Select a bandplan"
 msgstr ""
 
@@ -1980,54 +1992,54 @@ msgstr "设置"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1808 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1810 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "显示原始存储"
 
-#: ../wxui/main.py:940
+#: ../wxui/main.py:951
 msgid "Show debug log location"
 msgstr "打开调试日志所在文件夹"
 
-#: ../wxui/memedit.py:926
+#: ../wxui/memedit.py:928
 msgid "Show extra fields"
 msgstr "显示更多其他内容"
 
-#: ../wxui/main.py:945
+#: ../wxui/main.py:956
 #, fuzzy
 msgid "Show image backup location"
 msgstr "打开调试日志所在文件夹"
 
-#: ../wxui/memedit.py:2059
+#: ../wxui/memedit.py:2061
 msgid "Some memories are incompatible with this radio"
 msgstr "某些内容与此电台不兼容"
 
-#: ../wxui/memedit.py:1924
+#: ../wxui/memedit.py:1926
 msgid "Some memories are not deletable"
 msgstr "某些内容不可被删除"
 
-#: ../wxui/memedit.py:1764
+#: ../wxui/memedit.py:1766
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1770
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1790
+#: ../wxui/memedit.py:1792
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "对比原始存储"
 
-#: ../wxui/memedit.py:1656
+#: ../wxui/memedit.py:1658
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1655
+#: ../wxui/memedit.py:1657
 msgid "Sort memories"
 msgstr ""
 
@@ -2036,7 +2048,7 @@ msgstr ""
 msgid "Sorting"
 msgstr "设置"
 
-#: ../wxui/query_sources.py:465
+#: ../wxui/query_sources.py:472
 msgid "State"
 msgstr ""
 
@@ -2044,7 +2056,7 @@ msgstr ""
 msgid "State/Province"
 msgstr "州/省"
 
-#: ../wxui/main.py:1782
+#: ../wxui/main.py:1802
 msgid "Success"
 msgstr ""
 
@@ -2052,7 +2064,7 @@ msgstr ""
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr ""
 
-#: ../wxui/query_sources.py:473
+#: ../wxui/query_sources.py:480
 msgid "The DMR-MARC Worldwide Network"
 msgstr ""
 
@@ -2088,7 +2100,7 @@ msgid ""
 "Proceed anyway?"
 msgstr ""
 
-#: ../wxui/main.py:1321
+#: ../wxui/main.py:1332
 #, python-format
 msgid ""
 "The recommended procedure for importing memories is to open the source file "
@@ -2098,7 +2110,7 @@ msgid ""
 "memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1725
+#: ../wxui/memedit.py:1727
 msgid "This Memory"
 msgstr "该内容"
 
@@ -2122,13 +2134,13 @@ msgid ""
 "compatibility."
 msgstr ""
 
-#: ../wxui/main.py:1552
+#: ../wxui/main.py:1563
 msgid ""
 "This is a live-mode radio, which means changes are sent to the radio in real-"
 "time as you make them. Upload is not necessary!"
 msgstr ""
 
-#: ../wxui/main.py:1558
+#: ../wxui/main.py:1569
 msgid ""
 "This is a radio-independent file and cannot be uploaded directly to a radio. "
 "Open a radio image (or download one from a radio) and then copy/paste items "
@@ -2170,12 +2182,12 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
-#: ../wxui/memedit.py:1729
+#: ../wxui/memedit.py:1731
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "...并将区块上移"
 
-#: ../wxui/memedit.py:1727
+#: ../wxui/memedit.py:1729
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "...并将区块上移"
@@ -2213,7 +2225,7 @@ msgstr ""
 msgid "Tone"
 msgstr "亚音频"
 
-#: ../wxui/memedit.py:987
+#: ../wxui/memedit.py:989
 msgid "Tone Mode"
 msgstr "亚音频制式"
 
@@ -2250,7 +2262,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:384 ../wxui/memedit.py:1001
+#: ../wxui/memedit.py:384 ../wxui/memedit.py:1003
 msgid "Tuning Step"
 msgstr "调谐间隔"
 
@@ -2264,16 +2276,16 @@ msgid ""
 "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1454
+#: ../wxui/memedit.py:1456
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
-#: ../wxui/main.py:1247
+#: ../wxui/main.py:1258
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1940
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "无法打开此镜像：型号不支持"
@@ -2303,12 +2315,12 @@ msgstr "无法在此系统上显示 %s"
 msgid "Unable to set %s on this memory"
 msgstr "无法在此内容上设置 %s"
 
-#: ../wxui/main.py:1562
+#: ../wxui/main.py:1573
 #, fuzzy
 msgid "Unable to upload this file"
 msgstr "无法在此系统上显示 %s"
 
-#: ../wxui/query_sources.py:691
+#: ../wxui/query_sources.py:698
 msgid "United States"
 msgstr "美国"
 
@@ -2325,11 +2337,11 @@ msgstr "不支持的文件类型"
 msgid "Upload instructions"
 msgstr ""
 
-#: ../wxui/main.py:996
+#: ../wxui/main.py:1007
 msgid "Upload to radio"
 msgstr "上传到电台"
 
-#: ../wxui/main.py:828
+#: ../wxui/main.py:839
 msgid "Upload to radio..."
 msgstr "上传到电台……"
 
@@ -2338,11 +2350,11 @@ msgstr "上传到电台……"
 msgid "Uploaded memory %s"
 msgstr ""
 
-#: ../wxui/main.py:784
+#: ../wxui/main.py:795
 msgid "Use fixed-width font"
 msgstr "使用固定宽度字体"
 
-#: ../wxui/main.py:792
+#: ../wxui/main.py:803
 msgid "Use larger font"
 msgstr "使用大号字体"
 
@@ -2370,7 +2382,7 @@ msgstr ""
 msgid "Value must be zero or greater"
 msgstr ""
 
-#: ../wxui/memedit.py:2301
+#: ../wxui/memedit.py:2303
 msgid "Values"
 msgstr ""
 
@@ -2378,7 +2390,7 @@ msgstr ""
 msgid "Vendor"
 msgstr "厂商"
 
-#: ../wxui/main.py:957
+#: ../wxui/main.py:968
 msgid "View"
 msgstr "查看"
 
@@ -2386,16 +2398,16 @@ msgstr "查看"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/memedit.py:1540 ../wxui/main.py:1774
+#: ../wxui/memedit.py:1542 ../wxui/main.py:1794
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1539
+#: ../wxui/memedit.py:1541
 #, python-format
 msgid "Warning: %s"
 msgstr ""
 
-#: ../wxui/main.py:430
+#: ../wxui/main.py:441
 msgid "Welcome"
 msgstr ""
 
@@ -2419,11 +2431,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "disabled"
 msgstr "已禁用"
 
-#: ../wxui/main.py:1716
+#: ../wxui/main.py:1727
 msgid "enabled"
 msgstr "已启用"
 

--- a/chirp/sources/repeaterbook.py
+++ b/chirp/sources/repeaterbook.py
@@ -216,6 +216,8 @@ class RepeaterBook(base.NetworkResultRadio):
         bands = params.pop('bands', [])
         modes = params.pop('modes', [])
         fmconv = params.pop('fmconv', False)
+        openonly = params.pop('openonly')
+
         data_file = self.get_data(status,
                                   params.get('country'),
                                   params.pop('state'),
@@ -244,6 +246,9 @@ class RepeaterBook(base.NetworkResultRadio):
             return (not search_filter or
                     search_filter.lower() in content.lower())
 
+        def open_repeater(item):
+            return item['Use'] == 'OPEN'
+
         def included_band(item):
             if not bands:
                 return True
@@ -256,6 +261,8 @@ class RepeaterBook(base.NetworkResultRadio):
         for item in sorted(json.loads(open(data_file, 'rb').read())['results'],
                            key=sorter):
             if not item:
+                continue
+            if openonly and not open_repeater(item):
                 continue
             if item['Operational Status'] != 'On-air':
                 continue

--- a/chirp/wxui/query_sources.py
+++ b/chirp/wxui/query_sources.py
@@ -329,6 +329,11 @@ class RepeaterBookQueryDialog(QuerySourceDialog):
         self.Bind(wx.EVT_CHECKBOX, self._select_modes, self._modefilter)
         self._add_grid(grid, _('Limit Modes'), self._modefilter)
 
+        self._openonly = wx.CheckBox(panel, label=_('Open repeaters only'))
+        self._openonly.SetValue(CONF.get_bool('openonly', 'repeaterbook'))
+        self._openonly.SetToolTip(_('Exclude private and closed repeaters'))
+        self._add_grid(grid, _('Limit use'), self._openonly)
+
         self._fmconv = wx.CheckBox(panel, label=_('Convert to FM'))
         self._fmconv.SetValue(CONF.get_bool('fmconv', 'repeaterbook'))
         self._fmconv.SetToolTip(_('Dual-mode digital repeaters that support '
@@ -420,6 +425,7 @@ class RepeaterBookQueryDialog(QuerySourceDialog):
         CONF.set('country', self._country.GetStringSelection(), 'repeaterbook')
         CONF.set('service', self._service.GetStringSelection(), 'repeaterbook')
         CONF.set_bool('fmconv', self._fmconv.IsChecked(), 'repeaterbook')
+        CONF.set_bool('openonly', self._openonly.IsChecked(), 'repeaterbook')
         self.result_radio = repeaterbook.RepeaterBook()
         super().do_query()
 
@@ -437,6 +443,7 @@ class RepeaterBookQueryDialog(QuerySourceDialog):
             'service': 'gmrs' if service == _('GMRS') else '',
             'service_display': self._service.GetStringSelection(),
             'fmconv': self._fmconv.IsChecked(),
+            'openonly': self._openonly.IsChecked(),
         }
 
 

--- a/tests/unit/test_repeaterbook.py
+++ b/tests/unit/test_repeaterbook.py
@@ -42,6 +42,7 @@ class TestRepeaterbook(unittest.TestCase):
             'lat': 45,
             'lon': -122,
             'dist': 100,
+            'openonly': False,
         })
         m = rb.get_memory(0)
         self.assertIsInstance(m, chirp_common.Memory)
@@ -71,6 +72,7 @@ class TestRepeaterbook(unittest.TestCase):
             'lat': 45,
             'lon': -122,
             'dist': 0,
+            'openonly': False,
         })
         m = rb.get_memory(0)
         self.assertIsInstance(m, chirp_common.Memory)
@@ -88,6 +90,7 @@ class TestRepeaterbook(unittest.TestCase):
             'lon': -122,
             'dist': 100,
             'service': 'gmrs',
+            'openonly': False,
         })
         m = rb.get_memory(0)
         self.assertIsInstance(m, chirp_common.Memory)
@@ -104,6 +107,7 @@ class TestRepeaterbook(unittest.TestCase):
             'lat': -26,
             'lon': 133,
             'dist': 20000,
+            'openonly': False,
         })
         m = rb.get_memory(0)
         self.assertIsInstance(m, chirp_common.Memory)
@@ -123,6 +127,7 @@ class TestRepeaterbook(unittest.TestCase):
                   'lat': 45,
                   'lon': -122,
                   'dist': 0,
+                  'openonly': False,
                   'filter': 'tower'}
         rb = self._test_with_mocked(params)
         self.assertGreater(sum(rb.get_features().memory_bounds), 5)
@@ -133,6 +138,7 @@ class TestRepeaterbook(unittest.TestCase):
                   'lat': 45,
                   'lon': -122,
                   'dist': 0,
+                  'openonly': False,
                   'filter': 'tower'}
         rb1 = self._test_with_mocked(dict(params))
         self.assertGreater(sum(rb1.get_features().memory_bounds), 5)


### PR DESCRIPTION
This adds a checkbox to the Repeaterbook query window to limit results to open repeaters only.

Is this small enough to be a pull request only, or should I create an issue?