### PR TITLE
Added alias UV-5R 8W Tripower

### DIFF
--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -2025,12 +2025,16 @@ class TDUV5RRadio(chirp_common.Alias):
     MODEL = "TD-UV5R TriPower"
 
 
+class UV5R8WTri(chirp_common.Alias):
+    VENDOR = "Baofeng"
+    MODEL = "UV-5R 8W TriPower"
+
 @directory.register
 class BaofengBFF8HPRadio(BaofengUV5R):
     VENDOR = "Baofeng"
     MODEL = "BF-F8HP"
     ALIASES = [RT5_TPAlias, ROGA5SAlias, UV5XPAlias, TSTIF8Alias,
-               TenwayUV5RPro, TSTST9Alias, TDUV5RRadio]
+               TenwayUV5RPro, TSTST9Alias, TDUV5RRadio, UV5R8WTri]
     _basetype = BASETYPE_F8HP
     _idents = [UV5R_MODEL_291,
                UV5R_MODEL_A58

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wxPython>=4.0,<4.2.0 ; platform_system=="Linux" # See https://github.com/wxWidgets/Phoenix/issues/2225
-wxPython==4.2.0 ; platform_system!="Linux"
+wxPython==4.2.2 ; platform_system!="Linux"
 pyserial
 requests
 pywin32; platform_system=="Windows"


### PR DESCRIPTION
`Related to #11763 ` Alias added to model BF-F8HP for UV-5R 8W Tripower as suggested by Baofeng Support.

This UV-5R model, 8 Watt version, Tripower matches with BF-F8HP as recommended by Baofeng Support to be used in Chirp.
I just added the alias to be shown in the models list.

