### PR TITLE
RSValueMap lazy init

### DIFF
--- a/chirp/drivers/tk690.py
+++ b/chirp/drivers/tk690.py
@@ -1035,10 +1035,6 @@ class Kenwoodx90(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
               RadioSettingValueMap(
                     BUTTON_FUNCTION_LIST,
                     self._memobj.button_assignments[buttonName]))
-            # TODO satisfy above current_index futurewarning. Maybe with:
-            # user_option=next((i for i, (_, value) in \
-            # enumerate(BUTTON_FUNCTION_LIST) \
-            # if value == self._memobj.button_assignments[buttonName]), None)))
             button_assignments.append(rs)
         return group
 

--- a/chirp/drivers/tk690.py
+++ b/chirp/drivers/tk690.py
@@ -1039,7 +1039,6 @@ class Kenwoodx90(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
         return group
 
     def set_settings(self, settings):
-        print(self._memobj.button_assignments)
         for group in settings:
             for button in group:
                 groupKey = group.get_name()

--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -330,9 +330,16 @@ class RadioSettingValueMap(RadioSettingValueList):
         self._mem_vals = [e[1] for e in map_entries]
         RadioSettingValueList.__init__(self, user_options, current_index=0)
         if mem_val is not None:
-            self.set_mem_val(mem_val)
+            try:
+                self.queue_current(self._mem_vals.index(mem_val))
+            except ValueError:
+                LOG.error('Memory value %r not in value list %r',
+                          mem_val, self._mem_vals)
+                # Set this to just out of bounds so that the invalid-current
+                # handling detects it and flags it as invalid to the user.
+                self.queue_current(len(self._mem_vals))
         elif user_option is not None:
-            self.set_value(user_option)
+            self.queue_current(user_option)
         self._has_changed = False
 
     def set_mem_val(self, mem_val):

--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -328,7 +328,7 @@ class RadioSettingValueMap(RadioSettingValueList):
                                         "instead of: %s" % str(map_entry))
         user_options = [e[0] for e in map_entries]
         self._mem_vals = [e[1] for e in map_entries]
-        RadioSettingValueList.__init__(self, user_options, user_options[0])
+        RadioSettingValueList.__init__(self, user_options, current_index=0)
         if mem_val is not None:
             self.set_mem_val(mem_val)
         elif user_option is not None:


### PR DESCRIPTION
- **Fix missing EOL in FRS/GMRS stock config**
- **Fix RadioSettingValueMap deprecated current-value**
- **tk690: Remove stray print() debug**
- **Make RadioSettingValueMap support lazy init**
