### PR TITLE
fixes #11360 by initializing bell and favorite to 0 when channel is blanked

### DIFF
--- a/chirp/drivers/alinco_dr735t.py
+++ b/chirp/drivers/alinco_dr735t.py
@@ -333,6 +333,18 @@ class AlincoDR735T(chirp_common.CloneModeRadio):
                            ))
         bcl.set_doc("Busy Channel Lockout")
 
+        fav = RadioSetting("fav", "Favorite",
+                           RadioSettingValueBoolean(
+                               False
+                           ))
+        fav.set_doc("Favorite Channel")
+
+        bell = RadioSetting("bell", "Bell",
+                            RadioSettingValueBoolean(
+                                False
+                            ))
+        bell.set_doc("Bell Alert")
+
         stby_screen = RadioSetting("stby_screen", "Standby Screen Color",
                                    RadioSettingValueList(
                                        self.SCREEN_COLOR_MAP,
@@ -357,6 +369,8 @@ class AlincoDR735T(chirp_common.CloneModeRadio):
 
         mem.extra.append(het_mode)
         mem.extra.append(bcl)
+        mem.extra.append(fav)
+        mem.extra.append(bell)
         mem.extra.append(stby_screen)
         mem.extra.append(rx_screen)
         mem.extra.append(tx_screen)
@@ -376,6 +390,18 @@ class AlincoDR735T(chirp_common.CloneModeRadio):
                                bool(_mem.busy_channel_lockout)
                            ))
         bcl.set_doc("Busy Channel Lockout")
+
+        fav = RadioSetting("fav", "Favorite",
+                           RadioSettingValueBoolean(
+                                bool(_mem.favorite)
+                           ))
+        fav.set_doc("Favorite Channel")
+
+        bell = RadioSetting("bell", "Bell",
+                            RadioSettingValueBoolean(
+                                bool(_mem.bell)
+                            ))
+        bell.set_doc("Bell Alert")
 
         stby_screen = RadioSetting("stby_screen", "Standby Screen Color",
                                    RadioSettingValueList(
@@ -404,6 +430,8 @@ class AlincoDR735T(chirp_common.CloneModeRadio):
         mem.extra.append(het_mode)
         mem.extra.append(bcl)
         mem.extra.append(stby_screen)
+        mem.extra.append(fav)
+        mem.extra.append(bell)
         mem.extra.append(rx_screen)
         mem.extra.append(tx_screen)
 
@@ -417,6 +445,14 @@ class AlincoDR735T(chirp_common.CloneModeRadio):
 
             if setting.get_name() == "bcl":
                 _mem.busy_channel_lockout = \
+                    0x01 if setting.value else 0x00
+
+            if setting.get_name() == "fav":
+                _mem.favorite = \
+                    0x01 if setting.value else 0x00
+
+            if setting.get_name() == "bell":
+                _mem.bell = \
                     0x01 if setting.value else 0x00
 
             if setting.get_name() == "stby_screen":


### PR DESCRIPTION
# Description
This PR adds favorite and bell settings to the extra settings. 
Fixes #11360

--------------------

# CHIRP PR Guidelines

The following must be true before PRs can be merged:

1. All tests must be passing. The "PR Checks" job is speculative and failure doesn't always indicate a critial problem, but generally it needs to pass as well.
1. Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
1. Commits in a single PR should be related. Squash intermediate commits into logical units (i.e. "fix tests" commits need not survive on their own). Keep cleanup commits separate from functional changes.
1. Major new features or bug fixes should reference a [CHIRP issue](https://chirpmyradio.com/projects/chirp/issues) _in the commit message_. Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
1. Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc). The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
1. New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already). All new drivers must use `MemoryMapBytes`.
1. All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).
1. Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
