### PR TITLE
Disable filtering on Linux

### DIFF
--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -751,10 +751,13 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
         self._default_cell_bg_color = self._grid.GetCellBackgroundColour(0, 0)
 
         sizer = wx.BoxSizer(wx.VERTICAL)
-        self._filter_query = memquery.SearchBox(self,
-                                                style=wx.TE_PROCESS_ENTER)
-        self._filter_query.Bind(wx.EVT_TEXT_ENTER, self._do_filter_query)
-        sizer.Add(self._filter_query, 0, wx.EXPAND | wx.ALL, border=5)
+        if sys.platform != 'linux':
+            # FIXME: This doesn't work properly on Linux/GTK because the help
+            # window takes over focus from everything and has to be force quit.
+            self._filter_query = memquery.SearchBox(self,
+                                                    style=wx.TE_PROCESS_ENTER)
+            self._filter_query.Bind(wx.EVT_TEXT_ENTER, self._do_filter_query)
+            sizer.Add(self._filter_query, 0, wx.EXPAND | wx.ALL, border=5)
         sizer.Add(self._grid, 1, wx.EXPAND)
         self.SetSizer(sizer)
 


### PR DESCRIPTION
On Linux/GTK the help window for the filter query box takes over total
control and focus from the parent app such that you can't even unfocus
it and must force quit. Disable for now.

Related to #11760
