### PR TITLE
Fix marking some untranslated strings

### DIFF
--- a/chirp/locale/Makefile
+++ b/chirp/locale/Makefile
@@ -21,7 +21,7 @@ chirpui.pot:
 
 %.po: chirpui.pot
 	if [ -f $@ ]; then                                \
-	msgmerge --no-wrap -sU $@ chirpui.pot;            \
+	msgmerge --previous --no-wrap -sUN $@ chirpui.pot;            \
 	else                                              \
 	msginit --input=chirpui.pot --locale=$(@:%.po=%); \
 	fi

--- a/chirp/locale/bg_BG.po
+++ b/chirp/locale/bg_BG.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2024-09-05 02:01-0700\n"
 "Last-Translator: Стоян <stoyanster от гмаил>\n"
 "Language-Team: Bulgarian <dict@ludost.net>\n"
@@ -42,21 +42,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s трябва да бъде между %(min)i и %(max)i"
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i запис и преместване всички нагоре"
 msgstr[1] "%i записа и преместване всички нагоре"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i запис"
 msgstr[1] "%i записа"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -91,7 +91,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(няма)"
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr "...и още %i"
@@ -777,7 +777,7 @@ msgstr "Канада"
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Промяната на тази настройка изисква презареждане на настройките от образа, което ще се случи сега."
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Канали с еднакви TX и RX %s са представени с режим на тона „%s“."
@@ -790,17 +790,17 @@ msgstr "Файлове с образи на Chirp"
 msgid "Choice Required"
 msgstr "Необходим е избор"
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Изберете код на DTSC за %s"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Изберете тон за %s"
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr "Изберете режим на прекръстосване"
 
@@ -809,7 +809,7 @@ msgstr "Изберете режим на прекръстосване"
 msgid "Choose a recent model"
 msgstr "Изберете режим на прекръстосване"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr "Изберете дуплекс"
 
@@ -871,14 +871,14 @@ msgstr "Затваряне на файла"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Групиране на %i запис"
 msgstr[1] "Групиране на %i записа"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Коментар"
 
@@ -906,7 +906,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Превръщане в ЧМ"
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Копиране"
 
@@ -927,7 +927,7 @@ msgstr "Порт по избор"
 msgid "Custom..."
 msgstr "По избор…"
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Изрязване"
 
@@ -945,7 +945,7 @@ msgstr "Полярност на DTCS"
 msgid "DTMF decode"
 msgstr "Декодиране на DTMF"
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr "Записи за цифрови разговори"
 
@@ -957,7 +957,7 @@ msgstr "Напред е опасно"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Премахване"
 
@@ -974,11 +974,11 @@ msgstr "Режим за разработчик"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Режимът на разработчик е %s. Приложението трябва да бъде рестартирано"
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Разлики в необработеното съдържание на записите"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Цифров код"
 
@@ -1048,12 +1048,12 @@ msgstr "Цифровите ретранслатори, поддържащи и �
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Промяна стойностите на %i записа"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Промяна на запис № %i"
@@ -1070,11 +1070,11 @@ msgstr "Включено"
 msgid "Enter Frequency"
 msgstr "Въведете честота"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr "Въведете отместване (МХц)"
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr "Въведете честота на предаване (МХц)"
 
@@ -1165,7 +1165,7 @@ msgstr "Изключване на частните и затворени рет�
 msgid "Experimental driver"
 msgstr "Изпитателен управляващ софтуер"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr "При изнасяне могат да бъдат запазвани само файлове на CSV"
 
@@ -1177,7 +1177,7 @@ msgstr "Изнасяне в CSV"
 msgid "Export to CSV..."
 msgstr "Изнасяне в CSV…"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr "Допълнителни"
 
@@ -1322,7 +1322,7 @@ msgstr ""
 "3 - Включете радиото\n"
 "4 - Изтеглете информацията\n"
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1393,7 +1393,7 @@ msgstr ""
 "3 - Включете радиото\n"
 "4 - Изпратете информацията\n"
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1502,15 +1502,15 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Получаване на настройки"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 msgid "Goto Memory"
 msgstr "Към запис"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr "Към запис:"
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr "Към…"
 
@@ -1526,7 +1526,7 @@ msgstr "Искам помощ…"
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 msgid "Hide empty memories"
 msgstr "Скриване на празни зиписи"
 
@@ -1568,11 +1568,11 @@ msgstr "Пореден номер"
 msgid "Info"
 msgstr "Сведения"
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr "Сведения"
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr "Вмъкване на ред отгоре"
 
@@ -1594,7 +1594,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Неприемлива стойност „%(value)s“ (използвайте десетични градуси)"
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 msgid "Invalid Entry"
 msgstr "Недействителен запис"
 
@@ -1602,7 +1602,7 @@ msgstr "Недействителен запис"
 msgid "Invalid ZIP code"
 msgstr "Неприемлив пощенски код"
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Неприемлива промяна: %s"
@@ -1727,7 +1727,7 @@ msgstr "Записи"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr "Записите не могат да бъдат променяни поради неподдържана версия на управляващия софтуер"
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Запис № %i не може да бъде премахван"
@@ -1741,7 +1741,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr "Етикет на записа (пази се в станцията)"
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr "За да бъде променян, записът трябва да принадлежи към банка"
 
@@ -1785,15 +1785,15 @@ msgstr "Сведения"
 msgid "More than one port found: %s"
 msgstr "Намерен е повече от един порт: %s"
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 msgid "Move Down"
 msgstr "Преместване надолу"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 msgid "Move Up"
 msgstr "Преместване нагоре"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Действията за преместване са забранени при сортиран изглед"
 
@@ -1805,7 +1805,7 @@ msgstr "Нов прозорец"
 msgid "New version available"
 msgstr "Налично е ново издание"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr "Отдолу липсват празни редове!"
 
@@ -1823,7 +1823,7 @@ msgstr "Не са намерени модули"
 msgid "No modules found in issue %i"
 msgstr "Не са намерени модули в доклад за дефект %i"
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -1835,7 +1835,7 @@ msgstr "Няма резултати"
 msgid "No results!"
 msgstr "Няма резултати!"
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr "Число"
 
@@ -1948,7 +1948,7 @@ msgstr "По желание: -122.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "По желание: държава, сграда и т.н."
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 msgid "Overwrite memories?"
 msgstr "Презаписване на записи?"
 
@@ -1970,26 +1970,26 @@ msgstr "Разбор"
 msgid "Password"
 msgstr "Парола"
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Поставяне"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Поставените записи ще презапишат %s съществуващи записа"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Поставените записи ще презапишат записи %s"
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Поставените записи ще презапишат запис № %s"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Поставеният запис ще презапише запис № %s"
@@ -2068,7 +2068,7 @@ msgstr "Отпечатване"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr "Свойства"
 
@@ -2319,7 +2319,7 @@ msgstr "Настройките не могат да бъдат променян�
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Отместване (или честота на предаване) управлявано от дуплекса"
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Показване на необработеното съдържание на записа"
 
@@ -2327,7 +2327,7 @@ msgstr "Показване на необработеното съдържани�
 msgid "Show debug log location"
 msgstr "Папка с дневник"
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr "Допълнителни полета"
 
@@ -2335,40 +2335,44 @@ msgstr "Допълнителни полета"
 msgid "Show image backup location"
 msgstr "Папка с резервни копия"
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Пропускане"
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr "Някои от записите са несъвместими със станцията"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr "Някои от записите не могат да бъдат премахвани"
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Сортиране на %i запис"
 msgstr[1] "Сортиране на %i записа"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Сортиране на %i запис възходящо"
 msgstr[1] "Сортиране на %i записа възходящо"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Сортиране на %i запис низходящо"
 msgstr[1] "Сортиране на %i записа низходящо"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr "Сортиране по колона:"
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 msgid "Sort memories"
 msgstr "Сортиране на записи"
 
@@ -2455,7 +2459,7 @@ msgstr "Следните сведения ще бъдат изпратени:"
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "Препоръчителната процедура за внасяне на записи е да отворите изходния файл и да копирате/поставите записите от него в таблицата. Ако продължите от тук, CHIRP ще замени всички текущи записи с тези от %(file)s. Желаете ли да отворите този файл, за да копирате/поставите записите ръчно, или да продължите с внасянето?"
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 msgid "This Memory"
 msgstr "Този запис"
 
@@ -2509,11 +2513,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 msgid "This memory and shift all up"
 msgstr "Този запис преместване всички нагоре"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 msgid "This memory and shift block up"
 msgstr "Този запис преместване блока нагоре"
 
@@ -2546,7 +2550,7 @@ msgstr "От тук се зарежда модул от докладван де�
 msgid "Tone"
 msgstr "Тон"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Режим на тона"
 
@@ -2582,7 +2586,7 @@ msgstr "Модулация на приемане или предаване (ЧМ
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr "В режим TSQL тон на приемане или предаване, в противен случай тон на приемане"
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr "Стъпка"
 
@@ -2599,7 +2603,7 @@ msgstr "Търсене на порт на USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Грешка при определяне на порта на кабела. Проверете управляващия софтуер и куплунгите."
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Грешка при промяна на запис преди да е зареден от станцията"
 
@@ -2608,7 +2612,7 @@ msgstr "Грешка при промяна на запис преди да е з
 msgid "Unable to find stock config %r"
 msgstr "Грешка при намиране на стандартните настройки %r"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 msgid "Unable to import while the view is sorted"
 msgstr "Грешка при внасяне при сортиран изглед"
 
@@ -2721,7 +2725,7 @@ msgstr "Стойността трябва да бъде нула или пове
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr "Стойности"
 
@@ -2737,11 +2741,11 @@ msgstr "Изглед"
 msgid "WARNING!"
 msgstr "ВНИМАНИЕ!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr "Внимание"
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr "Внимание: %s"
@@ -2876,9 +2880,6 @@ msgstr "{bank} е пълна"
 
 #~ msgid "Select &All"
 #~ msgstr "Избор &всички"
-
-#~ msgid "Skip"
-#~ msgstr "Пропускане"
 
 #, fuzzy
 #~ msgid "Status"

--- a/chirp/locale/de.po
+++ b/chirp/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2012-10-02 22:11+0100\n"
 "Last-Translator: Benjamin, HB9EUK <hb9euk@hb9d.org>\n"
 "Language-Team: German\n"
@@ -35,21 +35,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Löschen (und nach oben verschieben)"
 msgstr[1] "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Speicher"
 msgstr[1] "Speicher"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -81,7 +81,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -780,17 +780,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross Mode"
@@ -800,7 +800,7 @@ msgstr "Cross Mode"
 msgid "Choose a recent model"
 msgstr "Cross Mode"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr ""
 
@@ -863,14 +863,14 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -919,7 +919,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Ausschneiden"
 
@@ -939,7 +939,7 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Erkennung"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Löschen"
 
@@ -971,11 +971,11 @@ msgstr "Entwickler"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Digital Code"
 
@@ -1050,12 +1050,12 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1074,11 +1074,11 @@ msgstr "Aktiviert"
 msgid "Enter Frequency"
 msgstr "Frequenz"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1171,7 +1171,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Weiter mit dem experimentellen Treiber?"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1185,7 +1185,7 @@ msgstr "In Datei exportieren"
 msgid "Export to CSV..."
 msgstr "In Datei exportieren"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr ""
 
@@ -1327,7 +1327,7 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1393,7 +1393,7 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1492,16 +1492,16 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Zeige RAW Speicher"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr ""
 
@@ -1517,7 +1517,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Überschreiben?"
@@ -1561,11 +1561,11 @@ msgstr "Index"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Zeile oben einfügen"
@@ -1589,7 +1589,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ungültiger Wert. Muss eine ganze Zahl sein."
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ungültiger Wert für dieses Feld"
@@ -1598,7 +1598,7 @@ msgstr "Ungültiger Wert für dieses Feld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1727,7 +1727,7 @@ msgstr "Speicher"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1741,7 +1741,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr ""
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr ""
 
@@ -1788,17 +1788,17 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 #, fuzzy
 msgid "Move Down"
 msgstr "Nach _Unten"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 #, fuzzy
 msgid "Move Up"
 msgstr "Nach _Oben"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1811,7 +1811,7 @@ msgstr ""
 msgid "New version available"
 msgstr "Eine neue Version von CHIRP ist verfügbar:"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Zeile unten einfügen"
@@ -1830,7 +1830,7 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr ""
 
@@ -1958,7 +1958,7 @@ msgstr "Optionen"
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Überschreiben?"
@@ -1978,26 +1978,26 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
@@ -2077,7 +2077,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr ""
 
@@ -2331,7 +2331,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Zeige RAW Speicher"
 
@@ -2339,7 +2339,7 @@ msgstr "Zeige RAW Speicher"
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr ""
 
@@ -2347,41 +2347,45 @@ msgstr ""
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Überspringen"
+
+#: ../wxui/memedit.py:2156
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Eingefügter Speicher {number} ist nicht mit diesem Gerät kompatibel weil:"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 #, fuzzy
 msgid "Sort memories"
 msgstr "Überschreiben?"
@@ -2464,7 +2468,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 #, fuzzy
 msgid "This Memory"
 msgstr "Zeige RAW Speicher"
@@ -2519,12 +2523,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Löschen (und nach oben verschieben)"
@@ -2558,7 +2562,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Tone"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Tone Mode"
 
@@ -2596,7 +2600,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Abstimmungsschritt"
@@ -2614,7 +2618,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2623,7 +2627,7 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr "Speichervorgaben öffnen"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Kann Gerät auf {port} nicht erkennen"
@@ -2741,7 +2745,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr ""
 
@@ -2758,11 +2762,11 @@ msgstr "_Ansicht"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -3160,9 +3164,6 @@ msgstr ""
 
 #~ msgid "Show raw memory"
 #~ msgstr "Zeige Roh Speicher"
-
-#~ msgid "Skip"
-#~ msgstr "Überspringen"
 
 #~ msgid "Special Channels"
 #~ msgstr "Spezial Kanäle"

--- a/chirp/locale/el.po
+++ b/chirp/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2023-02-11 15:12+0200\n"
 "Last-Translator: Sokratis Alichanidis <sv2hzs@posteo.net>\n"
 "Language-Team: Greek\n"
@@ -37,21 +37,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 msgstr[1] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Μνήμες"
 msgstr[1] "Μνήμες"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -83,7 +83,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(καμία)"
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -769,7 +769,7 @@ msgstr "Καναδάς"
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -782,17 +782,17 @@ msgstr "Αρχεία ειδώλου CHIRP"
 msgid "Choice Required"
 msgstr "Απαιτείται επιλογή"
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Επιλέξτε κωδικό DTCS %s"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Επιλέξτε τόνο %s"
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "Επιλέξτε κωδικό DTCS %s"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 #, fuzzy
 msgid "Choose duplex"
 msgstr "Επιλογή duplex"
@@ -864,14 +864,14 @@ msgstr "Κλείσιμο αρχείου"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Σχόλιο"
 
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr ""
 
@@ -920,7 +920,7 @@ msgstr "Εισάγετε προσαρμοσμένη θύρα:"
 msgid "Custom..."
 msgstr "Προσαρμοσμένη..."
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 #, fuzzy
 msgid "Cut"
 msgstr "Χώρα"
@@ -941,7 +941,7 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr "Μνήμη DV"
 
@@ -953,7 +953,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Διαγραφή"
 
@@ -971,11 +971,11 @@ msgstr "Λειτουργία προγραμματιστή"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 #, fuzzy
 msgid "Digital Code"
 msgstr "Ψηφιακός Κωδικός"
@@ -1050,12 +1050,12 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Επεξεργασία λεπτομερειών για %i μνήμες"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Επεξεργασία λεπτομερειών για τη μνήμη %i"
@@ -1073,11 +1073,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Εισάγετε συχνότητα"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr "Εισάγετε συχνότητα εκπομπής (MHz)"
 
@@ -1168,7 +1168,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Πειραματικός οδηγός"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr "Η εξαγωγή είναι δυνατή μόνο σε αρχεία CSV"
 
@@ -1181,7 +1181,7 @@ msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 msgid "Export to CSV..."
 msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr "Περισσότερα"
 
