### PR TITLE
Update UV-5GPlus model alias

### DIFF
--- a/chirp/share/model_alias_map.yaml
+++ b/chirp/share/model_alias_map.yaml
@@ -105,7 +105,7 @@ Baofeng/Pofung:
   model: P11UV
 - alt: Radioddity UV-5G
   model: UV-5G
-- alt: Baofeng GM-5RH
+- alt: Radioddity UV-5G Plus
   model: UV-5G Plus
 - alt: BF-F8HP
   model: UV-5R HTQ


### PR DESCRIPTION
This alias was added before the Radioddity UV-5G Plus was added as
a formal model in the code. Users seem confused, so point this one
at that model which looks more similar than the current alternative.
