### PR TITLE
rt22: Fix tones not being enabled

### DIFF
--- a/chirp/drivers/retevis_rt22.py
+++ b/chirp/drivers/retevis_rt22.py
@@ -548,6 +548,10 @@ class RT22Radio(chirp_common.CloneModeRadio):
             _mem.set_raw("\xFF" * (_mem.size() // 8))
             return
 
+        # Initialize the memory to a known-good state
+        _mem.fill_raw(b'\x00')
+        _mem.unknown5[0] = 0x80
+
         _mem.rxfreq = mem.freq / 10
 
         if mem.duplex == "off":


### PR DESCRIPTION
Memories that chirp edits from scratch ended up with more unknown
bits set, which interfered with the enabling of tones. This makes us
clear the memory to zero first (which appears to be the way other
software does it) and also set one of the unknown bits to a known
value.

Fixes #11451
