### PR TITLE
ga510v2: Limit name to 8 chars per OEM

### DIFF
--- a/chirp/drivers/baofeng_uv17.py
+++ b/chirp/drivers/baofeng_uv17.py
@@ -483,7 +483,7 @@ class UV17(baofeng_uv17Pro.UV17Pro):
         _mem.set_raw(b"\x00" * 16)
 
         _namelength = self.get_features().valid_name_length
-        _nam.name = mem.name.ljust(_namelength, '\x00')
+        _nam.name = mem.name[:_namelength].ljust(11, '\x00')
 
         self.set_memory_common(mem, _mem)
 

--- a/chirp/drivers/ga510.py
+++ b/chirp/drivers/ga510.py
@@ -1163,7 +1163,7 @@ class RadioddityGA510v2(baofeng_uv17.UV17):
                     chirp_common.PowerLevel("Medium", watts=5.00),
                     chirp_common.PowerLevel("High",  watts=10.00)]
 
-    LENGTH_NAME = 11
+    LENGTH_NAME = 8
     SCODE_LIST = ["%s" % x for x in range(1, 16)]
     SQUELCH_LIST = ["Off"] + list("123456789")
     LIST_POWERON_DISPLAY_TYPE = ["Full", "Message", "Voltage"]


### PR DESCRIPTION
Fixes #11425
