### PR TITLE
Fix memory dragging off-by-N rows issue

### DIFF
--- a/chirp/drivers/tk280.py
+++ b/chirp/drivers/tk280.py
@@ -1200,11 +1200,11 @@ class KenwoodTKx80(chirp_common.CloneModeRadio):
                                   current_index=int(sett.signalling_type)))
         optfeat1.append(sigtyp)
 
-        if self.TYPE[0] == "P":
+        if self.TYPE[0:1] == b"P":
             bsav = MemSetting(
                 "settings.battery_save", "Battery Save",
-                RadioSettingValueList(BSAVE.values(),
-                                      current_index=sett.battery_save))
+                RadioSettingValueMap([(v, k) for k, v in BSAVE.items()],
+                                     sett.battery_save))
             optfeat1.append(bsav)
 
         tot = MemSetting("settings.tot", "Time Out Timer (TOT)",

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -674,6 +674,7 @@ class ChirpMemoryDropTarget(wx.DropTarget):
         payload = self.parse_data()
         x, y = self._memedit._grid.CalcUnscrolledPosition(x, y)
         y -= self._memedit._grid.GetColLabelSize()
+        y -= self._memedit._grid.GetPosition()[1]
         row, cell = self._memedit._grid.XYToCell(x, y)
         start_row = self._memedit.mem2row(payload['mems'][0].number)
         if row < 0 or row == start_row:
@@ -703,6 +704,7 @@ class ChirpMemoryDropTarget(wx.DropTarget):
 
         x, y = self._memedit._grid.CalcUnscrolledPosition(x, y)
         y -= self._memedit._grid.GetColLabelSize()
+        y -= self._memedit._grid.GetPosition()[1]
         row, cell = self._memedit._grid.XYToCell(x, y)
         max_row = self._memedit._grid.GetNumberRows()
         if row >= 0:


### PR DESCRIPTION
Since the introduction of the filter query field, the memory dragging
function has been off by a few rows when dropped. This is due to
improperly calculating the position of the memory editor in the
window, which this patch corrects.
