### PR TITLE
TK-690: Handle memory bank renaming and changing head types.

### DIFF
--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -473,12 +473,12 @@ class ChirpSettingGrid(wx.Panel):
             else:
                 LOG.info('User made change to %s=%s despite warning',
                          event.GetPropertyName(), event.GetValue())
-        self._needs_reload = setting.volatile
-        if self.needs_reload:
+        if setting.volatile:
             wx.MessageBox(_(
                 'Changing this setting requires refreshing the settings from '
                 'the image, which will happen now.'),
                           _('Refresh required'), wx.OK)
+            self._needs_reload = True
 
         # If we were unspecified or otherwise marked, clear those markings
         self.pg.SetPropertyColoursToDefault(event.GetProperty().GetName())
@@ -488,15 +488,13 @@ class ChirpSettingGrid(wx.Panel):
         return self._group.get_name()
 
     @property
-    def needs_reload(self):
-        return self._needs_reload
-
-    @property
     def propgrid(self):
         return self.pg
 
     def _pg_changed(self, event):
-        wx.PostEvent(self, EditorChanged(self.GetId()))
+        wx.PostEvent(self, EditorChanged(self.GetId(),
+                                         reload=self._needs_reload))
+        self._needs_reload = False
 
     def _get_editor_int(self, setting, value):
         e = wx.propgrid.IntProperty(setting.get_shortname(),

--- a/chirp/wxui/settingsedit.py
+++ b/chirp/wxui/settingsedit.py
@@ -31,7 +31,6 @@ class ChirpSettingsEdit(common.ChirpEditor):
 
         self._radio = radio
         self._settings = None
-        self._propgrid = None
 
         sizer = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(sizer)
@@ -85,7 +84,6 @@ class ChirpSettingsEdit(common.ChirpEditor):
 
     def _add_group(self, group, parent=None):
         propgrid = common.ChirpSettingGrid(group, self._group_control)
-        self._propgrid = propgrid
         self.Bind(common.EVT_EDITOR_CHANGED, self._changed, propgrid)
         LOG.debug('Adding page for %s (parent=%s)' % (group.get_shortname(),
                                                       parent))
@@ -174,6 +172,7 @@ class ChirpSettingsEdit(common.ChirpEditor):
             elif isinstance(e, settings.RadioSettingGroup):
                 self._remove_dead_settings(e)
 
+    @common.error_proof()
     def _changed(self, event):
         if not self._apply_settings():
             return
@@ -182,7 +181,7 @@ class ChirpSettingsEdit(common.ChirpEditor):
             self._remove_dead_settings(g)
         self.do_radio(self._set_settings_cb, 'set_settings', settings)
         wx.PostEvent(self, common.EditorChanged(self.GetId()))
-        if self._propgrid.needs_reload:
+        if event.reload:
             LOG.warning('Settings grid needs a reload')
             wx.CallAfter(self._reload)
 


### PR DESCRIPTION
This one isn't ready to merge yet, but I was wondering if I could get some tips on how to handle two inter-dependent settings, which I struggled with in commit 2924127e28?

Specifically, the channel name length and group name length must add up to the total display length, which is either 8 or 14 characters, depending on which head unit is equipped. I attempted to handle that logic, but haven't found a way to successfully update one setting in the UI when the other one's value changes. 

Similarly, even though I set the head unit type to be a volatile setting (as some buttons are only available on the full head unit), there's no change in the list of settings on the button_assignments settings tab after changing the head unit type.