@@ -1323,7 +1323,7 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1389,7 +1389,7 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1488,15 +1488,15 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Λήψη ρυθμίσεων"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 msgid "Goto Memory"
 msgstr "Μετάβαση σε Μνήμη"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr "Μετάβαση σε Μνήμη:"
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 #, fuzzy
 msgid "Goto..."
 msgstr "Μετάβαση σε"
@@ -1513,7 +1513,7 @@ msgstr "Βοήθεια..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Αντικατάσταση μνημών;"
@@ -1556,11 +1556,11 @@ msgstr ""
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr "Εισαγωγή γραμμής επάνω"
 
@@ -1584,7 +1584,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Μη έγκυρη τιμή: %s"
@@ -1593,7 +1593,7 @@ msgstr "Μη έγκυρη τιμή: %s"
 msgid "Invalid ZIP code"
 msgstr "Μη έγκυρος ΤΚ"
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Μη έγκυρη τιμή: %s"
@@ -1725,7 +1725,7 @@ msgstr "Μνήμες"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Η μνήμη %i δεν μπορεί να διαγραφεί"
@@ -1739,7 +1739,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr ""
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr "Η μνήμη πρέπει να βρίσκεται σε ομάδα για να γίνει επεξεργασία"
 
@@ -1785,15 +1785,15 @@ msgstr "Πληροφορίες"
 msgid "More than one port found: %s"
 msgstr "Βρέθηκαν περισσότερες από μία θύρες: %s"
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 msgid "Move Down"
 msgstr ""
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 msgid "Move Up"
 msgstr ""
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1805,7 +1805,7 @@ msgstr ""
 msgid "New version available"
 msgstr "Διαθέσιμη νέα έκδοση"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr "Καμία κενή σειρά από κάτω!"
 
@@ -1823,7 +1823,7 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -1836,7 +1836,7 @@ msgstr "Κανένα αποτέλεσμα!"
 msgid "No results!"
 msgstr "Κανένα αποτέλεσμα!"
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr "Αριθμός"
 
@@ -1951,7 +1951,7 @@ msgstr "Προαιρετικό: -122.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Προαιρετικό: Επαρχία, Νοσοκομείο κλπ"
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 msgid "Overwrite memories?"
 msgstr "Αντικατάσταση μνημών;"
 
@@ -1970,26 +1970,26 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
-msgstr ""
-
-#: ../wxui/memedit.py:2061
-#, python-format
-msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
 #: ../wxui/memedit.py:2064
 #, python-format
+msgid "Pasted memories will overwrite %s existing memories"
+msgstr ""
+
+#: ../wxui/memedit.py:2067
+#, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr "Εκτύπωση"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr "Ιδιότητες"
 
@@ -2321,7 +2321,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr ""
 
@@ -2329,7 +2329,7 @@ msgstr ""
 msgid "Show debug log location"
 msgstr "Εμφάνιση τοποθεσίας αρχείου καταγραφής αποσφαλμάτωσης"
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr ""
 
@@ -2338,40 +2338,44 @@ msgstr ""
 msgid "Show image backup location"
 msgstr "Εμφάνιση τοποθεσίας αρχείου καταγραφής αποσφαλμάτωσης"
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr ""
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr "Κάποιες μνήμες δεν είναι συμβατές με αυτόν τον πομποδέκτη"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr "Κάποιες μνήμες δεν είναι δυνατόν να διαγραφούν"
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 #, fuzzy
 msgid "Sort memories"
 msgstr "Αντικατάσταση μνημών;"
@@ -2454,7 +2458,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 #, fuzzy
 msgid "This Memory"
 msgstr "Μνήμη DV"
@@ -2513,12 +2517,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
@@ -2552,7 +2556,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Τόνος"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Τύπος τόνου"
 
@@ -2589,7 +2593,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr "Βήμα συντονισμού"
 
@@ -2606,7 +2610,7 @@ msgstr "Έυρεση θυρών USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2615,7 +2619,7 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Αδυναμία ανοίγματος του πρόχειρου"
@@ -2731,7 +2735,7 @@ msgstr "Η τιμή πρέπει να είναι μηδέν ή μεγαλύτε�
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr ""
 
@@ -2747,11 +2751,11 @@ msgstr "Εμφάνιση"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr "Προειδοποίηση"
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr "Προειδοποίηση: %s"

--- a/chirp/locale/en_US.po
+++ b/chirp/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2011-11-29 16:07-0800\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -33,21 +33,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "_Delete"
 msgstr[1] "_Delete"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -778,17 +778,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr ""
 
@@ -796,7 +796,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr ""
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr ""
 
@@ -859,14 +859,14 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr ""
 
@@ -892,7 +892,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 #, fuzzy
 msgid "Copy"
 msgstr "_Copy"
@@ -914,7 +914,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 #, fuzzy
 msgid "Cut"
 msgstr "_Cut"
@@ -933,7 +933,7 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr ""
 
@@ -945,7 +945,7 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 #, fuzzy
 msgid "Delete"
 msgstr "_Delete"
@@ -964,12 +964,12 @@ msgstr "Developer"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr ""
 
@@ -1042,12 +1042,12 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1064,11 +1064,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr ""
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1158,7 +1158,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1172,7 +1172,7 @@ msgstr "Import from RFinder"
 msgid "Export to CSV..."
 msgstr "Import from RFinder"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr ""
 
@@ -1311,7 +1311,7 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1377,7 +1377,7 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1476,16 +1476,16 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Show raw memory"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr ""
 
@@ -1501,7 +1501,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Diff raw memories"
@@ -1546,11 +1546,11 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr ""
 
@@ -1572,7 +1572,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1580,7 +1580,7 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1705,7 +1705,7 @@ msgstr "Diff raw memories"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1719,7 +1719,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr ""
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr ""
 
@@ -1762,17 +1762,17 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 #, fuzzy
 msgid "Move Down"
 msgstr "Move D_n"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 #, fuzzy
 msgid "Move Up"
 msgstr "Move _Up"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1784,7 +1784,7 @@ msgstr ""
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr ""
 
@@ -1802,7 +1802,7 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -1814,7 +1814,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr ""
 
@@ -1924,7 +1924,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Diff raw memories"
@@ -1944,27 +1944,27 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 #, fuzzy
 msgid "Paste"
 msgstr "_Paste"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr ""
 
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Show raw memory"
@@ -2302,7 +2302,7 @@ msgstr "Show raw memory"
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr ""
 
@@ -2310,40 +2310,44 @@ msgstr ""
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr ""
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 #, fuzzy
 msgid "Sort memories"
 msgstr "Diff raw memories"
@@ -2425,7 +2429,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 #, fuzzy
 msgid "This Memory"
 msgstr "Show raw memory"
@@ -2480,12 +2484,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "_Delete"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "_Delete"
@@ -2519,7 +2523,7 @@ msgstr ""
 msgid "Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr ""
 
@@ -2555,7 +2559,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr ""
 
@@ -2572,7 +2576,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2581,7 +2585,7 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 msgid "Unable to import while the view is sorted"
 msgstr ""
 
@@ -2696,7 +2700,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr ""
 
@@ -2713,11 +2717,11 @@ msgstr "_View"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr ""

--- a/chirp/locale/es.po
+++ b/chirp/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:27-0800\n"
 "PO-Revision-Date: 2024-12-14 00:30-0300\n"
 "Last-Translator: MELERIX\n"
 "Language-Team: \n"
@@ -43,21 +43,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s debe estar entre %(min)i y %(max)i"
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Memoria y desplazar todo hacia arriba"
 msgstr[1] "%i Memorias y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Memoria"
 msgstr[1] "%i Memorias"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -89,7 +89,7 @@ msgstr "(¿Ha funcionado esto antes? ¿Radio nueva? ¿Funciona con el software O
 msgid "(none)"
 msgstr "(nada)"
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr "...y %i más"
@@ -1115,7 +1115,7 @@ msgstr "Canada"
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Cambiar este ajuste requiere actualizar los ajustes desde la imagen, lo cual ocurrirá ahora."
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Canales con TX y RX equivalentes %s son representados por modo de tono de \"%s\""
@@ -1128,17 +1128,17 @@ msgstr "Archivos de imagen Chirp"
 msgid "Choice Required"
 msgstr "Elección requerida"
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Elegir %s código DTCS"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Elegir %s tono"
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr "Elegir modo cruzado"
 
@@ -1146,7 +1146,7 @@ msgstr "Elegir modo cruzado"
 msgid "Choose a recent model"
 msgstr "Elegir un modelo reciente"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr "Elegir Dúplex"
 
@@ -1213,14 +1213,14 @@ msgstr "Cerrar archivo"
 msgid "Close string value with double-quote (\")"
 msgstr "Cerrar el valor de la cadena con comillas dobles (\")"
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Agrupar %i memoria"
 msgstr[1] "Agrupar %i memorias"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Comentario"
 
@@ -1248,7 +1248,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Convertir a FM"
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Copiar"
 
@@ -1269,7 +1269,7 @@ msgstr "Puerto personalizado"
 msgid "Custom..."
 msgstr "Personalizado..."
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Cortar"
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Decodificación DTMF"
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr "Memoria DV"
 
@@ -1301,7 +1301,7 @@ msgstr "Peligro adelante"
 msgid "Dec"
 msgstr "Decimal"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Borrar"
 
@@ -1318,11 +1318,11 @@ msgstr "Modo desarrollador"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Estado de desarrollador ahora está %s. CHIRP debe ser reiniciado para que tome efecto"
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Diferenciar memorias en bruto"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Código digital"
 
@@ -1392,12 +1392,12 @@ msgstr "Los repetidores digitales de modo dual que soportan análogo se mostrar�
 msgid "Duplex"
 msgstr "Dúplex"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Editar detalles para %i memorias"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editar detalles para memoria %i"
@@ -1414,11 +1414,11 @@ msgstr "Habilitado"
 msgid "Enter Frequency"
 msgstr "Ingresar frecuencia"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr "Ingresar desplazamiento (MHz)"
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr "Ingresar frecuencia TX (MHz)"
 
@@ -1508,7 +1508,7 @@ msgstr "Excluir repetidores privados y cerrados"
 msgid "Experimental driver"
 msgstr "Controlador experimental"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr "Exportar sólo puede escribir archivos CSV"
 
@@ -1520,7 +1520,7 @@ msgstr "Exportar a CSV"
 msgid "Export to CSV..."
 msgstr "Exportar a CSV..."
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr "Extra"
 
@@ -1687,7 +1687,7 @@ msgstr ""
 "3 - Enciende tu radio\n"
 "4 - Haz la descarga de tus datos de radio\n"
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1791,7 +1791,7 @@ msgstr ""
 "3 - Enciende tu radio\n"
 "4 - Haz la carga de tus datos de radio\n"
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1920,15 +1920,15 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Obteniendo ajustes"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 msgid "Goto Memory"
 msgstr "Ir a memoria"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr "Ir a memoria:"
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr "Ir a..."
 
@@ -1944,7 +1944,7 @@ msgstr "Ayúdame..."
 msgid "Hex"
 msgstr "Hexadecimal"
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 msgid "Hide empty memories"
 msgstr "Ocultar memorias vacías"
 
@@ -1986,11 +1986,11 @@ msgstr "Índice"
 msgid "Info"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr "Insertar fila arriba"
 
@@ -2012,7 +2012,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s inválido (usa grados decimales)"
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 msgid "Invalid Entry"
 msgstr "Entrada inválida"
 
@@ -2020,7 +2020,7 @@ msgstr "Entrada inválida"
 msgid "Invalid ZIP code"
 msgstr "Código postal inválido"
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Edición inválida: %s"
@@ -2143,7 +2143,7 @@ msgstr "Memorias"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr "Las memorias son de sólo lectura debido a una versión de firmware no soportada"
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoria %i no es borrable"
@@ -2157,7 +2157,7 @@ msgstr "Nombre del campo de memoria (uno de %s)"
 msgid "Memory label (stored in radio)"
 msgstr "Etiqueta de memoria (almacenada en la radio)"
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr "La memoria debe estar en un banco para ser editada"
 
@@ -2200,15 +2200,15 @@ msgstr "Más información"
 msgid "More than one port found: %s"
 msgstr "Más de un puerto encontrado: %s"
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 msgid "Move Down"
 msgstr "Mover abajo"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 msgid "Move Up"
 msgstr "Mover arriba"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Las operaciones de movimiento están deshabilitadas mientras la vista es ordenada"
 
@@ -2220,7 +2220,7 @@ msgstr "Nueva ventana"
 msgid "New version available"
 msgstr "Nueva versión disponible"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr "¡No hay filas vacías debajo!"
 
@@ -2238,7 +2238,7 @@ msgstr "No se encontraron módulos"
 msgid "No modules found in issue %i"
 msgstr "No se encontraron módulos en problema %i"
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr "No hay más espacio disponible; algunas memorias no fueron aplicadas"
 
@@ -2250,7 +2250,7 @@ msgstr "No hay resultados"
 msgid "No results!"
 msgstr "¡No hay resultados!"
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr "Numero"
 
@@ -2361,7 +2361,7 @@ msgstr "Opcional: AA00 - AA00aa11"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcional: Condado, Hospital, etc."
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 msgid "Overwrite memories?"
 msgstr "¿Sobrescribir memorias?"
 
@@ -2383,26 +2383,26 @@ msgstr "Analizando"
 msgid "Password"
 msgstr "Contraseña"
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Las memorias pegadas sobrescribirán %s memorias existentes"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Las memorias pegadas sobrescribirán memorias %s"
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Las memorias pegadas sobrescribirán la memoria %s"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria pegada sobrescribirá la memoria %s"
@@ -2499,7 +2499,7 @@ msgstr "Imprimiendo"
 msgid "Prolific USB device"
 msgstr "Dispositivo USB Prolific"
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr "Propiedades"
 
@@ -2745,7 +2745,7 @@ msgstr "Los ajustes son de sólo lectura debido a una versión de firmware no so
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Cantidad de desplazamiento (o frecuencia de transmisión) controlada por dúplex"
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Mostrar memoria en bruto"
 
@@ -2753,7 +2753,7 @@ msgstr "Mostrar memoria en bruto"
 msgid "Show debug log location"
 msgstr "Mostrar ubicación del registro de depuración"
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr "Mostrar campos adicionales"
 
@@ -2761,40 +2761,44 @@ msgstr "Mostrar campos adicionales"
 msgid "Show image backup location"
 msgstr "Mostrar ubicación de la copia de respaldo de la imagen"
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Omitir"
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr "Algunas memorias son incompatibles con esta radio"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr "Algunas memorias no son borrables"
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Ordenar %i memoria"
 msgstr[1] "Ordenar %i memorias"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Ordenar %i memoria de forma ascendente"
 msgstr[1] "Ordenar %i memorias de forma ascendente"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Ordenar %i memoria de forma descendente"
 msgstr[1] "Ordenar %i memorias de forma descendente"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr "Ordenar por columna:"
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 msgid "Sort memories"
 msgstr "Ordenar memorias"
 
@@ -2896,7 +2900,7 @@ msgstr "La siguiente información será enviada:"
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "El procedimiento recomendado para importar memorias es para abrir el archivo de origen y copiar/pegar memorias desde este en tu imagen objetivo. Si continúas con esta función de importación, CHIRP remplazara todas las memorias de tu archivo actualmente abierto por las de %(file)s. ¿Te gustaría abrir este archivo para copiar/pegar memorias a través de este, o proceder con la importación?"
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 msgid "This Memory"
 msgstr "Esta memoria"
 
@@ -2959,11 +2963,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr "Este es el número de boleto para un problema ya creado en el sitio web chirpmyradio.com"
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 msgid "This memory and shift all up"
 msgstr "Esta memoria y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 msgid "This memory and shift block up"
 msgstr "Esta memoria y desplazar bloque hacia arriba"
 
@@ -3001,7 +3005,7 @@ msgstr "Esto va a cargar un módulo desde un problema del sitio web"
 msgid "Tone"
 msgstr "Tono"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Modo de tono"
 
@@ -3037,7 +3041,7 @@ msgstr "Modulación de transmisión/recepción (FM, AM, SSB, etc)"
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr "Tono de transmisión/recepción para el modo TSQL, sino, tono de recepción"
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr "Paso de sintonización"
 
