### PR TITLE
uv17pro: Fix exposing static banks on some models

### DIFF
--- a/chirp/drivers/baofeng_uv17.py
+++ b/chirp/drivers/baofeng_uv17.py
@@ -492,14 +492,6 @@ class UV17(baofeng_uv17Pro.UV17Pro):
 
         self.set_memory_common(mem, _mem)
 
-    def get_features(self):
-        rf = super().get_features()
-        rf.has_bank = False
-        return rf
-
-    def get_mapping_models(self):
-        return []
-
 
 @directory.register
 class UV13Pro(UV17):

--- a/chirp/drivers/baofeng_uv17Pro.py
+++ b/chirp/drivers/baofeng_uv17Pro.py
@@ -1139,15 +1139,12 @@ class UV17Pro(bfc.BaofengCommonHT):
             raise errors.RadioError('Unexpected error communicating '
                                     'with the radio')
 
-    def get_bank_model(self):
-        return chirp_common.StaticBankModel(self, banks=10)
-
     def get_features(self):
         """Get the radio's features"""
 
         rf = chirp_common.RadioFeatures()
         rf.has_settings = True
-        rf.has_bank = True
+        rf.has_bank = False
         rf.has_tuning_step = False
         rf.can_odd_split = True
         rf.has_name = True
@@ -1415,6 +1412,14 @@ class UV17ProGPS(UV17Pro):
                    UV17Pro._uhf_range, UV17Pro._uhf2_range]
     MODES = UV17Pro.MODES + ['AM']
 
+    def get_bank_model(self):
+        return chirp_common.StaticBankModel(self, banks=10)
+
+    def get_features(self):
+        rf = super().get_features()
+        rf.has_bank = True
+        return rf
+
 
 @directory.register
 class BF5RM(UV17Pro):
@@ -1610,6 +1615,14 @@ class F8HPPro(UV17Pro):
                               False, CHARSET_GB2312))
         rs.set_apply_callback(apply_stationid, _nameobj)
         basic.append(rs)
+
+    def get_bank_model(self):
+        return chirp_common.StaticBankModel(self, banks=10)
+
+    def get_features(self):
+        rf = super().get_features()
+        rf.has_bank = True
+        return rf
 
 
 @directory.register


### PR DESCRIPTION
Previously in commit:5d295a8b we added a static bank model to show
the static mappings between memories and "banks" in these radios.
However, only some of the more advanced models have this functionality,
not all the radios that inherit from UV17Pro. This fixes that to only
apply this model to the UV17ProGPS and BF-F8HP-PRO models.

Further, in commit:d1f8504e we fixed the bug where the UV17 models
inherited this behavior to disable it for them. Those overrides are
no longer necessary, so this removes them.

Related to #11642
