### PR TITLE
Avoiding globals in kenwood_live.py

### DIFF
--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -85,7 +85,7 @@ def _connect_radio(radio):
     """Determine baud rate and verify radio on-line"""
     global BAUD
     xid = "D710" + radio.SHORT
-    resp = kenwood_live.get_id(radio.pipe)
+    resp = kenwood_live.KenwoodLiveRadio().get_id(radio.pipe)
     BAUD = radio.pipe.baudrate      # As detected by kenwood_live
     LOG.debug("Got [%s] at %i Baud." % (resp, BAUD))
     resp = resp[3:]     # Strip "ID " prefix

--- a/chirp/drivers/ts850.py
+++ b/chirp/drivers/ts850.py
@@ -16,8 +16,7 @@
 import logging
 
 from chirp import chirp_common, directory, errors
-from chirp.drivers.kenwood_live import KenwoodLiveRadio, \
-    command, iserr, NOCACHE
+from chirp.drivers.kenwood_live import KenwoodLiveRadio, iserr, NOCACHE
 
 LOG = logging.getLogger(__name__)
 
@@ -94,7 +93,7 @@ class TS850Radio(KenwoodLiveRadio):
         if number in self._memcache and not NOCACHE:
             return self._memcache[number]
 
-        result = command(self.pipe, *self._cmd_get_memory(number))
+        result = self.command(self.pipe, *self._cmd_get_memory(number))
 
         if result == "N":
             mem = chirp_common.Memory()
@@ -107,7 +106,7 @@ class TS850Radio(KenwoodLiveRadio):
         self._memcache[mem.number] = mem
 
         # check for split frequency operation
-        result = command(self.pipe, *self._cmd_get_split(number))
+        result = self.command(self.pipe, *self._cmd_get_split(number))
         self._parse_split_spec(mem, result)
 
         return mem
@@ -130,7 +129,8 @@ class TS850Radio(KenwoodLiveRadio):
         # Clear out memory contents to prevent errors
         spec = self._make_base_spec(memory, 0)
         spec = "".join(spec)
-        result = command(self.pipe, *self._cmd_set_memory(memory.number, spec))
+        result = self.command(self.pipe,
+                              *self._cmd_set_memory(memory.number, spec))
 
         if iserr(result):
             raise errors.InvalidDataError("Radio refused %i" %
@@ -139,15 +139,16 @@ class TS850Radio(KenwoodLiveRadio):
         # If we have a split set the transmit frequency first.
         if memory.duplex == TS850_DUPLEX[1]:
             spec = "".join(self._make_split_spec(memory))
-            result = command(self.pipe, *self._cmd_set_split(memory.number,
-                                                             spec))
+            result = self.command(self.pipe,
+                                  *self._cmd_set_split(memory.number, spec))
             if iserr(result):
                 raise errors.InvalidDataError("Radio refused %i" %
                                               memory.number)
 
         spec = self._make_mem_spec(memory)
         spec = "".join(spec)
-        result = command(self.pipe, *self._cmd_set_memory(memory.number, spec))
+        result = self.command(self.pipe,
+                              *self._cmd_set_memory(memory.number, spec))
         if iserr(result):
             raise errors.InvalidDataError("Radio refused %i" % memory.number)
 
@@ -155,7 +156,7 @@ class TS850Radio(KenwoodLiveRadio):
         if number not in self._memcache:
             return
 
-        resp = command(self.pipe, *self._cmd_erase_memory(number))
+        resp = self.command(self.pipe, *self._cmd_erase_memory(number))
         if iserr(resp):
             raise errors.RadioError("Radio refused delete of %i" % number)
 


### PR DESCRIPTION
Fixes: `TODO: This global use of LAST_DELIMITER breaks reentrancy` in chirp/drivers/kenwood_live.py.
Most of the needed refactoring is cosmetical.
I would say that a real test with a Kenwood TM-D710 is the only one that would be needed to cover a slightly different code path.

# CHIRP PR Guidelines

The following must be true before PRs can be merged:

1. All tests must be passing. The "PR Checks" job is speculative and failure doesn't always indicate a critial problem, but generally it needs to pass as well.
1. Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
1. Commits in a single PR should be related. Squash intermediate commits into logical units (i.e. "fix tests" commits need not survive on their own). Keep cleanup commits separate from functional changes.
1. Major new features or bug fixes should reference a [CHIRP issue](https://chirpmyradio.com/projects/chirp/issues) _in the commit message_. Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
1. Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc). The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
1. New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already). All new drivers must use `MemoryMapBytes`.
1. All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).
1. Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