@@ -3054,7 +3058,7 @@ msgstr "Buscador de puertos USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "No se puede determinar puerto para tu cable. Comprueba tus controladores y conexiones."
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr "No se puede editar memoria antes de que la radio este cargada"
 
@@ -3063,7 +3067,7 @@ msgstr "No se puede editar memoria antes de que la radio este cargada"
 msgid "Unable to find stock config %r"
 msgstr "No se puede buscar la configuración original %r"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 msgid "Unable to import while the view is sorted"
 msgstr "No se puede importar mientras la vista es ordenada"
 
@@ -3176,7 +3180,7 @@ msgstr "Valor debe ser cero o superior"
 msgid "Value to search memory field for"
 msgstr "Valor a buscar en el campo de memoria"
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr "Valores"
 
@@ -3192,11 +3196,11 @@ msgstr "Ver"
 msgid "WARNING!"
 msgstr "¡ADVERTENCIA!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr "Advertencia: %s"
@@ -3691,9 +3695,6 @@ msgstr "{bank} está lleno"
 
 #~ msgid "Show Information"
 #~ msgstr "Mostrar información"
-
-#~ msgid "Skip"
-#~ msgstr "Omitir"
 
 #~ msgid "Smart Tone Modes"
 #~ msgstr "Modos de tono inteligente"

--- a/chirp/locale/fr.po
+++ b/chirp/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2024-05-22 16:39-0400\n"
 "Last-Translator: Alexandre J. Raymond <alexandre.j.raymond@gmail.com>\n"
 "Language-Team: French\n"
@@ -41,21 +41,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s doit être entre %(min)i et %(max)i"
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Mémoires et tout décaler vers le haut"
 msgstr[1] "%i Mémoires et tout décaler vers le haut"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Mémoire"
 msgstr[1] "%i Mémoires"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -87,7 +87,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(vide)"
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr "...et %i de plus"
@@ -1115,7 +1115,7 @@ msgstr "Canada"
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Modifier ce paramètre nécessite de rafraîchir tous les paramètres depuis l'image, ce qui va être fait maintenant."
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Les canaux avec TX et RX équivalents %s sont représentés par le mode de tonalité de \"%s\""
@@ -1128,17 +1128,17 @@ msgstr "Fichiers image Chirp"
 msgid "Choice Required"
 msgstr "Choix nécessaire"
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Choisir code DTCS %s"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Choisir tonalité %s"
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr "Choisir mode cross"
 
@@ -1147,7 +1147,7 @@ msgstr "Choisir mode cross"
 msgid "Choose a recent model"
 msgstr "Choisir mode cross"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr "Choisir duplex"
 
@@ -1215,14 +1215,14 @@ msgstr "Fermer fichier"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Mémoire groupement %i"
 msgstr[1] "Mémoires groupement %i"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Convertir en FM"
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Copier"
 
@@ -1271,7 +1271,7 @@ msgstr "Port personnalisé"
 msgid "Custom..."
 msgstr "Personnalisation..."
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Couper"
 
@@ -1291,7 +1291,7 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Décodage DTMF"
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr "Mémoire DV"
 
@@ -1303,7 +1303,7 @@ msgstr "Danger"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -1321,11 +1321,11 @@ msgstr "Mode développeur"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Le mode développement est maintenant %s. CHIRP doit être redémarré pour que ceci prenne effet"
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Comparaison mémoires brutes"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Code numérique"
 
@@ -1395,12 +1395,12 @@ msgstr "Les répéteurs numériques bimodes supportant l'analogique seront prés
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Éditer les details pour %i mémoires"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editer les details pour la mémoire %i"
@@ -1417,11 +1417,11 @@ msgstr "Activé"
 msgid "Enter Frequency"
 msgstr "Entrer la fréquence"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr "Saisir le décalage (MHz)"
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr "Saisir la fréquence d'émission (MHz)"
 
@@ -1512,7 +1512,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Pilote expérimental"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr "L'exportation ne peut écrire que des fichiers CSV"
 
@@ -1524,7 +1524,7 @@ msgstr "Exporter vers un fichier CSV"
 msgid "Export to CSV..."
 msgstr "Exporter vers un fichier CSV..."
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr "Extra"
 
@@ -1694,7 +1694,7 @@ msgstr ""
 "3 - Allumez votre radio\n"
 "4 - Téléchargez les données depuis votre radio\n"
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1798,7 +1798,7 @@ msgstr ""
 "3 - Allumez votre radio\n"
 "4 - Téléchargez les données vers votre radio\n"
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1927,15 +1927,15 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Acquisition des préférences"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 msgid "Goto Memory"
 msgstr "Aller à la mémoire"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr "Aller à la mémoire:"
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr "Aller..."
 
@@ -1951,7 +1951,7 @@ msgstr "Aidez-moi..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 msgid "Hide empty memories"
 msgstr "Cacher les mémoires vides"
 
@@ -1993,11 +1993,11 @@ msgstr "Index"
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr "Information"
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr "Insérer une ligne avant"
 
@@ -2019,7 +2019,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Invalide %(value)s (utiliser degrés decimaux)"
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 msgid "Invalid Entry"
 msgstr "Entrée invalide"
 
@@ -2027,7 +2027,7 @@ msgstr "Entrée invalide"
 msgid "Invalid ZIP code"
 msgstr "Code postal invalide"
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Édition invalide: %s"
@@ -2153,7 +2153,7 @@ msgstr "Mémoires"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La mémoire %i n'est pas supprimable"
@@ -2167,7 +2167,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr "Texte mémoire (stocké dans la radio)"
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr "La mémoire doit être dans une banque pour être éditée"
 
@@ -2211,15 +2211,15 @@ msgstr "Info"
 msgid "More than one port found: %s"
 msgstr "Plus d'un port trouvé: %s"
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 msgid "Move Down"
 msgstr "Descendre"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 msgid "Move Up"
 msgstr "Monter"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Les déplacements sont désactivés lorsque la vue est triée"
 
@@ -2231,7 +2231,7 @@ msgstr "Nouvelle fenêtre"
 msgid "New version available"
 msgstr "Nouvelle version disponible"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr "Pas de ligne vide dessous!"
 
@@ -2249,7 +2249,7 @@ msgstr "Aucun module trouvé"
 msgid "No modules found in issue %i"
 msgstr "Aucun module trouvé pour le problème %i"
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr "Aucun résultat"
 msgid "No results!"
 msgstr "Aucun résultat!"
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr "Nombre"
 
@@ -2374,7 +2374,7 @@ msgstr "Optionnel: -122.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Optionnel: Comté, Hôpital, etc."
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 msgid "Overwrite memories?"
 msgstr "Écraser les mémoires?"
 
@@ -2396,26 +2396,26 @@ msgstr "Analyse"
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Coller"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Les mémoires collées vont écraser %s mémoires existantes"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Les mémoires collées vont écraser les mémoires %s"
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Les mémoires collées vont écraser la mémoire %s"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La mémoire collee va écraser la mémoire %s"
@@ -2512,7 +2512,7 @@ msgstr "Impression"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr "Propriétés"
 
@@ -2765,7 +2765,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Décalage (ou fréquence de transmission) contrôlée par duplex"
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Afficher les données de mémoires brutes"
 
@@ -2773,7 +2773,7 @@ msgstr "Afficher les données de mémoires brutes"
 msgid "Show debug log location"
 msgstr "Montrer l'emplacement du fichier de débogage"
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr "Montrer les champs supplémentaires"
 
@@ -2781,40 +2781,44 @@ msgstr "Montrer les champs supplémentaires"
 msgid "Show image backup location"
 msgstr "Montrer l'emplacement du fichier de débogage"
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Ignorer"
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr "Des mémoires sont incompatibles avec cette radio"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr "Des mémoires ne sont pas supprimables"
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Tri %i mémoire"
 msgstr[1] "Tri %i mémoires"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Tri croissant %i mémoire"
 msgstr[1] "Tri croissant %i mémoires"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Tri décroissant %i mémoire"
 msgstr[1] "Tri décroissant %i mémoires"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr "Tri par colonne:"
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 msgid "Sort memories"
 msgstr "Tri des mémoires"
 
@@ -2912,7 +2916,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "La procedure préconisée d'importation des mémoires consiste à ouvrir le fichier source et copier/coller les mémoires depuis celui-ci vers l'image cible. Si vous continuez avec cette fonction d'importation, CHIRP va remplacer toutes les mémoires du fichier actuellement ouvert avec celles de %(file)s. Souhaitez-vous ouvrir ce fichier pour copier/coller entre eux ou l'importer?"
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 msgid "This Memory"
 msgstr "Cette mémoire"
 
@@ -2975,11 +2979,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 msgid "This memory and shift all up"
 msgstr "Cette mémoire et décaler tous vers le haut"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 msgid "This memory and shift block up"
 msgstr "Cette mémoire et décaler le bloc vers le haut"
 
@@ -3017,7 +3021,7 @@ msgstr "Ceci chargera un module pour un problème signalé sur le site web"
 msgid "Tone"
 msgstr "Tonalité"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Mode tonalité"
 
@@ -3053,7 +3057,7 @@ msgstr "Modulation transmission/réception (FM, AM, SSB, etc)"
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr "Tonalité transmission/réception pour mode TSQL, ou bien tonalité réception"
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr "Pas de réglage"
 
@@ -3070,7 +3074,7 @@ msgstr "Rechercher port USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Impossible de déterminer le port de votre câble. Vérifiez les pilotes et connexions."
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Impossible d'éditer une mémoire avant téléchargement de la radio"
 
@@ -3079,7 +3083,7 @@ msgstr "Impossible d'éditer une mémoire avant téléchargement de la radio"
 msgid "Unable to find stock config %r"
 msgstr "Impossible de trouver la configuration de base %r"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 msgid "Unable to import while the view is sorted"
 msgstr "Impossible d'importer lorsque la vue est triée"
 
@@ -3192,7 +3196,7 @@ msgstr "La valeur doit être zero ou positive"
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr "Valeurs"
 
@@ -3208,11 +3212,11 @@ msgstr "Voir"
 msgid "WARNING!"
 msgstr "ATTENTION!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr "Attention"
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr "Attention: %s"
@@ -3572,9 +3576,6 @@ msgstr "{bank} pleine"
 
 #~ msgid "Show raw memory"
 #~ msgstr "Montrer les mémoires brutes"
-
-#~ msgid "Skip"
-#~ msgstr "Ignorer"
 
 #~ msgid "Special Channels"
 #~ msgstr "Canaux spéciaux"

--- a/chirp/locale/hu.po
+++ b/chirp/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2015-01-28 13:47+0100\n"
 "Last-Translator: Attila Joubert <joubert.attila@gmail.com>\n"
 "Language-Team: English\n"
@@ -34,21 +34,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "... és a tömböt felfelé lépteti"
 msgstr[1] "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memória"
 msgstr[1] "Memória"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -80,7 +80,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, fuzzy, python-format
 msgid "...and %i more"
 msgstr "...és minden memória felfelé lép"
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -779,17 +779,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "RX DTCS kód"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Kereszt-üzem"
@@ -799,7 +799,7 @@ msgstr "Kereszt-üzem"
 msgid "Choose a recent model"
 msgstr "Kereszt-üzem"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr ""
 
@@ -862,14 +862,14 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Megjegyzés"
 
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Másolás"
 
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Kivágás"
 
@@ -938,7 +938,7 @@ msgstr "DTCS pol."
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 #, fuzzy
 msgid "DV Memory"
 msgstr "ez a memória"
@@ -952,7 +952,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Érzékelés"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Törlés"
 
@@ -971,11 +971,11 @@ msgstr "Fejlesztői"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Digitális kód"
 
@@ -1050,12 +1050,12 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, fuzzy, python-format
 msgid "Edit details for %i memories"
 msgstr "Több memória szerkesztése"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1074,11 +1074,11 @@ msgstr "Engedélyezve"
 msgid "Enter Frequency"
 msgstr "Frekvencia"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1171,7 +1171,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Folytassam kísérleti driver-rel?"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1185,7 +1185,7 @@ msgstr "Export fájlba"
 msgid "Export to CSV..."
 msgstr "Export fájlba"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr ""
 
@@ -1327,7 +1327,7 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1393,7 +1393,7 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1493,17 +1493,17 @@ msgstr ""
 msgid "Getting settings"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 #, fuzzy
 msgid "Goto Memory"
 msgstr "ez a memória"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 #, fuzzy
 msgid "Goto Memory:"
 msgstr "ez a memória"
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr ""
 
@@ -1519,7 +1519,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Felülírja?"
@@ -1563,12 +1563,12 @@ msgstr "Sorszám"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 #, fuzzy
 msgid "Information"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Memória beszúrása fölé"
@@ -1592,7 +1592,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Érvénytelen érték! Egész szám kell legyen."
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Érvénytelen érték %s"
@@ -1601,7 +1601,7 @@ msgstr "Érvénytelen érték %s"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "Érvénytelen érték %s"
@@ -1730,7 +1730,7 @@ msgstr "Memória"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1744,7 +1744,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr ""
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr ""
 
@@ -1791,17 +1791,17 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 #, fuzzy
 msgid "Move Down"
 msgstr "Lefel_é"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 #, fuzzy
 msgid "Move Up"
 msgstr "Fe_lfelé"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1814,7 +1814,7 @@ msgstr ""
 msgid "New version available"
 msgstr "A CHIRP egy új verziója érhető el:"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Memória beszúrása alá"
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -1845,7 +1845,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgstr "Beállítások"
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Felülírja?"
@@ -1981,26 +1981,26 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
@@ -2080,7 +2080,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr ""
 
@@ -2337,7 +2337,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Memóriasor mutatása"
 
@@ -2345,7 +2345,7 @@ msgstr "Memóriasor mutatása"
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr ""
 
@@ -2353,41 +2353,45 @@ msgstr ""
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Ugrás"
+
+#: ../wxui/memedit.py:2156
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "A beillesztett {number}. számú memória nem kompatibilis ezzel a rádióval, mert:"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 #, fuzzy
 msgid "Sort memories"
 msgstr "Felülírja?"
@@ -2470,7 +2474,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 #, fuzzy
 msgid "This Memory"
 msgstr "ez a memória"
@@ -2525,12 +2529,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "... és a tömböt felfelé lépteti"
@@ -2564,7 +2568,7 @@ msgstr ""
 msgid "Tone"
 msgstr "CTCSS"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Hang (CTCSS) mód"
 
@@ -2602,7 +2606,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Lépésköz"
@@ -2620,7 +2624,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2629,7 +2633,7 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr "A csoportos beállítás megnyitása"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Nem érzékelek a {port} porton!"
@@ -2748,7 +2752,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr ""
 
@@ -2765,11 +2769,11 @@ msgstr "Né_zet"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -3210,9 +3214,6 @@ msgstr ""
 
 #~ msgid "Show raw memory"
 #~ msgstr "memóriasor mutatása"
-
-#~ msgid "Skip"
-#~ msgstr "Ugrás"
 
 #~ msgid "Smart Tone Modes"
 #~ msgstr "Hang (CTCSS) mód"

--- a/chirp/locale/it.po
+++ b/chirp/locale/it.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-15 11:21+0100\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2024-12-15 11:20+0100\n"
 "Last-Translator: Giovanni Scafora IK5TWZ <scafora.giovanni@gmail.com>\n"
 "Language-Team: CHIRP Italian Translation\n"
@@ -43,21 +43,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s deve essere compreso tra %(min)i e %(max)i"
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i memoria e sposta tutto su"
 msgstr[1] "%i memorie e sposta tutto su"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i memoria"
 msgstr[1] "%i memorie"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -89,7 +89,7 @@ msgstr "(Ha mai funzionato prima? Radio nuova? Funziona con il software OEM?)"
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr "...ed altri %i"
@@ -829,7 +829,7 @@ msgstr ""
 "5. Assicurarsi che la radio sia sintonizzata su un canale privo di attività.\n"
 "6. Fare clic su OK per caricare l'immagine sul dispositivo.\n"
 
