### PR TITLE
uv17pro: Fix AM emulation handling

### DIFF
--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -72,7 +72,10 @@ class TestCaseEdges(base.DriverTest):
                     m.tuning_step = step
                     self.radio.set_memory(m)
                     n = self.radio.get_memory(m.number)
-                    self.assertEqualMem(m, n, ignore=['tuning_step'])
+                    # Some radios have per-band required modes, which we
+                    # don't care about testing here
+                    self.assertEqualMem(m, n, ignore=['tuning_step',
+                                                      'mode'])
 
     def test_empty_to_not(self):
         firstband = self.rf.valid_bands[0]

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -776,9 +776,6 @@ class TestOverrideRules(base.BaseTest):
         'BTECH_MURS-V2',
         'Radioddity_DB25-G',
         'Retevis_RB17P',
-        'Baofeng_UV-17ProGPS',
-        'Baofeng_5RM',
-        'Baofeng_K5-Plus',
     ]
 
     def _test_radio_override_immutable_policy(self, rclass):


### PR DESCRIPTION
This moves it in line with the other drivers that recently were
improved to handle the AM emulation through validate_memory()

Related to #11561
