### PR TITLE
kenwood_live: Refresh memory after setting

### DIFF
--- a/chirp/drivers/kenwood_live.py
+++ b/chirp/drivers/kenwood_live.py
@@ -272,6 +272,7 @@ class KenwoodLiveRadio(chirp_common.LiveRadio):
 
         spec = self._make_mem_spec(memory)
         spec = ",".join(spec)
+        del self._memcache[memory.number]
         r1 = self.command(self.pipe,
                           *self._cmd_set_memory(memory.number, spec))
         if not iserr(r1) and self._has_name:
@@ -281,7 +282,6 @@ class KenwoodLiveRadio(chirp_common.LiveRadio):
                 *self._cmd_set_memory_name(memory.number, memory.name))
             if not iserr(r2):
                 memory.name = memory.name.rstrip()
-                self._memcache[memory.number] = memory.dupe()
             else:
                 raise errors.InvalidDataError("Radio refused name %i: %s" %
                                               (memory.number,


### PR DESCRIPTION
Found while testing something on a D74, our set-memory cache logic
is complicated by the radios that don't support alpha tags. Instead
of assuming success with both memory and name is the case where we
should cache the outgoing memory, invalidate the cache so we will
re-fetch the memory from the radio to confirm it is correct. This is
what we already do with erase_memory()