-#: ../drivers/tg_uv2p.py:232 ../drivers/wouxun.py:213 ../drivers/uvb5.py:290
+#: ../drivers/uvb5.py:290 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -845,7 +845,7 @@ msgstr ""
 "5. Assicurarsi che la radio sia sintonizzata su un canale privo di attività.\n"
 "6. Fare clic su OK per scaricare l'immagine dal dispositivo.\n"
 
-#: ../drivers/tg_uv2p.py:240 ../drivers/wouxun.py:221 ../drivers/uvb5.py:298
+#: ../drivers/uvb5.py:298 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -1049,8 +1049,8 @@ msgstr "Inizia sempre con un elenco recente"
 msgid "Amateur"
 msgstr "Radioamatore"
 
-#: ../wxui/common.py:609 ../wxui/common.py:636 ../wxui/bugreport.py:328
-#: ../wxui/bugreport.py:437
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:609
+#: ../wxui/common.py:636
 msgid "An error has occurred"
 msgstr "Si è verificato un errore"
 
@@ -1115,7 +1115,7 @@ msgstr "Canada"
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Per modificare questa impostazione è necessario aggiornare le impostazioni dall'immagine, cosa che avverrà ora."
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "I canali con TX e RX equivalenti %s sono rappresentati dalla modalità di tono \"%s\"."
@@ -1128,17 +1128,17 @@ msgstr "File immagine di Chirp"
 msgid "Choice Required"
 msgstr "Scelta richiesta"
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Scegliere il codice DTCS %s"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Scegliere il Tono %s"
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr "Scegliere la modalità Cross"
 
@@ -1146,7 +1146,7 @@ msgstr "Scegliere la modalità Cross"
 msgid "Choose a recent model"
 msgstr "Scegli un modello recente"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr "Scegliere il duplex"
 
@@ -1187,12 +1187,12 @@ msgstr "Clonazione completata, controllo dei byte spuri"
 msgid "Cloning"
 msgstr "Clonazione"
 
-#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/bj9900.py:133
+#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
 #: ../drivers/ft817.py:341
 msgid "Cloning from radio"
 msgstr "Clonazione dalla radio"
 
-#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/bj9900.py:165
+#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
 #: ../drivers/ft817.py:379
 msgid "Cloning to radio"
 msgstr "Clonazione verso la radio"
@@ -1213,14 +1213,14 @@ msgstr "Chiudi il file"
 msgid "Close string value with double-quote (\")"
 msgstr "Chiudi il valore della stringa con un doppio apice (\")"
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Raggruppa %i memoria"
 msgstr[1] "Raggruppa %i memorie"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Commento"
 
@@ -1248,7 +1248,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Converti in FM"
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Copia"
 
@@ -1269,7 +1269,7 @@ msgstr "Porta personalizzata"
 msgid "Custom..."
 msgstr "Personalizza..."
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Taglia"
 
@@ -1289,7 +1289,7 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Decodifica DTMF"
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr "Memoria DV"
 
@@ -1301,7 +1301,7 @@ msgstr "Pericolo in vista"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Elimina"
 
@@ -1318,11 +1318,11 @@ msgstr "Modalità sviluppatore"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Lo stato dello sviluppatore è ora impostato su %s. Per avere effetto, CHIRP deve essere riavviato"
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Diff memorie raw"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Codice digitale"
 
@@ -1392,12 +1392,12 @@ msgstr "I ripetitori digitali dual-mode che supportano l'analogico saranno mostr
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Modifica dettagli per %i memorie"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Modifica dettagli per la memoria %i"
@@ -1414,11 +1414,11 @@ msgstr "Abilitato"
 msgid "Enter Frequency"
 msgstr "Inserire la frequenza"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr "Inserire l'offset (MHz)"
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr "Inserire la frequenza TX (MHz)"
 
@@ -1508,7 +1508,7 @@ msgstr "Escludi ripetitori privati e chiusi"
 msgid "Experimental driver"
 msgstr "Driver sperimentale"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr "L'esportazione può scrivere solo file CSV"
 
@@ -1520,7 +1520,7 @@ msgstr "Esporta in CSV"
 msgid "Export to CSV..."
 msgstr "Esporta in CSV..."
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr "Extra"
 
@@ -1542,7 +1542,7 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr "Impossibile caricare il browser della radio"
 
-#: ../sources/przemienniki_net.py:59 ../sources/przemienniki_eu.py:57
+#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
 msgid "Failed to parse result"
 msgstr "Impossibile elaborare il risultato"
 
@@ -1669,11 +1669,11 @@ msgstr ""
 "5 - Scollegare il cavo dati dell'interfaccia! In caso contrario, non ci sarà\n"
 "    l'audio del lato destro!\n"
 
-#: ../drivers/bf_t1.py:482 ../drivers/mursv1.py:341
-#: ../drivers/baofeng_wp970i.py:327 ../drivers/baofeng_uv17Pro.py:468
-#: ../drivers/gmrsuv1.py:391 ../drivers/btech.py:693 ../drivers/uv6r.py:339
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv5x3.py:417
-#: ../drivers/gmrsv2.py:363
+#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
+#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
+#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
+#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
+#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1687,7 +1687,7 @@ msgstr ""
 "3 - Accendere la radio\n"
 "4 - Effettuare il download dei dati della radio\n"
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1777,7 +1777,7 @@ msgstr ""
 "    l'audio del lato destro!\n"
 "6 - Accendere la radio per uscire dalla modalità clone.\n"
 
-#: ../drivers/bf_t1.py:488 ../drivers/btech.py:699
+#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1791,7 +1791,7 @@ msgstr ""
 "3 - Accendere la radio\n"
 "4 - Effettuare il caricamento dei dati sulla radio\n"
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1819,7 +1819,7 @@ msgstr ""
 "3 - Accendere la radio\n"
 "4 - Fare clic su OK per iniziare\n"
 
-#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
+#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1847,11 +1847,11 @@ msgstr ""
 "3 - Accendere la radio\n"
 "4 - Effettuare il download dei dati dalla radio\n"
 
-#: ../drivers/mursv1.py:347 ../drivers/baofeng_wp970i.py:333
-#: ../drivers/baofeng_uv17Pro.py:474 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/vgc.py:604 ../drivers/uv6r.py:345
-#: ../drivers/tdxone_tdq8a.py:462 ../drivers/uv5x3.py:423
-#: ../drivers/gmrsv2.py:369
+#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
+#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
+#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
+#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
+#: ../drivers/baofeng_uv17Pro.py:474
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1897,13 +1897,13 @@ msgstr "La frequenza %s non rientra nel range supportato"
 msgid "Frequency granularity in kHz"
 msgstr "Granularità della frequenza in kHz"
 
+#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
 #: ../drivers/tdh8.py:2612 ../drivers/baofeng_uv17Pro.py:1196
-#: ../drivers/mml_jc8810.py:1378 ../drivers/ga510.py:1072
 msgid "Frequency in this range must not be AM mode"
 msgstr "La frequenza in questo intervallo non deve essere in modalità AM"
 
+#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
 #: ../drivers/tdh8.py:2609 ../drivers/baofeng_uv17Pro.py:1192
-#: ../drivers/mml_jc8810.py:1375 ../drivers/ga510.py:1065
 msgid "Frequency in this range requires AM mode"
 msgstr "La frequenza in questo intervallo richiede la modalità AM"
 
@@ -1920,15 +1920,15 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Acquisire le impostazioni"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 msgid "Goto Memory"
 msgstr "Vai alla memoria"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr "Vai alla memoria:"
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr "Vai..."
 
@@ -1944,7 +1944,7 @@ msgstr "Aiutami..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 msgid "Hide empty memories"
 msgstr "Nascondi memorie vuote"
 
@@ -1986,11 +1986,11 @@ msgstr "Indice"
 msgid "Info"
 msgstr "Informazioni"
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr "Informazioni"
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr "Inserisci riga sopra"
 
@@ -2011,8 +2011,8 @@ msgstr "Errore interno del driver"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Il valore %(value)s non è valido (usare i gradi decimali)"
 
-#: ../wxui/memedit.py:1610 ../wxui/query_sources.py:68
-#: ../wxui/query_sources.py:122
+#: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
+#: ../wxui/memedit.py:1613
 msgid "Invalid Entry"
 msgstr "Valore non valido"
 
@@ -2020,7 +2020,7 @@ msgstr "Valore non valido"
 msgid "Invalid ZIP code"
 msgstr "Codice postale non valido"
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Modifica non valida: %s"
@@ -2046,7 +2046,7 @@ msgstr "Numero:"
 msgid "LIVE"
 msgstr "In diretta live"
 
-#: ../wxui/main.py:834 ../wxui/main.py:1516 ../drivers/radtel_rt490.py:1026
+#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:834 ../wxui/main.py:1516
 msgid "Language"
 msgstr "Lingua"
 
@@ -2143,7 +2143,7 @@ msgstr "Memorie"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr "Le memorie sono di sola lettura a causa della versione del firmware non supportata"
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoria %i non è eliminabile"
@@ -2157,7 +2157,7 @@ msgstr "Nome del campo di memoria (uno di %s)"
 msgid "Memory label (stored in radio)"
 msgstr "Etichetta di memoria (memorizzata nella radio)"
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr "La memoria deve trovarsi in un banco per essere modificata"
 
@@ -2166,8 +2166,8 @@ msgstr "La memoria deve trovarsi in un banco per essere modificata"
 msgid "Memory {num} not in bank {bank}"
 msgstr "La memoria {num} non è presente nel banco {bank}"
 
-#: ../wxui/memedit.py:593 ../wxui/query_sources.py:571
-#: ../wxui/query_sources.py:724
+#: ../wxui/query_sources.py:571 ../wxui/query_sources.py:724
+#: ../wxui/memedit.py:593
 msgid "Mode"
 msgstr "Modalità"
 
@@ -2200,15 +2200,15 @@ msgstr "Maggiori informazioni"
 msgid "More than one port found: %s"
 msgstr "Trovata più di una porta: %s"
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 msgid "Move Down"
 msgstr "Sposta giù"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 msgid "Move Up"
 msgstr "Sposta su"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Le operazioni di spostamento sono disabilitate quando la visualizzazione è ordinata"
 
@@ -2220,7 +2220,7 @@ msgstr "Nuova finestra"
 msgid "New version available"
 msgstr "Nuova versione disponibile"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr "Nessuna riga vuota in basso!"
 
@@ -2238,11 +2238,11 @@ msgstr "Nessun modulo trovato"
 msgid "No modules found in issue %i"
 msgstr "Nessun modulo trovato nel sito %i"
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr "Non c'è più spazio disponibile; alcune memorie non sono state inserite"
 
-#: ../sources/przemienniki_net.py:55 ../sources/przemienniki_eu.py:53
+#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
 msgid "No results"
 msgstr "Nessun risultato"
 
@@ -2250,7 +2250,7 @@ msgstr "Nessun risultato"
 msgid "No results!"
 msgstr "Nessun risultato!"
 
-#: ../wxui/memedit.py:1019 ../wxui/query_sources.py:43
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr "Numero"
 
@@ -2361,7 +2361,7 @@ msgstr "Opzionale: AA00 - AA00aa11"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opzionale: contea, ospedale, ecc."
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 msgid "Overwrite memories?"
 msgstr "Sovrascrivere le memorie?"
 
@@ -2375,7 +2375,7 @@ msgstr ""
 "In questa versione, è supportato solo un sottoinsieme\n"
 "delle oltre 130 impostazioni radio disponibili.\n"
 
-#: ../sources/przemienniki_net.py:50 ../sources/przemienniki_eu.py:48
+#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
 msgid "Parsing"
 msgstr "Elaborazione"
 
@@ -2383,26 +2383,26 @@ msgstr "Elaborazione"
 msgid "Password"
 msgstr "Password"
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Incolla"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Le memorie incollate sovrascriveranno %s memorie esistenti"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Le memorie incollate sovrascriveranno le memorie %s"
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Le memorie incollate sovrascriveranno la memoria %s"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria incollata sovrascriverà la memoria %s"
@@ -2499,7 +2499,7 @@ msgstr "Stampa in corso"
 msgid "Prolific USB device"
 msgstr "Dispositivo USB Prolific"
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr "Proprietà"
 
@@ -2536,7 +2536,7 @@ msgstr "La sintassi della query è OK"
 msgid "Query syntax help"
 msgstr "Aiuto per la sintassi delle query"
 
-#: ../sources/przemienniki_net.py:36 ../sources/przemienniki_eu.py:36
+#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
 msgid "Querying"
 msgstr "Interrogazione"
 
@@ -2745,7 +2745,7 @@ msgstr "Le impostazioni sono di sola lettura a causa della versione del firmware
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Shift (o frequenza di trasmissione) controllato dal duplex"
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Mostra memoria raw"
 
@@ -2753,7 +2753,7 @@ msgstr "Mostra memoria raw"
 msgid "Show debug log location"
 msgstr "Mostra posizione del log di debug"
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr "Mostra campi aggiuntivi"
 
@@ -2761,44 +2761,48 @@ msgstr "Mostra campi aggiuntivi"
 msgid "Show image backup location"
 msgstr "Mostra posizione del backup dell'immagine"
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr ""
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr "Alcune memorie sono incompatibili con questa radio"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr "Alcune memorie non sono eliminabili"
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Ordina %i memoria"
 msgstr[1] "Ordina %i memorie"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "%i memoria in ordine crescente"
 msgstr[1] "%i memorie in ordine crescente"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "%i memoria in ordine decrescente"
 msgstr[1] "%i memorie in ordine decrescente"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr "Ordina per colonna:"
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 msgid "Sort memories"
 msgstr "Ordina memorie"
 
-#: ../sources/przemienniki_net.py:62 ../sources/przemienniki_eu.py:60
+#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
 msgid "Sorting"
 msgstr "Ordinamento"
 
@@ -2895,7 +2899,7 @@ msgstr "Saranno trasmesse le seguenti informazioni:"
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "La procedura consigliata per importare le memorie consiste nell'aprire il file di origine e nel copiare/incollare le memorie da esso nell'immagine di destinazione. Se si prosegue con questa funzione di importazione, CHIRP sostituirà tutte le memorie del file attualmente aperto con quelle presenti in %(file)s. Si desidera aprire il file per copiare/incollare le memorie o procedere con l'importazione?"
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 msgid "This Memory"
 msgstr "Questa memoria"
 
@@ -2958,11 +2962,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr "Questo è il numero di ticket di un problema già creato sul sito web chirpmyradio.com"
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 msgid "This memory and shift all up"
 msgstr "Questa memoria e sposta tutto in alto"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 msgid "This memory and shift block up"
 msgstr "Questa memoria e sposta il blocco in alto"
 
@@ -3000,7 +3004,7 @@ msgstr "Caricherà un modulo dal sito"
 msgid "Tone"
 msgstr "Tono"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Modalità tono"
 
@@ -3036,7 +3040,7 @@ msgstr "Trasmissione/ricezione di modulazione (FM, AM, SSB, ecc.)"
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr "Tono di trasmissione/ricezione per la modalità TSQL, altrimenti tono di ricezione"
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr "Passo della sintonia"
 
@@ -3053,7 +3057,7 @@ msgstr "Trova porta USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Impossibile determinare la porta per il cavo. Controllare i driver e i collegamenti."
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Impossibile modificare la memoria prima di averla caricata dalla radio"
 
@@ -3062,7 +3066,7 @@ msgstr "Impossibile modificare la memoria prima di averla caricata dalla radio"
 msgid "Unable to find stock config %r"
 msgstr "Impossibile trovare la configurazione standard %r"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 msgid "Unable to import while the view is sorted"
 msgstr "Impossibile importare mentre la visualizzazione è ordinata"
 
@@ -3070,7 +3074,7 @@ msgstr "Impossibile importare mentre la visualizzazione è ordinata"
 msgid "Unable to open the clipboard"
 msgstr "Impossibile aprire gli appunti"
 
-#: ../sources/przemienniki_net.py:48 ../sources/przemienniki_eu.py:46
+#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
 msgid "Unable to query"
 msgstr "Impossibile eseguire la ricerca"
 
@@ -3175,7 +3179,7 @@ msgstr "Il valore deve essere maggiore o uguale a zero"
 msgid "Value to search memory field for"
 msgstr "Valore da ricercare nel campo della memoria"
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr "Valori"
 
