### PR TITLE
Update wxPython to >=4.2.1 - fixes #10577

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-wxPython>=4.0,<4.2.0 ; platform_system=="Linux" # See https://github.com/wxWidgets/Phoenix/issues/2225
-wxPython==4.2.0 ; platform_system!="Linux"
+wxPython>=4.2.1 # Fixes https://github.com/wxWidgets/Phoenix/issues/2225
 pyserial
 requests
 pywin32; platform_system=="Windows"


### PR DESCRIPTION
wxPython 4.2.1 fixes the dependency on the broken attrdict3 package, as per their issue tracker: https://github.com/wxWidgets/Phoenix/issues/2225#issuecomment-1596190592