### PR TITLE
Do a case insensitive sort of available translations for CHIRP

### DIFF
--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1499,7 +1499,7 @@ class ChirpMain(wx.Frame):
         # parameter. But, we can pad out the automatic selection to get some
         # extra padding in the dialog since we don't otherwise index it.
         choices = ([_('Automatic from system') + ' ' * 30] +
-                   sorted(langs.keys()))
+                   sorted(langs.keys(), key=str.casefold))
         try:
             current = wx.Locale.FindLanguageInfo(
                 CONF.get('force_language', 'prefs'))

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1494,7 +1494,8 @@ class ChirpMain(wx.Frame):
 
         trans = wx.Translations.Get()
         langs = {fmt_lang(wx.Locale.FindLanguageInfo(code)): code
-                 for code in trans.GetAvailableTranslations('CHIRP')}
+                 for code in trans.GetAvailableTranslations('CHIRP')
+                 if code != 'messages'}
         # This is stupid, but wx.GetSingleChoice does not honor the width
         # parameter. But, we can pad out the automatic selection to get some
         # extra padding in the dialog since we don't otherwise index it.


### PR DESCRIPTION
The list of languages available in the View menu is sorted in a case sensitive way. This PR applies a case insensitive sort that makes the list easier to read.

This PR also avoids an exception caused by `GetAvailableTranslations()` returning also `messages` as an available language because `chirp/locale/` contains the file `messages.po` (this doens't happen on Linux when CHIRP is installed because that file isn't installed). A better fix would be to skip any object that doesn't have a `DescriptionNative` property but it would make the code more complicated for an edge case.

| Before (case sensitive) | After (case insensitive) |
| ------------- | ------------- |
| ![CHIRP language case senstitive](https://github.com/user-attachments/assets/bbbab4f2-ad1d-4b2d-98f7-c8e3c2b3e23e) | ![CHIRP language case insenstitive](https://github.com/user-attachments/assets/1db3359f-03d6-4d0c-8e83-201b25e241f9) |
