### PR TITLE
rt470x: Support 18MHz-1G per new firmware changes

### DIFF
--- a/chirp/drivers/mml_jc8810.py
+++ b/chirp/drivers/mml_jc8810.py
@@ -1355,6 +1355,7 @@ class RT470XRadio(RT470LRadio):
     def get_features(self):
         rf = super().get_features()
         rf.valid_modes.append('AM')
+        rf.valid_bands = [(18000000, 1000000000)]
         return rf
 
     def validate_memory(self, mem):


### PR DESCRIPTION
As noted in the associated bug, the latest firmware mentions the full
band availability and the reporter tested that channels uploaded in
the extreme edges still work even on the older firmware versions.

Fixes #11605