@@ -3191,11 +3195,11 @@ msgstr "Visualizza"
 msgid "WARNING!"
 msgstr "ATTENZIONE!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr "Attenzione"
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr "Attenzione: %s"

--- a/chirp/locale/ja_JP.po
+++ b/chirp/locale/ja_JP.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2023-12-03 11:04+0900\n"
 "Last-Translator: weboo <weboo@users.noreply.github.com>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
@@ -33,21 +33,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i 件削除して全体を上方向にシフト"
 msgstr[1] "%i 件削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i 件の内容を削除"
 msgstr[1] "%i 件の内容を削除"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -790,17 +790,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr ""
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr ""
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr ""
 
@@ -870,14 +870,14 @@ msgstr "ファイルを閉じる"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "%i 件を同一グループにまとめる"
 msgstr[1] "%i 件を同一グループにまとめる"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "コメント"
 
@@ -903,7 +903,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "コピー"
 
@@ -925,7 +925,7 @@ msgstr "ポートを手動で設定"
 msgid "Custom..."
 msgstr "カスタム..."
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "切り取り"
 
@@ -943,7 +943,7 @@ msgstr "DTCS極性"
 msgid "DTMF decode"
 msgstr "DTMF デコード"
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr ""
 
@@ -955,7 +955,7 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "削除"
 
@@ -973,11 +973,11 @@ msgstr "開発者モード"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr ""
 
@@ -1047,12 +1047,12 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1069,11 +1069,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "周波数を入力"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1163,7 +1163,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "実験的ドライバー"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1175,7 +1175,7 @@ msgstr "CSVにエクスポート"
 msgid "Export to CSV..."
 msgstr "CSVにエクスポート..."
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr ""
 
@@ -1313,7 +1313,7 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1379,7 +1379,7 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1478,15 +1478,15 @@ msgstr ""
 msgid "Getting settings"
 msgstr "設定を取得しています"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 msgid "Goto Memory"
 msgstr "行移動"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr "指定した行に移動:"
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr "行移動..."
 
@@ -1502,7 +1502,7 @@ msgstr "ポートが不明の場合..."
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 msgid "Hide empty memories"
 msgstr "空のメモリーを非表示"
 
@@ -1544,11 +1544,11 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr "上に1行追加"
 
@@ -1570,7 +1570,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1578,7 +1578,7 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1702,7 +1702,7 @@ msgstr "メモリー"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "メモリー %i は削除できません"
@@ -1716,7 +1716,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr ""
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr ""
 
@@ -1759,15 +1759,15 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr "2つ以上のポートが見つかりました: %s"
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 msgid "Move Down"
 msgstr "下に移動"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 msgid "Move Up"
 msgstr "上に移動"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1779,7 +1779,7 @@ msgstr "新規ウィンドウ"
 msgid "New version available"
 msgstr "新しいバージョンが利用可能です"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr "空の行が見つかりません"
 
@@ -1797,7 +1797,7 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -1809,7 +1809,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr "行"
 
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 msgid "Overwrite memories?"
 msgstr "メモリーを上書きしますか？"
 
@@ -1937,26 +1937,26 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "ペースト"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "ペーストすると %s 件のメモリーが上書きされます"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
@@ -2035,7 +2035,7 @@ msgstr "印刷"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr "プロパティ"
 
@@ -2282,7 +2282,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr ""
 
@@ -2290,7 +2290,7 @@ msgstr ""
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr "追加フィールドを表示"
 
@@ -2298,40 +2298,44 @@ msgstr "追加フィールドを表示"
 msgid "Show image backup location"
 msgstr "イメージのバックアップを表示"
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr ""
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "並び替え（%i 件）"
 msgstr[1] "並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "昇順に並び替え（%i 件）"
 msgstr[1] "昇順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "降順に並び替え（%i 件）"
 msgstr[1] "降順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr "カラムを選択"
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 msgid "Sort memories"
 msgstr "並び替え"
 
@@ -2412,7 +2416,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "推奨されるメモリーのインポート方法は、ソースファイルを開き、そこから指定場所にメモリーをコピー＆ペーストすることです。このままこのインポート機能を続行すると、CHIRPは現在開いているファイルにあるすべてのメモリーを %(file)s 内のものに置き換えます。このファイルを開いて「メモリ」をコピー＆ペーストしますか？それともインポートを続けますか？"
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 msgid "This Memory"
 msgstr "この行の内容を削除"
 
@@ -2472,11 +2476,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 msgid "This memory and shift all up"
 msgstr "この行を削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 msgid "This memory and shift block up"
 msgstr "この行を削除してグループを上方向にシフト"
 
@@ -2509,7 +2513,7 @@ msgstr ""
 msgid "Tone"
 msgstr "トーン(Hz)"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "トーンモード"
 
@@ -2546,7 +2550,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr "ステップ(kHz)"
 
@@ -2563,7 +2567,7 @@ msgstr "USBポート検出"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "ポートを検出できませんでした。ドライバーがインストールされているかと接続状態をもう一度確認してください。"
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2572,7 +2576,7 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 msgid "Unable to import while the view is sorted"
 msgstr ""
 
@@ -2685,7 +2689,7 @@ msgstr "値は 0 以上にしてください"
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr "値"
 
@@ -2701,11 +2705,11 @@ msgstr "表示"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr ""

--- a/chirp/locale/nl.po
+++ b/chirp/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2012-03-18 12:01+0100\n"
 "Last-Translator: Michael Tel <m.tel@xs4all.nl>\n"
 "Language-Team: Dutch\n"
@@ -34,21 +34,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Verwijderen (en naar boven verplaatsen)"
 msgstr[1] "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Kanalen"
 msgstr[1] "Kanalen"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -80,7 +80,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -779,17 +779,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS code"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross-mode"
@@ -799,7 +799,7 @@ msgstr "Cross-mode"
 msgid "Choose a recent model"
 msgstr "Cross-mode"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr ""
 
@@ -862,14 +862,14 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Opmerking"
 
@@ -896,7 +896,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Kopiëren"
 
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Knippen"
 
@@ -938,7 +938,7 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr ""
 
@@ -951,7 +951,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Detecteren"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Verwijderen"
 
@@ -970,11 +970,11 @@ msgstr "Ontwerper"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Digitale code"
 
@@ -1048,12 +1048,12 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1071,11 +1071,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Frequentie"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1167,7 +1167,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1181,7 +1181,7 @@ msgstr "Exporteren naar bestand"
 msgid "Export to CSV..."
 msgstr "Exporteren naar bestand"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr ""
 
@@ -1320,7 +1320,7 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1386,7 +1386,7 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1485,16 +1485,16 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Toon ruw kanaal"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr ""
 
@@ -1510,7 +1510,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Overschrijven?"
@@ -1555,11 +1555,11 @@ msgstr "Index"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Regel hierboven invoegen"
@@ -1583,7 +1583,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ongeldige waarde. Het moet een integer zijn."
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ongeldige waarde voor dit veld"
@@ -1592,7 +1592,7 @@ msgstr "Ongeldige waarde voor dit veld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1721,7 +1721,7 @@ msgstr "Kanalen"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1735,7 +1735,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr ""
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr ""
 
@@ -1780,17 +1780,17 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 #, fuzzy
 msgid "Move Down"
 msgstr "Verplaats omlaa_g"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 #, fuzzy
 msgid "Move Up"
 msgstr "Verplaats om_hoog"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1802,7 +1802,7 @@ msgstr ""
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Regel hieronder invoegen"
@@ -1821,7 +1821,7 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -1833,7 +1833,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr ""
 
@@ -1949,7 +1949,7 @@ msgstr "Opties"
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Overschrijven?"
@@ -1969,26 +1969,26 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Plakken"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
@@ -2068,7 +2068,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr ""
 
@@ -2320,7 +2320,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Toon ruw kanaal"
 
@@ -2328,7 +2328,7 @@ msgstr "Toon ruw kanaal"
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr ""
 
@@ -2336,41 +2336,45 @@ msgstr ""
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Overslaan"
+
+#: ../wxui/memedit.py:2156
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Geplakt kanaal {number} is niet compatibel met deze radio omdat:"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 #, fuzzy
 msgid "Sort memories"
 msgstr "Overschrijven?"
@@ -2452,7 +2456,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 #, fuzzy
 msgid "This Memory"
 msgstr "Toon ruw kanaal"
@@ -2507,12 +2511,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
@@ -2546,7 +2550,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Toon"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Toonmodus"
 
@@ -2584,7 +2588,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Kanaal-afstand"
@@ -2602,7 +2606,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2611,7 +2615,7 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr "Openen aanwezige configuratie"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Niet in staat om de radio op {port} te detecteren"
@@ -2729,7 +2733,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr ""
 
@@ -2746,11 +2750,11 @@ msgstr "Bee_ld"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -3105,9 +3109,6 @@ msgstr ""
 
 #~ msgid "Show raw memory"
 #~ msgstr "Toon ruw geheugen"
-
-#~ msgid "Skip"
-#~ msgstr "Overslaan"
 
 #~ msgid "Special Channels"
 #~ msgstr "Speciale kanalen"

--- a/chirp/locale/pl.po
+++ b/chirp/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2023-07-12 21:21+0200\n"
 "Last-Translator: szporwolik\n"
 "Language-Team: Polish\n"
@@ -34,7 +34,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s muszą być pomiędzy %(min)i oraz %(max)i"
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -42,7 +42,7 @@ msgstr[0] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[1] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[2] "%i pamięci oraz przesuń wszystkie do góry"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -50,7 +50,7 @@ msgstr[0] "%i pamięci"
 msgstr[1] "%i pamięci"
 msgstr[2] "%i pamięci"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -83,7 +83,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(brak)"
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr "...oraz %i więcej"
@@ -779,7 +779,7 @@ msgstr "Kanada"
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Zmiana tego ustawienia wymaga odświeżenia z obrazu, co zostanie teraz wykonane."
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Kanały z takim samym TX oraz RX %s są reprezentowane trybem tonu \"%s\""
@@ -792,17 +792,17 @@ msgstr "Pliki obrazu CHIRP"
 msgid "Choice Required"
 msgstr "Wymagany wybór"
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Wybierz %s kod DTCS "
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Wybierz %s ton"
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr "Wybierz tryb krzyżowy"
 
@@ -811,7 +811,7 @@ msgstr "Wybierz tryb krzyżowy"
 msgid "Choose a recent model"
 msgstr "Wybierz tryb krzyżowy"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr "Wybierz duplex"
 
@@ -873,7 +873,7 @@ msgstr "Zamknij plik"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -881,7 +881,7 @@ msgstr[0] "Grupuj %i pamięci"
 msgstr[1] "Grupuj %i pamięci"
 msgstr[2] "Grupuj %i pamięci"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -907,7 +907,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Kopiuj"
 
@@ -930,7 +930,7 @@ msgstr "Wprowadź port:"
 msgid "Custom..."
 msgstr "Nietypowy..."
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Wytnij"
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr "Pamięć DV"
 
@@ -962,7 +962,7 @@ msgstr "Niebezpieczeństwo"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Usuń"
 
@@ -980,11 +980,11 @@ msgstr "Tryb dewelopera"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Tryb developera jest teraz %s. CHIRP musi zostać ponowie uruchomiony, aby zmiany przyniosły efekt"
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Porównaj surowe pamięci"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Kod cyfrowy"
 
@@ -1055,12 +1055,12 @@ msgstr ""
 msgid "Duplex"
 msgstr "Dupleks"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Zmień szczegóły dla %i pamięci"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Zmień szczególy dla pamięci %i"
@@ -1077,11 +1077,11 @@ msgstr "Włączony"
 msgid "Enter Frequency"
 msgstr "Wprowadź częstotliwość"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr "Wprowadź przesunięcie (MHz)"
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr "Wprowadź częstotliwość nadawania (MHz)"
 
@@ -1172,7 +1172,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Sterownik eksperymentalny"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr "Eksport może tylko zapisywać pliki CSV"
 
@@ -1184,7 +1184,7 @@ msgstr "Eksportuj do pliku CSV"
 msgid "Export to CSV..."
 msgstr "Eksportuj do pliku CSV..."
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr "Dodatkowa"
 
@@ -1325,7 +1325,7 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1391,7 +1391,7 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1490,15 +1490,15 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Pobieranie ustawień"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 msgid "Goto Memory"
 msgstr "Idź do pamięci"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr "Idź do pamięci:"
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr "Idź do..."
 
@@ -1514,7 +1514,7 @@ msgstr "Pomocy..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 msgid "Hide empty memories"
 msgstr "Ukrywaj puste pamięci"
 
@@ -1556,11 +1556,11 @@ msgstr "Indeks"
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr "Informacja"
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr "Umieść wiersz wyżej"
 
@@ -1582,7 +1582,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Niewłaściwe %(value)s (używaj stopni dziesiętnych)"
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 msgid "Invalid Entry"
 msgstr "Niewłaściwy wpis: %s"
 
@@ -1590,7 +1590,7 @@ msgstr "Niewłaściwy wpis: %s"
 msgid "Invalid ZIP code"
 msgstr "Niewłaściwy kod pocztowy"
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Niewłaściwa edycja: %s"
@@ -1715,7 +1715,7 @@ msgstr "Pamięci"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Pamięć %i jest nieusuwalna"
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr ""
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr "Pamięć musi być w banku, aby można ją było edytować"
 
@@ -1772,15 +1772,15 @@ msgstr "Info"
 msgid "More than one port found: %s"
 msgstr "Znaleziono więcej niż jeden port: %s"
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 msgid "Move Down"
 msgstr "Przesuń w dół"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 msgid "Move Up"
 msgstr "Przesuń w górę"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr "Nowe okno"
 msgid "New version available"
 msgstr "Nowa wersja jest dostępna"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr "Brak pustych wierszy poniżej!"
 
@@ -1810,7 +1810,7 @@ msgstr "Nie znaleziono modułów"
 msgid "No modules found in issue %i"
 msgstr "Nie znaleziono modułów w zgłoszeniu %i"
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr "Brak wyników"
 msgid "No results!"
 msgstr "Brak wyników!"
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr "Numer"
 
@@ -1931,7 +1931,7 @@ msgstr "Opcjonalnie: AA00 - AA00aa11"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcjonalnie: Szpital, Hrabstwo itp."
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 msgid "Overwrite memories?"
 msgstr "Nadpisać pamięci?"
 
@@ -1950,26 +1950,26 @@ msgstr "Parsowanie"
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Wklej"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Wklejone pamięci nadpisze %s istniejących pamięci"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Wklejone pamięci nadpisze pamięci %s"
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Wklejone pamięci nadpiszą pamięć %s"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Wklejona pamięć nadpisze pamięć %s"
@@ -2048,7 +2048,7 @@ msgstr "Drukowanie"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr "Właściwości"
 
@@ -2293,7 +2293,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Pokaż surową pamięć"
 
@@ -2301,7 +2301,7 @@ msgstr "Pokaż surową pamięć"
 msgid "Show debug log location"
 msgstr "Pokaż lokalizację pliku debug"
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr "Pokazuj dodatkowe pola"
 
@@ -2309,15 +2309,19 @@ msgstr "Pokazuj dodatkowe pola"
 msgid "Show image backup location"
 msgstr "Pokaż lokalizację backupu pamięci"
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Przeskocz"
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr "Niektóre pamięci są niekompatybilne z tą radiostacją"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr "Niektóre pamięci są nieusuwalne"
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -2325,7 +2329,7 @@ msgstr[0] "Sortuj %i pamięci"
 msgstr[1] "Sortuj %i pamięci"
 msgstr[2] "Sortuj %i pamięci"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -2333,7 +2337,7 @@ msgstr[0] "Sortuj %i pamięci rosnąco"
 msgstr[1] "Sortuj %i pamięci rosnąco"
 msgstr[2] "Sortuj %i pamięci rosnąco"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -2341,11 +2345,11 @@ msgstr[0] "Sortuj %i pamięci malejąco"
 msgstr[1] "Sortuj %i pamięci malejąco"
 msgstr[2] "Sortuj %i pamięci malejąco"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr "Sortuj wg kolumny:"
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 msgid "Sort memories"
 msgstr "Sortuj pamięci"
 
