### PR TITLE
uv5r: Expose rich "K1 connection" error

### DIFF
--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -392,7 +392,7 @@ def _do_ident(radio, magic, secondack=True):
     if ack != b"\x06":
         if ack:
             LOG.debug(repr(ack))
-        raise errors.RadioError("Radio did not respond")
+        raise errors.RadioNoContactLikelyK1()
 
     serial.write(b"\x02")
 
@@ -555,7 +555,7 @@ def _ident_radio(radio):
 
     if error:
         raise error
-    raise errors.RadioError("Radio did not respond")
+    raise errors.RadioNoContactLikelyK1()
 
 
 def _do_download(radio):


### PR DESCRIPTION
These radios use a K1 connector and suffer from the usual fitment
issues. Expose the rich error with "more info" about this problem.

Related to #11738
