### PR TITLE
Fix linux bugreport menu item failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CHIRP Project
 
 This is the official git repository for the
-__[CHIRP](https://chirp.danplanet.com)__ project.
+__[CHIRP](https://www.chirpmyradio.com)__ project.
 
 When submitting PRs, please squash commits into logical units in a fashion
 similar to what is currently expected by the project on the mailing list.

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -970,11 +970,11 @@ class ChirpMain(wx.Frame):
         self.bug_report_item = wx.MenuItem(
             help_menu, wx.NewId(),
             _('Report or update a bug...'))
-        self.bug_report_item.Enable(False)
         self.Bind(wx.EVT_MENU,
                   functools.partial(bugreport.do_bugreport, self),
                   self.bug_report_item)
         help_menu.Append(self.bug_report_item)
+        self.bug_report_item.Enable(False)
 
         menu_bar = wx.MenuBar()
         menu_bar.Append(file_menu, wx.GetStockLabel(wx.ID_FILE))


### PR DESCRIPTION
On Linux/GTK menu items aren't actually created until they are added
to a menu. The recently added bugreport menu item was Enable()d before
adding, which fails on Linux.

Fixes: #11400
