### PR TITLE
Add AppStream metadata

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include chirp/share/*.desktop
+include chirp/share/*.metainfo.xml
 include chirp/share/*.png
 include chirp/share/*.svg
 include chirp/share/*.ico

--- a/chirp/share/com.chirpmyradio.CHIRP.metainfo.xml
+++ b/chirp/share/com.chirpmyradio.CHIRP.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>com.chirpmyradio.CHIRP</id>
+  <launchable type="desktop-id">chirp.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <name>CHIRP</name>
+  <developer_name>CHIRP Software LLC</developer_name>
+  <summary>Program amateur radios</summary>
+  <description>
+    <p>
+      CHIRP is a free, open-source tool for programming your radio. It supports a large number of manufacturers and models,
+      as well as provides a way to interface with multiple data sources and formats.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image type="source">https://archive.chirpmyradio.com/.site/screenshot1.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://chirpmyradio.com</url>
+  <url type="bugtracker">https://chirpmyradio.com/projects/chirp/issues</url>
+  <content_rating type="oars-1.1"/>
+</component>


### PR DESCRIPTION
This PR adds an [AppStream metadata](https://www.freedesktop.org/software/appstream/docs/) file (but will not auto-install it) for CHIRP that we originally created for our Fedora Linux CHIRP package.

AppStream is a collaborative effort for enhancing the way we interact with the software repositories provided by the distribution by standardizing sets of additional metadata and is used (and mostly required) by most Linux/*nix package management systems/GUIs nowadays.

@kk7ds Feel free to review and merge.