### PR TITLE
Issue #11717 mitigation in UV17 driver, extra blocks for read now possible in subclass

### DIFF
--- a/chirp/drivers/baofeng_uv17.py
+++ b/chirp/drivers/baofeng_uv17.py
@@ -75,7 +75,7 @@ def _download(radio):
     status.msg = "Cloning from radio..."
     radio.status_fn(status)
 
-    for block_number in radio.BLOCK_ORDER:
+    for block_number in radio.BLOCK_O_READ:
         if block_number not in memory_map:
             # Memory block not found.
             LOG.error('Block %i (0x%x) not in memory map: %s',
@@ -158,6 +158,10 @@ class UV17(baofeng_uv17Pro.UV17Pro):
 
     MODES = ["FM", "NFM"]
     BLOCK_ORDER = [16, 17, 18, 19,  24, 25, 26, 4, 6]
+
+    # Add extra read blocks (e.g. calibration block 2) to the end here:
+    BLOCK_O_READ = list(BLOCK_ORDER)
+
     MEM_TOTAL = 0x9000
     WRITE_MEM_TOTAL = 0x9000
     BLOCK_SIZE = 0x40
@@ -487,6 +491,14 @@ class UV17(baofeng_uv17Pro.UV17Pro):
         _nam.name = mem.name[:_namelength].ljust(11, '\x00')
 
         self.set_memory_common(mem, _mem)
+
+    def get_features(self):
+        rf = super().get_features()
+        rf.has_bank = False
+        return rf
+
+    def get_mapping_models(self):
+        return []
 
 
 @directory.register


### PR DESCRIPTION
As we have discussed in https://github.com/kk7ds/chirp/pull/1176#discussion_r1861323606, this should be solved in superclass, i.e. here instead in the RT620 driver:
- The has_bank mitigation has to be done here as the driver is also affected (Bug #11717 mitigation)
- Added extra class variable BLOCK_READ to allow additional block to be read and stored in image (for future calibration upload from backup with big warning on inherited drivers if necessary)

1.   tox style and fast-driver tests passed
1.   Newest master has been used
1.   Single commit
1.   Mitigates bug in tracker with [ID #11717](https://chirpmyradio.com/issues/11717) added to have it referenced here