### PR TITLE
ga510v2: Fix reading memory block list

### DIFF
--- a/chirp/drivers/ga510.py
+++ b/chirp/drivers/ga510.py
@@ -1138,6 +1138,7 @@ class RadioddityGA510v2(baofeng_uv17.UV17):
 
     MODES = ["FM", "NFM"]
     BLOCK_ORDER = [2, 4, 6, 16, 24]
+    BLOCK_O_READ = list(BLOCK_ORDER)
     MEM_TOTAL = 0x6000
     WRITE_MEM_TOTAL = 0x6000
     BLOCK_SIZE = 0x40


### PR DESCRIPTION
The fix for #11717 (commit d1f8504e) introduced a new alternate block
list for the download operation to allow grabbing blocks that we do
not upload. The GA510V2 radio subclasses UV17 and changes the block
list but was not updated to copy the read-only block list and thus
inherited the longer one from the parent class.

Fixes #11739