@@ -2426,7 +2430,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "Rekomendowaną procedurą do importowania pamięci jest otworzenie pliku źródłowego i kopiowanie/wklejanie z niego do docelowego pliku obrazu. Kontynuacja importu spowoduje, że CHIRP zastąpi wszystkie pamięci w aktualnie otwartym pliku tymi z %(file)s. Czy chcesz otworzyć ten plik, aby kopiować/wklejać pamięci lub kontynuować import?"
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 msgid "This Memory"
 msgstr "Tą pamięć"
 
@@ -2480,11 +2484,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 msgid "This memory and shift all up"
 msgstr "Tą pamięć i przeusń wszystkie wyżej"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 msgid "This memory and shift block up"
 msgstr "Tą pamięć i przesuń blok wyżej"
 
@@ -2517,7 +2521,7 @@ msgstr "To załaduje moduł ze strony zgłoszenia"
 msgid "Tone"
 msgstr "Ton TX"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Tryb tonu"
 
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr "Krok strojenia"
 
@@ -2571,7 +2575,7 @@ msgstr "Wykrywacz portów USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Nie można wykryć portu kabla. Należy sprawdzić sterowniki oraz połączenie."
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Przed pobraniem pamięci, nie można jej edytować"
 
@@ -2580,7 +2584,7 @@ msgstr "Przed pobraniem pamięci, nie można jej edytować"
 msgid "Unable to find stock config %r"
 msgstr "Nie znaleziono konfiguracji wstępnej %r"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Przed pobraniem pamięci, nie można jej edytować"
@@ -2694,7 +2698,7 @@ msgstr "Wartość musi wynosić zero lub więcej"
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr "Wartości"
 
@@ -2710,11 +2714,11 @@ msgstr "Widok"
 msgid "WARNING!"
 msgstr "UWAGA!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr "Uwaga"
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr "Uwaga: %s"
@@ -3084,9 +3088,6 @@ msgstr "{bank} jest pełny"
 
 #~ msgid "Show raw memory"
 #~ msgstr "Pokaż surową pamięć"
-
-#~ msgid "Skip"
-#~ msgstr "Przeskocz"
 
 #~ msgid "Special Channels"
 #~ msgstr "Kanały specjalne"

--- a/chirp/locale/pt_BR.po
+++ b/chirp/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2013-03-30 22:04-0300\n"
 "Last-Translator: Crezivando <crezivando@gmail.com>\n"
 "Language-Team: Language pt-BR\n"
@@ -33,21 +33,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Apagar (e deslocar)"
 msgstr[1] "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memórias"
 msgstr[1] "Memórias"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -778,17 +778,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Modo Cross"
@@ -798,7 +798,7 @@ msgstr "Modo Cross"
 msgid "Choose a recent model"
 msgstr "Modo Cross"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr ""
 
@@ -861,14 +861,14 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Comentário"
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Copiar"
 
@@ -917,7 +917,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Cortar"
 
@@ -937,7 +937,7 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr ""
 
@@ -950,7 +950,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Detectar"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Apagar"
 
@@ -969,11 +969,11 @@ msgstr "Desenvolvedor"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Código Digital"
 
@@ -1047,12 +1047,12 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1070,11 +1070,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Frequência"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1180,7 +1180,7 @@ msgstr "Exportar Para Arquivo"
 msgid "Export to CSV..."
 msgstr "Exportar Para Arquivo"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr ""
 
@@ -1319,7 +1319,7 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1385,7 +1385,7 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1484,16 +1484,16 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Mostrar Memória Raw"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr ""
 
@@ -1509,7 +1509,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Sobrescrever?"
@@ -1554,11 +1554,11 @@ msgstr "Índice"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Inserir row acima"
@@ -1582,7 +1582,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Valor inválido. Deve ser um número inteiro."
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Valor Inválido para este campo"
@@ -1591,7 +1591,7 @@ msgstr "Valor Inválido para este campo"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1720,7 +1720,7 @@ msgstr "Memórias"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1734,7 +1734,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr ""
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr ""
 
@@ -1779,17 +1779,17 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 #, fuzzy
 msgid "Move Down"
 msgstr "Mover Abaix_o"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 #, fuzzy
 msgid "Move Up"
 msgstr "Mover _Acima"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1801,7 +1801,7 @@ msgstr ""
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Inserir row abaixo"
@@ -1820,7 +1820,7 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -1832,7 +1832,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr ""
 
@@ -1948,7 +1948,7 @@ msgstr "Opções"
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Sobrescrever?"
@@ -1968,26 +1968,26 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Colar"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
@@ -2067,7 +2067,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr ""
 
@@ -2319,7 +2319,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Mostrar Memória Raw"
 
@@ -2327,7 +2327,7 @@ msgstr "Mostrar Memória Raw"
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr ""
 
@@ -2335,41 +2335,45 @@ msgstr ""
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Skip"
+
+#: ../wxui/memedit.py:2156
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Memória colada {number} não é compatível com este rádio porque:"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff Memórias Raw"
 msgstr[1] "Diff Memórias Raw"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 #, fuzzy
 msgid "Sort memories"
 msgstr "Sobrescrever?"
@@ -2451,7 +2455,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 #, fuzzy
 msgid "This Memory"
 msgstr "Mostrar Memória Raw"
@@ -2506,12 +2510,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Apagar (e deslocar)"
@@ -2545,7 +2549,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Tom"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Modo Tom"
 
@@ -2583,7 +2587,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Tune Step"
@@ -2601,7 +2605,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2610,7 +2614,7 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr "Abrir config do estoque"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Incapaz de detectar rádio na {port}"
@@ -2728,7 +2732,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr ""
 
@@ -2745,11 +2749,11 @@ msgstr "_Visualizar"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -3103,9 +3107,6 @@ msgstr ""
 
 #~ msgid "Show raw memory"
 #~ msgstr "Mostrar memória raw"
-
-#~ msgid "Skip"
-#~ msgstr "Skip"
 
 #~ msgid "Special Channels"
 #~ msgstr "Canais Especiais"

--- a/chirp/locale/ru.po
+++ b/chirp/locale/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2023-10-11 16:47+0300\n"
 "Last-Translator: Olesya Gerasimenko <translation-team@basealt.ru>\n"
 "Language-Team: Basealt Translation Team\n"
@@ -37,7 +37,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s должно находиться в диапазоне от %(min)i до %(max)i"
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -45,7 +45,7 @@ msgstr[0] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[1] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[2] "Ячейки памяти (%i) и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -53,7 +53,7 @@ msgstr[0] "Ячейки памяти (%i)"
 msgstr[1] "Ячейки памяти (%i)"
 msgstr[2] "Ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -86,7 +86,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(нет)"
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr "...и ещё %i"
@@ -1117,7 +1117,7 @@ msgstr "Канада"
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Для изменения этого параметра требуется обновить параметры из образа, что и будет сейчас выполнено."
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Каналы с эквивалентными TX и RX %s представлены видом субтона «%s»."
@@ -1130,17 +1130,17 @@ msgstr "Файлы образов Chirp"
 msgid "Choice Required"
 msgstr "Необходимо сделать выбор"
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Выберите код DTCS %s"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Выберите тон %s"
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr "Выберите кросс-режим"
 
@@ -1149,7 +1149,7 @@ msgstr "Выберите кросс-режим"
 msgid "Choose a recent model"
 msgstr "Выберите кросс-режим"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr "Выберите дуплекс"
 
@@ -1217,7 +1217,7 @@ msgstr "Закрыть файл"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1225,7 +1225,7 @@ msgstr[0] "Объединить ячейки памяти (%i) в кластер
 msgstr[1] "Объединить ячейки памяти (%i) в кластер"
 msgstr[2] "Объединить ячейки памяти (%i) в кластер"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Комментарий"
 
@@ -1253,7 +1253,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Копировать"
 
@@ -1275,7 +1275,7 @@ msgstr "Пользовательский порт"
 msgid "Custom..."
 msgstr "Пользовательский..."
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Вырезать"
 
@@ -1295,7 +1295,7 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr "DV-память"
 
@@ -1307,7 +1307,7 @@ msgstr "Впереди опасность"
 msgid "Dec"
 msgstr "Десятичный"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Удалить"
 
@@ -1325,11 +1325,11 @@ msgstr "Режим разработчика"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Режим разработчика теперь %s. Для применения изменений необходимо перезапустить CHIRP"
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Сравнить необработанные ячейки памяти"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Цифровой код"
 
@@ -1401,12 +1401,12 @@ msgstr ""
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Редактировать сведения о ячейках памяти (%i)"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Редактировать сведения о ячейке памяти (%i)"
@@ -1423,11 +1423,11 @@ msgstr "Включено"
 msgid "Enter Frequency"
 msgstr "Введите частоту"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr "Введите смещение (МГц)"
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr "Введите частоту TX (МГц)"
 
@@ -1518,7 +1518,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr "Экспериментальный драйвер"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr "При экспорте можно выполнять запись только в файлы CSV"
 
@@ -1530,7 +1530,7 @@ msgstr "Экспорт в CSV"
 msgid "Export to CSV..."
 msgstr "Экспорт в CSV..."
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr "Дополнительно"
 
@@ -1701,7 +1701,7 @@ msgstr ""
 "3 - Включите вашу станцию\n"
 "4 - Выполните загрузку ваших радиоданных\n"
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1807,7 +1807,7 @@ msgstr ""
 "3 - Включите вашу станцию\n"
 "4 - Выполните отправку ваших радиоданных\n"
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1936,15 +1936,15 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Получение параметров"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 msgid "Goto Memory"
 msgstr "Перейти к ячейке памяти"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr "Переход к ячейке памяти:"
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr "Переход..."
 
@@ -1960,7 +1960,7 @@ msgstr "Помощь..."
 msgid "Hex"
 msgstr "Шестнадцатеричный"
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 msgid "Hide empty memories"
 msgstr "Скрыть пустые ячейки памяти"
 
@@ -2002,11 +2002,11 @@ msgstr "Индекс"
 msgid "Info"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr "Вставить строку выше"
 
@@ -2029,7 +2029,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s — неверно (используйте десятичные градусы)"
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 msgid "Invalid Entry"
 msgstr "Некорректная запись"
 
@@ -2037,7 +2037,7 @@ msgstr "Некорректная запись"
 msgid "Invalid ZIP code"
 msgstr "Неверный почтовый индекс"
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Некорректное изменение: %s"
@@ -2165,7 +2165,7 @@ msgstr "Ячейки памяти"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Ячейку памяти %i нельзя удалить"
@@ -2179,7 +2179,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr ""
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr "Чтобы редактировать ячейку памяти, необходимо поместить её в банк"
 
@@ -2223,15 +2223,15 @@ msgstr "Информация"
 msgid "More than one port found: %s"
 msgstr "Найдено более одного порта: %s"
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 msgid "Move Down"
 msgstr "Переместить вниз"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 msgid "Move Up"
 msgstr "Переместить вверх"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -2243,7 +2243,7 @@ msgstr "Новое окно"
 msgid "New version available"
 msgstr "Доступна новая версия"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr "Ниже нет пустых строк!"
 
@@ -2261,7 +2261,7 @@ msgstr "Модули не найдены"
 msgid "No modules found in issue %i"
 msgstr "В задаче %i не найдены модули"
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -2273,7 +2273,7 @@ msgstr "Нет результатов"
 msgid "No results!"
 msgstr "Нет результатов!"
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr "Число"
 
@@ -2386,7 +2386,7 @@ msgstr "Опционально: -122.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Опционально: округ, больница и т.д."
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 msgid "Overwrite memories?"
 msgstr "Перезаписать ячейки памяти?"
 
@@ -2408,26 +2408,26 @@ msgstr "Анализ"
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Вставить"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Вставленные ячейки памяти перезапишут существующие ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейку памяти %s"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Вставленная ячейка памяти перезапишет ячейку памяти %s"
@@ -2524,7 +2524,7 @@ msgstr "Печать"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr "Свойства"
 
@@ -2776,7 +2776,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Показать необработанную ячейку памяти"
 
@@ -2784,7 +2784,7 @@ msgstr "Показать необработанную ячейку памяти"
 msgid "Show debug log location"
 msgstr "Показать расположение журнала отладки"
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr "Показать дополнительные поля"
 
@@ -2793,15 +2793,19 @@ msgstr "Показать дополнительные поля"
 msgid "Show image backup location"
 msgstr "Показать расположение журнала отладки"
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Пропуск"
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr "Некоторые ячейки памяти несовместимы с этой станцией"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr "Некоторые ячейки памяти нельзя удалить"
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -2809,7 +2813,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i)"
 msgstr[1] "Упорядочить ячейки памяти (%i)"
 msgstr[2] "Упорядочить ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -2817,7 +2821,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по возра
 msgstr[1] "Упорядочить ячейки памяти (%i) по возрастанию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по возрастанию"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -2825,11 +2829,11 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по убыва
 msgstr[1] "Упорядочить ячейки памяти (%i) по убыванию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по убыванию"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr "Сортировать по столбцу:"
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 msgid "Sort memories"
 msgstr "Упорядочить ячейки памяти"
 
@@ -2925,7 +2929,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "Рекомендуемая процедура импорта ячеек памяти: открыть исходный файл и скопировать/вставить ячейки памяти из него в ваш целевой образ. Если продолжить работу с этой функцией импорта, CHIRP заменит все ячейки памяти в текущем открытом файле на ячейки из %(file)s. Открыть этот файл для копирования/вставки ячеек памяти или продолжить импорт?"
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 msgid "This Memory"
 msgstr "Эта ячейка памяти"
 
@@ -2983,11 +2987,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 msgid "This memory and shift all up"
 msgstr "Эта ячейка памяти и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 msgid "This memory and shift block up"
 msgstr "Эта ячейка памяти и сдвинуть блок вверх"
 
@@ -3025,7 +3029,7 @@ msgstr "Будет выполнена загрузка модуля из зад�
 msgid "Tone"
 msgstr "ТонПРД"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Вид субтона"
 
@@ -3062,7 +3066,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr "Шаг настройки"
 
@@ -3079,7 +3083,7 @@ msgstr "Поиск USB-портов"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Не удалось определить порт для вашего кабеля. Проверьте драйверы и подключения."
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Перед редактированием ячейки памяти необходимо загрузить станцию"
 
@@ -3088,7 +3092,7 @@ msgstr "Перед редактированием ячейки памяти не
 msgid "Unable to find stock config %r"
 msgstr "Не удалось найти предустановленную конфигурацию %r"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Перед редактированием ячейки памяти необходимо загрузить станцию"
@@ -3203,7 +3207,7 @@ msgstr "Значение должно быть больше или равно н
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr "Значения"
 
@@ -3219,11 +3223,11 @@ msgstr "Вид"
 msgid "WARNING!"
 msgstr "ПРЕДУПРЕЖДЕНИЕ!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr "Предупреждение: %s"
@@ -3596,9 +3600,6 @@ msgstr "{bank} полон"
 
 #~ msgid "Show raw memory"
 #~ msgstr "Show raw memory"
-
-#~ msgid "Skip"
-#~ msgstr "Пропуск"
 
 #~ msgid "Special Channels"
 #~ msgstr "Специальные каналы"

--- a/chirp/locale/tr_TR.po
+++ b/chirp/locale/tr_TR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2024-09-14 10:00+0300\n"
 "Last-Translator: Abdullah YILMAZ (TA1AUB) <h.abdullahyilmaz@hotmail.com>\n"
 "Language-Team: TURKISH\n"
@@ -42,21 +42,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s, %(min)i ile %(max)i arasında olmalıdır"
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Kaydı ve hepsini yukarı kaydır"
 msgstr[1] "%i Kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Kaydı"
 msgstr[1] "%i Kaydı"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -88,7 +88,7 @@ msgstr "(Bu daha önce işe yaradı mı? Yeni telsiz? OEM yazılımıyla çalı�
 msgid "(none)"
 msgstr "(hiçbiri)"
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr "...ve %i daha"
@@ -1081,7 +1081,7 @@ msgstr "Kanada"
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Bu ayarın değiştirilmesi, imajdaki ayarların yenilenmesini gerektirir, bu işlem şimdi gerçekleşecektir."
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Eşdeğer TX ve RX %s'ye sahip kanallar, \"%s\" ton modu ile temsil edilir"
@@ -1094,17 +1094,17 @@ msgstr "Chirp İmaj Dosyaları"
 msgid "Choice Required"
 msgstr "Seçim Gerekli"
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "%s DTCS Kodunu Seç"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr "%s Tonunu Seç"
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr "Çapraz Modu Seç"
 
