### PR TITLE
uv17: Fix missing setting warning message

### DIFF
--- a/chirp/drivers/baofeng_uv17Pro.py
+++ b/chirp/drivers/baofeng_uv17Pro.py
@@ -522,18 +522,17 @@ class UV17Pro(bfc.BaofengCommonHT):
 
             # Signal Code Name
             _nameobj = self._memobj.pttid[i]
-            try:
-                rs = RadioSetting(
-                    "pttid/%i.name" % i,
-                    "Signal Code %i Name" % (i + 1),
-                    RadioSettingValueString(
-                        0, 10, self._filterCodeName(_nameobj.name),
-                        False, CHARSET_GB2312))
-                rs.set_apply_callback(self.apply_codename, _nameobj)
-                dtmfe.append(rs)
-            except AttributeError:
+            if 'name' not in _nameobj:
                 # UV17, et al do not have pttid.name
-                pass
+                continue
+            rs = RadioSetting(
+                "pttid/%i.name" % i,
+                "Signal Code %i Name" % (i + 1),
+                RadioSettingValueString(
+                    0, 10, self._filterCodeName(_nameobj.name),
+                    False, CHARSET_GB2312))
+            rs.set_apply_callback(self.apply_codename, _nameobj)
+            dtmfe.append(rs)
 
         _codeobj = self._memobj.ani.code
         _code = "".join([DTMF_CHARS[x] for x in _codeobj if int(x) < 0x1F])


### PR DESCRIPTION
The UV17-based radios don't have a 'name' property for DTMF memories,
and the existing code had a try..except around the attempt to decode
it in the base pro driver. This is normally a good way to go, but
the bitwise infra logs an error, so this changes it to just check for
and skip if there's no name property.

Related to #11699
