### PR TITLE
Fix removing immutable settings for lists

### DIFF
--- a/chirp/wxui/settingsedit.py
+++ b/chirp/wxui/settingsedit.py
@@ -164,12 +164,13 @@ class ChirpSettingsEdit(common.ChirpEditor):
             if isinstance(e, settings.RadioSetting):
                 # Immutable and uninitialized settings don't get sent to the
                 # radio
-                if not e.value.get_mutable():
-                    LOG.debug('Skipping immutable %s', e.get_name())
-                    del root[e]
-                elif not e.value.initialized:
-                    LOG.debug('Skipping uninitialized %s', e.get_name())
-                    del root[e]
+                for value in e:
+                    if not value.get_mutable():
+                        LOG.debug('Skipping immutable %s', e.get_name())
+                        del root[e]
+                    elif not value.initialized:
+                        LOG.debug('Skipping uninitialized %s', e.get_name())
+                        del root[e]
             elif isinstance(e, settings.RadioSettingGroup):
                 self._remove_dead_settings(e)
 


### PR DESCRIPTION
Settings can have multiple values, although this is not often used and
the UI has places where this is not properly honored. Fix the case
where we look for and prune uninitialized/immutable settings and
be sure to iterate over all the values to avoid a crash.

Fixes #11549