@@ -1113,7 +1113,7 @@ msgstr "Çapraz Modu Seç"
 msgid "Choose a recent model"
 msgstr "Çapraz Modu Seç"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr "Dubleks seç"
 
@@ -1181,14 +1181,14 @@ msgstr "Dosyayı kapat"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "%i Kaydı sırala"
 msgstr[1] "%i kaydı sırala"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Yorum"
 
@@ -1216,7 +1216,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "FM'e dönüştür"
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "Kopyala"
 
@@ -1237,7 +1237,7 @@ msgstr "Özel Bağlantı Noktası"
 msgid "Custom..."
 msgstr "Özel..."
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "Kes"
 
@@ -1257,7 +1257,7 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "DTMF kod çöz"
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr "DV Kaydı"
 
@@ -1269,7 +1269,7 @@ msgstr "İleride Tehlike"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "Sil"
 
@@ -1286,11 +1286,11 @@ msgstr "Geliştirici Modu"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Geliştirici durumu artık %s. Etkili olması için CHIRP yeniden başlatılmalıdır"
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "Farklı Ham Kayıtlar"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Dijital Kod"
 
@@ -1360,12 +1360,12 @@ msgstr "Analogu destekleyen çift modlu dijital tekrarlayıcılar(röleler) FM o
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "%i kaydı için ayrıntıları düzenle"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "%i kaydı için ayrıntıları düzenle"
@@ -1382,11 +1382,11 @@ msgstr "Etkin"
 msgid "Enter Frequency"
 msgstr "Frekans Gir"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr "Ofset girin (MHz)"
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr "TX Frekansını girin (MHz)"
 
@@ -1477,7 +1477,7 @@ msgstr "Özel ve kapalı röleleri hariç tut"
 msgid "Experimental driver"
 msgstr "Deneysel sürücü"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr "Dışa aktarma yalnızca CSV dosyalarını yazabilir"
 
@@ -1489,7 +1489,7 @@ msgstr "CSV'ye aktar"
 msgid "Export to CSV..."
 msgstr "CSV'ye aktar..."
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -1654,7 +1654,7 @@ msgstr ""
 "3 - Telsizinizi açın\n"
 "4 - Telsiz verilerinizin indirilmesini gerçekleştirin\n"
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1755,7 +1755,7 @@ msgstr ""
 "3 - Telsizinizi açın\n"
 "4 - Telsiz verilerinizin yüklemesini gerçekleştirin\n"
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1884,15 +1884,15 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "Ayarlar alınıyor"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 msgid "Goto Memory"
 msgstr "Kayda Git"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr "Kayda Git:"
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr "Git..."
 
@@ -1908,7 +1908,7 @@ msgstr "Bana Yardım Et..."
 msgid "Hex"
 msgstr "Hex"
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 msgid "Hide empty memories"
 msgstr "Boş kayıtları gizle"
 
@@ -1950,11 +1950,11 @@ msgstr "Dizin"
 msgid "Info"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr "Yukarıya Satır Ekle"
 
@@ -1976,7 +1976,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Geçersiz %(value)s (ondalık basamak kullanın)"
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 msgid "Invalid Entry"
 msgstr "Geçersiz Girdi"
 
@@ -1984,7 +1984,7 @@ msgstr "Geçersiz Girdi"
 msgid "Invalid ZIP code"
 msgstr "Geçersiz Posta kodu"
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Geçersiz düzenleme: %s"
@@ -2109,7 +2109,7 @@ msgstr "Kayıtlar"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr "Desteklenmeyen aygıt yazılımı sürümü nedeniyle bellekler salt okunurdur"
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Kayıt %i silinemez"
@@ -2123,7 +2123,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr "Kayıt etiketi (radyoda saklanır)"
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr "Hafızanın düzenlenebilmesi için bir bankada olması gerekir"
 
@@ -2167,15 +2167,15 @@ msgstr "Bilgi"
 msgid "More than one port found: %s"
 msgstr "Birden fazla bağlantı noktası bulundu: %s"
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 msgid "Move Down"
 msgstr "Aşağı Taşı"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 msgid "Move Up"
 msgstr "Yukarı Taşı"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Görünüm sıralanırken taşıma işlemleri devre dışıdır"
 
@@ -2187,7 +2187,7 @@ msgstr "Yeni Pencere"
 msgid "New version available"
 msgstr "Yeni sürüm mevcut"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr "Aşağıda boş satır yok!"
 
@@ -2205,7 +2205,7 @@ msgstr "Modül bulunamadı"
 msgid "No modules found in issue %i"
 msgstr "%i kadında modül bulunamadı"
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr "Daha fazla alan yok; bazı kayıtlar uygulanmadı"
 
@@ -2217,7 +2217,7 @@ msgstr "Sonuç yok"
 msgid "No results!"
 msgstr "Sonuç yok!"
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr "Numara"
 
@@ -2330,7 +2330,7 @@ msgstr "İsteğe bağlı: -122.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "İsteğe bağlı: bölge, Hastane vb."
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 msgid "Overwrite memories?"
 msgstr "Kayıtların üzerine yazılsın mı?"
 
@@ -2351,26 +2351,26 @@ msgstr "Ayrıştırılıyor"
 msgid "Password"
 msgstr "Şifre"
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Yapıştırılan kayıtlar, mevcut %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Yapıştırılan kayıtlar %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Yapıştırılan kayıtlar, %s kaydının üzerine yazılacak"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Yapıştırılan kayıt, %s kaydının üzerine yazacak"
@@ -2464,7 +2464,7 @@ msgstr "Baskı"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr "Özellikler"
 
@@ -2717,7 +2717,7 @@ msgstr "Desteklenmeyen aygıt yazılımı sürümü nedeniyle ayarlar salt okunu
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Çift yönlü tarafından kontrol edilen kaydırma miktarı (veya iletim frekansı)"
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "Ham Kaydı Göster"
 
@@ -2725,7 +2725,7 @@ msgstr "Ham Kaydı Göster"
 msgid "Show debug log location"
 msgstr "Hata ayıklama günlüğü konumunu göster"
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr "Ekstra alanları göster"
 
@@ -2733,40 +2733,44 @@ msgstr "Ekstra alanları göster"
 msgid "Show image backup location"
 msgstr "İmaj yedekleme konumunu göster"
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Atla"
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr "Bazı kayıtlar bu telsizle uyumlu değil"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr "Bazı anılar silinemez"
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "%i kaydı sırala"
 msgstr[1] "%i kaydı sırala"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "%i kaydı artan şekilde sırala"
 msgstr[1] "%i kaydı artan şekilde sırala"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "%i kaydı azalan şekilde sırala"
 msgstr[1] "%i kaydı azalan şekilde sırala"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr "Sütuna göre sırala:"
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 msgid "Sort memories"
 msgstr "Kayıtları sırala"
 
@@ -2862,7 +2866,7 @@ msgstr "Aşağıdaki bilgiler sunulacaktır:"
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "Kayıtları içe aktarmak için önerilen prosedür, kaynak dosyayı açmak ve kayıtları bu dosyadan hedef görüntünüze kopyalamak/yapıştırmaktır. Bu içe aktarma işlevine devam ederseniz CHIRP, şu anda açık olan dosyanızdaki tüm kayıtları %(file)s içindekilerle değiştirecektir. Kayıtları kopyalamak/yapıştırmak için bu dosyayı açmak mı yoksa içe aktarma işlemine devam etmek mi istiyorsunuz?"
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 msgid "This Memory"
 msgstr "Bu kaydı"
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr "Bu, chirpmyradio.com web sitesinde önceden oluşturulmuş bir sorun için bilet numarasıdır"
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 msgid "This memory and shift all up"
 msgstr "Bu kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 msgid "This memory and shift block up"
 msgstr "Bu kaydı ve bloğu yukarı kaydır"
 
@@ -2967,7 +2971,7 @@ msgstr "Bu, bir web sitesi kaydından bir modül yükleyecektir"
 msgid "Tone"
 msgstr "Ton"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Ton Modu"
 
@@ -3003,7 +3007,7 @@ msgstr "Verici/alıcı modülasyonu (FM, AM, SSB, vb.)"
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr "TSQL modu için gönderme/alma tonu, aksi takdirde ton al"
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr "Ayarlama Adımı"
 
@@ -3020,7 +3024,7 @@ msgstr "USB Portu Bulucu"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Kablonuz için bağlantı noktası belirlenemiyor. Sürücülerinizi ve bağlantılarınızı kontrol edin."
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Radyo yüklenmeden önce kayıt düzenlenemiyor"
 
@@ -3029,7 +3033,7 @@ msgstr "Radyo yüklenmeden önce kayıt düzenlenemiyor"
 msgid "Unable to find stock config %r"
 msgstr "%r stok yapılandırması bulunamadı"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 msgid "Unable to import while the view is sorted"
 msgstr "Görünüm sıralanmışken içe aktarma yapılamıyor"
 
@@ -3142,7 +3146,7 @@ msgstr "Değer sıfır veya daha büyük olmalıdır"
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr "Değerler"
 
@@ -3158,11 +3162,11 @@ msgstr "Göster"
 msgid "WARNING!"
 msgstr "UYARI!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr "Uyarı"
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr "Uyarı: %s"
@@ -3325,9 +3329,6 @@ msgstr "{bank} dolu"
 
 #~ msgid "Show raw memory"
 #~ msgstr "Ham kaydı göster"
-
-#~ msgid "Skip"
-#~ msgstr "Atla"
 
 #, fuzzy
 #~ msgid "Status"

--- a/chirp/locale/uk_UA.po
+++ b/chirp/locale/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2015-11-30 10:36+0200\n"
 "Last-Translator: laser <student.laser@gmail.com>\n"
 "Language-Team: laser <student.laser@gmail.com>\n"
@@ -33,21 +33,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Видалити (та зсунути вгору)"
 msgstr[1] "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Пам'ять"
 msgstr[1] "Пам'ять"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -79,7 +79,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -765,7 +765,7 @@ msgstr ""
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -778,17 +778,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS код"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Кросрежим"
@@ -798,7 +798,7 @@ msgstr "Кросрежим"
 msgid "Choose a recent model"
 msgstr "Кросрежим"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr ""
 
@@ -861,14 +861,14 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "Коментар"
 
@@ -895,7 +895,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 #, fuzzy
 msgid "Copy"
 msgstr "Копіювати"
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 #, fuzzy
 msgid "Cut"
 msgstr "Вирізати"
@@ -939,7 +939,7 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr ""
 
@@ -952,7 +952,7 @@ msgstr ""
 msgid "Dec"
 msgstr "Визначити"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 #, fuzzy
 msgid "Delete"
 msgstr "Видалити"
@@ -972,12 +972,12 @@ msgstr "Розробник"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "Цифровий код"
 
@@ -1051,12 +1051,12 @@ msgstr ""
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1074,11 +1074,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Частота"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1170,7 +1170,7 @@ msgstr ""
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1184,7 +1184,7 @@ msgstr "Експорт до файлу"
 msgid "Export to CSV..."
 msgstr "Експорт до файлу"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr ""
 
@@ -1323,7 +1323,7 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1389,7 +1389,7 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1488,16 +1488,16 @@ msgstr ""
 msgid "Getting settings"
 msgstr ""
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 #, fuzzy
 msgid "Goto Memory"
 msgstr "Показати Raw пам'ять"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr ""
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr ""
 
@@ -1513,7 +1513,7 @@ msgstr ""
 msgid "Hex"
 msgstr ""
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 #, fuzzy
 msgid "Hide empty memories"
 msgstr "Перезаписати?"
@@ -1558,11 +1558,11 @@ msgstr "Зміст"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Додати рядок зверху"
@@ -1586,7 +1586,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Неприпустиме значення. Повинно бути цілим числом."
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Неприпустиме значення для цього поля"
@@ -1595,7 +1595,7 @@ msgstr "Неприпустиме значення для цього поля"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1725,7 +1725,7 @@ msgstr "Пам'ять"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1739,7 +1739,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr ""
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr ""
 
@@ -1784,17 +1784,17 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 #, fuzzy
 msgid "Move Down"
 msgstr "Перемістити В_низ"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 #, fuzzy
 msgid "Move Up"
 msgstr "Перемістити В_гору"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1806,7 +1806,7 @@ msgstr ""
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Додати рядок знизу"
@@ -1825,7 +1825,7 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
@@ -1837,7 +1837,7 @@ msgstr ""
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr ""
 
@@ -1953,7 +1953,7 @@ msgstr "Опції"
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Перезаписати?"
@@ -1973,27 +1973,27 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 #, fuzzy
 msgid "Paste"
 msgstr "Вставити"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
@@ -2073,7 +2073,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr ""
 
@@ -2326,7 +2326,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Показати Raw пам'ять"
@@ -2335,7 +2335,7 @@ msgstr "Показати Raw пам'ять"
 msgid "Show debug log location"
 msgstr ""
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr ""
 
@@ -2343,41 +2343,45 @@ msgstr ""
 msgid "Show image backup location"
 msgstr ""
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "Пропустити"
+
+#: ../wxui/memedit.py:2156
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Вставлена пам'ять {number} несумісна із цією радіостанцією тому що:"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 #, fuzzy
 msgid "Sort memories"
 msgstr "Перезаписати?"
@@ -2459,7 +2463,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 #, fuzzy
 msgid "This Memory"
 msgstr "Показати Raw пам'ять"
@@ -2514,12 +2518,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Видалити (та зсунути вгору)"
@@ -2553,7 +2557,7 @@ msgstr ""
 msgid "Tone"
 msgstr "Тон"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "Тоновий режим"
 
@@ -2591,7 +2595,7 @@ msgstr ""
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr ""
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 #, fuzzy
 msgid "Tuning Step"
 msgstr "Крок настройки"
@@ -2609,7 +2613,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2618,7 +2622,7 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr "Відкрити заводські конфігурації"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Не вдалося виявити радіо на {port}"
@@ -2736,7 +2740,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr ""
 
@@ -2753,11 +2757,11 @@ msgstr "В_игляд"
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -3121,9 +3125,6 @@ msgstr ""
 
 #~ msgid "Show raw memory"
 #~ msgstr "Показати raw пам'ять"
-
-#~ msgid "Skip"
-#~ msgstr "Пропустити"
 
 #~ msgid "Special Channels"
 #~ msgstr "Спеціальні канали"

--- a/chirp/locale/zh_CN.po
+++ b/chirp/locale/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-11 10:07-0800\n"
+"POT-Creation-Date: 2024-12-23 16:30-0800\n"
 "PO-Revision-Date: 2024-11-11 02:28+0800\n"
 "Last-Translator: DuckSoft, BH2UEP <realducksoft@gmail.com>\n"
 "Language-Team: \n"
@@ -40,19 +40,19 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s 必须在 %(min)i 和 %(max)i 之间"
 
-#: ../wxui/memedit.py:1796
+#: ../wxui/memedit.py:1799
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i 个存储并将所有上移"
 
-#: ../wxui/memedit.py:1787
+#: ../wxui/memedit.py:1790
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i 个存储"
 
-#: ../wxui/memedit.py:1791
+#: ../wxui/memedit.py:1794
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -83,7 +83,7 @@ msgstr "（这之前曾经奏效过吗？是新电台吗？使用原厂软件能
 msgid "(none)"
 msgstr "（无）"
 
-#: ../wxui/memedit.py:2149
+#: ../wxui/memedit.py:2152
 #, python-format
 msgid "...and %i more"
 msgstr "...以及其他 %i 个"
@@ -1077,7 +1077,7 @@ msgstr "加拿大"
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "更改此设置需要从映像中刷新设置，这将立即发生。"
 
-#: ../wxui/memedit.py:1445
+#: ../wxui/memedit.py:1448
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "收发一致的 %s 频道使用 \"%s\" 亚音频模式表示"
@@ -1090,17 +1090,17 @@ msgstr "CHIRP 映像文件"
 msgid "Choice Required"
 msgstr "需要选择"
 
