### PR TITLE
ksun_m6: Fix initialization of new memories

### DIFF
--- a/chirp/drivers/ksun_m6.py
+++ b/chirp/drivers/ksun_m6.py
@@ -55,10 +55,8 @@ struct {
       skip: 1,
       tx_tone: 2,
       tx_code: 12;
-  u8 _unk3: 1,
-     compander: 1,
-     _unk4: 1,
-     hopping: 1,
+  u8 compander: 2, // only 0b00/0b01 allowed
+     hopping: 2, // only 0b00/0b01 allowed
      scrambler: 4;
 } memory[80];
 """


### PR DESCRIPTION
Explicitly set a few extra bits to zero to initialize correctly new memory slots.

_unk3/_unk4 seem to be part of compander/hopping respectively, even though only a single value for both is accepted.

Setting _unk3 to 1 (compander:0b10) makes the radio ignore the channel completely. The original software also refuses to decode the slot and fail with a generic error.

Setting _unk4 to 1 (hopping:0b10) works on the radio, but still causes the original software to fail with an error.
