### PR TITLE
wouxun: Initialize bands after mmap parse

### DIFF
--- a/chirp/drivers/wouxun.py
+++ b/chirp/drivers/wouxun.py
@@ -308,6 +308,9 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
             self._mmap = memmap.MemoryMap(
                     ("\xFF" * 16) + self._mmap.get_packed()[8:8184])
         self._memobj = bitwise.parse(self._MEM_FORMAT, self._mmap)
+        # This sets our frequency ranges, so run it once after we process the
+        # mmap to make sure they're set for later
+        self.get_settings()
 
     def get_features(self):
         rf = chirp_common.RadioFeatures()


### PR DESCRIPTION
The wouxun driver has a race condition where it expects that
get_settings() will be called before get_features(), likely because
that's how the old GTK UI worked. This resulted in all the band
variants only enforcing the 2m/440 limits. This makes us call
get_settings() in parse_mmap() to initialize the values. Ideally, this
would be better refactored, but this works for now.

Fixes #11715