-#: ../wxui/memedit.py:1424
+#: ../wxui/memedit.py:1427
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "选择 %s DTCS 接收代码"
 
-#: ../wxui/memedit.py:1421
+#: ../wxui/memedit.py:1424
 #, python-format
 msgid "Choose %s Tone"
 msgstr "选择 %s 亚音频"
 
-#: ../wxui/memedit.py:1455
+#: ../wxui/memedit.py:1458
 msgid "Choose Cross Mode"
 msgstr "收发使用不同亚音频"
 
@@ -1108,7 +1108,7 @@ msgstr "收发使用不同亚音频"
 msgid "Choose a recent model"
 msgstr "选择一个最近的型号"
 
-#: ../wxui/memedit.py:1485
+#: ../wxui/memedit.py:1488
 msgid "Choose duplex"
 msgstr "选择双工"
 
@@ -1174,13 +1174,13 @@ msgstr "关闭文件"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:1855
+#: ../wxui/memedit.py:1858
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Cluster %i 个记忆"
 
-#: ../wxui/memedit.py:621
+#: ../wxui/memedit.py:624
 msgid "Comment"
 msgstr "备注"
 
@@ -1208,7 +1208,7 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "转换到 FM"
 
-#: ../wxui/memedit.py:1772
+#: ../wxui/memedit.py:1775
 msgid "Copy"
 msgstr "复制"
 
@@ -1229,7 +1229,7 @@ msgstr "自定义端口"
 msgid "Custom..."
 msgstr "自定义..."
 
-#: ../wxui/memedit.py:1768
+#: ../wxui/memedit.py:1771
 msgid "Cut"
 msgstr "剪切"
 
@@ -1249,7 +1249,7 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "DTMF 解码"
 
-#: ../wxui/memedit.py:2419
+#: ../wxui/memedit.py:2422
 msgid "DV Memory"
 msgstr "该存储"
 
@@ -1261,7 +1261,7 @@ msgstr "前方危险"
 msgid "Dec"
 msgstr "探测"
 
-#: ../wxui/memedit.py:1781
+#: ../wxui/memedit.py:1784
 msgid "Delete"
 msgstr "删除"
 
@@ -1278,11 +1278,11 @@ msgstr "开发者模式"
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "开发者状态现在是 %s。CHIRP 必须重新启动才能生效"
 
-#: ../wxui/memedit.py:1891 ../wxui/developer.py:88
+#: ../wxui/memedit.py:1894 ../wxui/developer.py:88
 msgid "Diff Raw Memories"
 msgstr "对比原始存储"
 
-#: ../wxui/memedit.py:2344
+#: ../wxui/memedit.py:2347
 msgid "Digital Code"
 msgstr "数字代码"
 
@@ -1352,12 +1352,12 @@ msgstr "支持模拟的双模数字中继将显示为 FM"
 msgid "Duplex"
 msgstr "双工"
 
-#: ../wxui/memedit.py:2374
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "修改 %i 个存储的详细信息"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2375
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "修改存储 %i 的详细信息"
@@ -1374,11 +1374,11 @@ msgstr "已启用"
 msgid "Enter Frequency"
 msgstr "频率"
 
-#: ../wxui/memedit.py:1472
+#: ../wxui/memedit.py:1475
 msgid "Enter Offset (MHz)"
 msgstr "输入频差（MHz）"
 
-#: ../wxui/memedit.py:1464
+#: ../wxui/memedit.py:1467
 msgid "Enter TX Frequency (MHz)"
 msgstr "输入发射频率（MHz）"
 
@@ -1469,7 +1469,7 @@ msgstr "排除私有和已关闭的中继"
 msgid "Experimental driver"
 msgstr "实验性的驱动程序"
 
-#: ../wxui/memedit.py:2297
+#: ../wxui/memedit.py:2300
 msgid "Export can only write CSV files"
 msgstr "只能导出CSV文件"
 
@@ -1481,7 +1481,7 @@ msgstr "以CSV文件格式导出"
 msgid "Export to CSV..."
 msgstr "以CSV文件格式导出……"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2411
 msgid "Extra"
 msgstr "更多"
 
@@ -1643,7 +1643,7 @@ msgstr ""
 "3 - 打开您的电台\n"
 "4 - 下载您的电台数据\n"
 
-#: ../drivers/tk760g.py:683
+#: ../drivers/tk690.py:572 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1744,7 +1744,7 @@ msgstr ""
 "3 - 打开您的电台\n"
 "4 - 上传您的电台数据\n"
 
-#: ../drivers/tk760g.py:689
+#: ../drivers/tk690.py:578 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1873,15 +1873,15 @@ msgstr "GMRS"
 msgid "Getting settings"
 msgstr "正在获取设置"
 
-#: ../wxui/memedit.py:1020
+#: ../wxui/memedit.py:1023
 msgid "Goto Memory"
 msgstr "前往存储"
 
-#: ../wxui/memedit.py:1019
+#: ../wxui/memedit.py:1022
 msgid "Goto Memory:"
 msgstr "前往存储："
 
-#: ../wxui/memedit.py:988
+#: ../wxui/memedit.py:991
 msgid "Goto..."
 msgstr "前往..."
 
@@ -1897,7 +1897,7 @@ msgstr "帮助我..."
 msgid "Hex"
 msgstr "十六进制"
 
-#: ../wxui/memedit.py:997
+#: ../wxui/memedit.py:1000
 msgid "Hide empty memories"
 msgstr "隐藏无数据的内容"
 
@@ -1939,11 +1939,11 @@ msgstr "索引"
 msgid "Info"
 msgstr "信息"
 
-#: ../wxui/memedit.py:1447
+#: ../wxui/memedit.py:1450
 msgid "Information"
 msgstr "信息"
 
-#: ../wxui/memedit.py:1762
+#: ../wxui/memedit.py:1765
 msgid "Insert Row Above"
 msgstr "上方插入一行"
 
@@ -1965,7 +1965,7 @@ msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "无效的 %(value)s（请使用十进制度数）"
 
 #: ../wxui/query_sources.py:68 ../wxui/query_sources.py:122
-#: ../wxui/memedit.py:1610
+#: ../wxui/memedit.py:1613
 msgid "Invalid Entry"
 msgstr "无效项目"
 
@@ -1973,7 +1973,7 @@ msgstr "无效项目"
 msgid "Invalid ZIP code"
 msgstr "无效的邮政编码"
 
-#: ../wxui/memedit.py:1609 ../wxui/memedit.py:2499
+#: ../wxui/memedit.py:1612 ../wxui/memedit.py:2502
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "编辑无效：%s"
@@ -2098,7 +2098,7 @@ msgstr "存储"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr "由于不支持的固件版本，存储是只读的"
 
-#: ../wxui/memedit.py:1649
+#: ../wxui/memedit.py:1652
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "存储 %i 不能删除"
@@ -2112,7 +2112,7 @@ msgstr ""
 msgid "Memory label (stored in radio)"
 msgstr "存储标签（存储在电台中）"
 
-#: ../wxui/bankedit.py:233
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr "存储必须在一个存储区中才能编辑"
 
@@ -2155,15 +2155,15 @@ msgstr "更多信息"
 msgid "More than one port found: %s"
 msgstr "找到多个端口：%s"
 
-#: ../wxui/memedit.py:984
+#: ../wxui/memedit.py:987
 msgid "Move Down"
 msgstr "下移"
 
-#: ../wxui/memedit.py:974
+#: ../wxui/memedit.py:977
 msgid "Move Up"
 msgstr "上移"
 
-#: ../wxui/memedit.py:2209
+#: ../wxui/memedit.py:2212
 msgid "Move operations are disabled while the view is sorted"
 msgstr "排序启用时不能移动"
 
@@ -2175,7 +2175,7 @@ msgstr "创建一个新的窗口"
 msgid "New version available"
 msgstr "有新版本"
 
-#: ../wxui/memedit.py:1928
+#: ../wxui/memedit.py:1931
 msgid "No empty rows below!"
 msgstr "下方已无空行！"
 
@@ -2193,7 +2193,7 @@ msgstr "未找到模块"
 msgid "No modules found in issue %i"
 msgstr "在 issue %i 中未找到模块"
 
-#: ../wxui/memedit.py:2087
+#: ../wxui/memedit.py:2090
 msgid "No more space available; some memories were not applied"
 msgstr "没有更多空间可用；一些存储未应用"
 
@@ -2205,7 +2205,7 @@ msgstr "无结果"
 msgid "No results!"
 msgstr "无结果！"
 
-#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1019
+#: ../wxui/query_sources.py:43 ../wxui/memedit.py:1022
 msgid "Number"
 msgstr "编号"
 
@@ -2318,7 +2318,7 @@ msgstr "可选：-122.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "可选：县，医院，等等."
 
-#: ../wxui/memedit.py:2067
+#: ../wxui/memedit.py:2070
 msgid "Overwrite memories?"
 msgstr "要覆盖存储吗？"
 
@@ -2339,26 +2339,26 @@ msgstr "解析"
 msgid "Password"
 msgstr "密码"
 
-#: ../wxui/memedit.py:1776
+#: ../wxui/memedit.py:1779
 msgid "Paste"
 msgstr "粘贴"
 
-#: ../wxui/memedit.py:2061
+#: ../wxui/memedit.py:2064
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "粘贴的存储将覆盖 %s 个现有存储"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2067
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "粘贴的存储将覆盖存储 %s"
 
-#: ../wxui/memedit.py:2058
+#: ../wxui/memedit.py:2061
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "粘贴的存储将覆盖存储 %s"
 
-#: ../wxui/memedit.py:2055
+#: ../wxui/memedit.py:2058
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "粘贴的存储将覆盖存储 %s"
@@ -2453,7 +2453,7 @@ msgstr "正在打印"
 msgid "Prolific USB device"
 msgstr "Prolific USB 设备"
 
-#: ../wxui/memedit.py:1755
+#: ../wxui/memedit.py:1758
 msgid "Properties"
 msgstr "属性"
 
@@ -2700,7 +2700,7 @@ msgstr "由于不支持的固件版本，设置是只读的"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "由双工控制的移动量（或发射频率）"
 
-#: ../wxui/memedit.py:1884 ../wxui/developer.py:91
+#: ../wxui/memedit.py:1887 ../wxui/developer.py:91
 msgid "Show Raw Memory"
 msgstr "显示原始存储"
 
@@ -2708,7 +2708,7 @@ msgstr "显示原始存储"
 msgid "Show debug log location"
 msgstr "打开调试日志所在文件夹"
 
-#: ../wxui/memedit.py:993
+#: ../wxui/memedit.py:996
 msgid "Show extra fields"
 msgstr "显示更多其他内容"
 
@@ -2716,37 +2716,41 @@ msgstr "显示更多其他内容"
 msgid "Show image backup location"
 msgstr "打开镜像备份所在文件夹"
 
-#: ../wxui/memedit.py:2153
+#: ../wxui/memedit.py:615
+msgid "Skip"
+msgstr "跳过"
+
+#: ../wxui/memedit.py:2156
 msgid "Some memories are incompatible with this radio"
 msgstr "某些内容与此电台不兼容"
 
-#: ../wxui/memedit.py:2000
+#: ../wxui/memedit.py:2003
 msgid "Some memories are not deletable"
 msgstr "某些内容不可被删除"
 
-#: ../wxui/memedit.py:1840
+#: ../wxui/memedit.py:1843
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "将 %i 个存储排序"
 
-#: ../wxui/memedit.py:1844
+#: ../wxui/memedit.py:1847
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "将 %i 个存储升序排列"
 
-#: ../wxui/memedit.py:1866
+#: ../wxui/memedit.py:1869
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "将 %i 个存储降序排列"
 
-#: ../wxui/memedit.py:1732
+#: ../wxui/memedit.py:1735
 msgid "Sort by column:"
 msgstr "排序列："
 
-#: ../wxui/memedit.py:1731
+#: ../wxui/memedit.py:1734
 msgid "Sort memories"
 msgstr "排序存储"
 
@@ -2836,7 +2840,7 @@ msgstr "将提交以下信息："
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "导入存储的推荐方法是打开源文件，然后将存储从源文件复制/粘贴到目标镜像中。如果继续使用此导入功能，CHIRP 将使用 %(file)s 中的存储替换当前打开文件中的所有存储。您想要打开此文件以复制/粘贴记忆，还是继续导入？"
 
-#: ../wxui/memedit.py:1801
+#: ../wxui/memedit.py:1804
 msgid "This Memory"
 msgstr "该内容"
 
@@ -2899,11 +2903,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr "这是 chirpmyradio.com 网站上已创建问题的票号"
 
-#: ../wxui/memedit.py:1805
+#: ../wxui/memedit.py:1808
 msgid "This memory and shift all up"
 msgstr "此存储并上移所有"
 
-#: ../wxui/memedit.py:1803
+#: ../wxui/memedit.py:1806
 msgid "This memory and shift block up"
 msgstr "此存储并上移区块"
 
@@ -2940,7 +2944,7 @@ msgstr "这将从网站 issue 中加载一个模块"
 msgid "Tone"
 msgstr "亚音频"
 
-#: ../wxui/memedit.py:1054
+#: ../wxui/memedit.py:1057
 msgid "Tone Mode"
 msgstr "亚音频制式"
 
@@ -2976,7 +2980,7 @@ msgstr "发射/接收调制方式（FM、AM、SSB 等）"
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr "TSQL 模式下的发射/接收亚音频，否则为接收亚音频"
 
-#: ../wxui/memedit.py:387 ../wxui/memedit.py:1068
+#: ../wxui/memedit.py:387 ../wxui/memedit.py:1071
 msgid "Tuning Step"
 msgstr "调谐间隔"
 
@@ -2993,7 +2997,7 @@ msgstr "USB 端口查找器"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "无法确定您的电缆端口。检查您的驱动程序和连接。"
 
-#: ../wxui/memedit.py:1530
+#: ../wxui/memedit.py:1533
 msgid "Unable to edit memory before radio is loaded"
 msgstr "无法在加载电台之前编辑存储器"
 
@@ -3002,7 +3006,7 @@ msgstr "无法在加载电台之前编辑存储器"
 msgid "Unable to find stock config %r"
 msgstr "无法找到预设配置 %r"
 
-#: ../wxui/memedit.py:2014
+#: ../wxui/memedit.py:2017
 msgid "Unable to import while the view is sorted"
 msgstr "无法在视图排序时导入"
 
@@ -3115,7 +3119,7 @@ msgstr "数值必须为零或更大"
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2399
+#: ../wxui/memedit.py:2402
 msgid "Values"
 msgstr "数值"
 
@@ -3131,11 +3135,11 @@ msgstr "查看"
 msgid "WARNING!"
 msgstr "警告！"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1616 ../wxui/main.py:1891
+#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1619 ../wxui/main.py:1891
 msgid "Warning"
 msgstr "警告"
 
-#: ../wxui/memedit.py:1615
+#: ../wxui/memedit.py:1618
 #, python-format
 msgid "Warning: %s"
 msgstr "警告：%s"
@@ -3590,9 +3594,6 @@ msgstr "{bank} 已满"
 
 #~ msgid "Show Information"
 #~ msgstr "显示信息"
-
-#~ msgid "Skip"
-#~ msgstr "跳过"
 
 #~ msgid "Smart Tone Modes"
 #~ msgstr "自动选择亚音频制式"

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -611,6 +611,9 @@ class ChirpCrossModeColumn(ChirpChoiceColumn):
 
 
 class ChirpSkipColumn(ChirpChoiceColumn):
+    # This is just here so it is marked for translation
+    __TITLE = _('Skip')
+
     @property
     def valid(self):
         return self._features.valid_skips


### PR DESCRIPTION
There are several strings we synthesize in the UI from internals that
are not marked for translation and thus do not make it into the POT
file. It turns out that the issue in bug #11209 is because of this:
adding the string directly to the translation file gets commented-out
by msgmerge if it thinks it's an old string no longer needed. Thus,
trying to get things like "Skip" translated by adding to the .po
file just got commented out on the next refresh.

Related to #11209
