### PR TITLE
Fixes for kenwood live

### DIFF
--- a/chirp/drivers/kenwood_live.py
+++ b/chirp/drivers/kenwood_live.py
@@ -798,6 +798,7 @@ class TMD710Radio(KenwoodLiveRadio):
         rf.valid_name_length = 8
         rf.valid_skips = D710_SKIP
         rf.memory_bounds = (0, 999)
+        rf.valid_bands = [(118000000, 524000000), (800000000, 1300000000)]
         return rf
 
     def _cmd_get_memory(self, number):

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -1308,9 +1308,16 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
                 mem.offset = want_offset
 
         if defaults.step_khz in features.valid_tuning_steps:
-            LOG.debug(
-                'Chose default step %s from bandplan' % defaults.step_khz)
             want_tuning_step = defaults.step_khz
+            if mem.freq % (want_tuning_step * 1000):
+                want_tuning_step = chirp_common.required_step(mem.freq)
+                LOG.debug('Bandplan step %s not suitable for %s, choosing %s',
+                          defaults.step_khz,
+                          chirp_common.format_freq(mem.freq),
+                          want_tuning_step)
+            else:
+                LOG.debug(
+                    'Chose default step %s from bandplan' % defaults.step_khz)
         else:
             want_tuning_step = 5.0
             try:


### PR DESCRIPTION
- **kenwood v71: Fix long-standing valid_bands issue**
- **Fix tuning step when bandplan is invalid**
