### PR TITLE
More tk280 tk3180 updates

### DIFF
--- a/chirp/drivers/tk280.py
+++ b/chirp/drivers/tk280.py
@@ -1130,6 +1130,17 @@ class KenwoodTKx80(chirp_common.CloneModeRadio):
             return ''
 
     def _get_settings_ost(self, ost):
+        rs = MemSetting('settings.ost_backup', 'OST Backup',
+                        RadioSettingValueInvertedBoolean(
+                            not self._memobj.settings.ost_backup))
+        rs.set_doc('Store OST on channel even if dialed away')
+        ost.append(rs)
+
+        rs = MemSetting('settings.ost_direct', 'OST Direct',
+                        RadioSettingValueInvertedBoolean(
+                            not self._memobj.settings.ost_direct))
+        ost.append(rs)
+
         def apply_ost(setting, index, which):
             try:
                 mode, val, pol = self._parse_qtdqt(str(setting.value))

--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -203,9 +203,14 @@ class RadioSettingValueFloat(RadioSettingValue):
 
 class RadioSettingValueBoolean(RadioSettingValue):
 
-    """A boolean setting"""
+    """A boolean setting
 
-    def __init__(self, current):
+    If using MemSetting, mem_vals can be set to the False, True values
+    that are to be actually stored in memory instead of 0, 1
+    """
+
+    def __init__(self, current, mem_vals=(0, 1)):
+        self._mem_vals = mem_vals
         RadioSettingValue.__init__(self)
         self.queue_current(current)
 
@@ -730,6 +735,12 @@ class MemSetting(RadioSetting):
                                              self.value.mem_pad_char)
         else:
             value = self.value
+
+        # After we determined if this is inverted or not, convert to the values
+        # that memory wants to see.
+        if isinstance(self.value, RadioSettingValueBoolean):
+            value = self.value._mem_vals[int(value)]
+
         obj = memobj
         elements = self._path.split('.')
         for element in elements[:-1]:

--- a/chirp/wxui/clone.py
+++ b/chirp/wxui/clone.py
@@ -411,6 +411,8 @@ class ChirpCloneDialog(wx.Dialog):
         filter_ports = [
             # MacOS unpaired bluetooth serial
             '/dev/cu.Bluetooth-Incoming-Port',
+            '/dev/cu.debug-console',
+            '/dev/cu.wlan-debug',
         ]
 
         LOG.debug('All system ports: %s', [x.__dict__ for x in system_ports])

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1134,6 +1134,11 @@ class ChirpMain(wx.Frame):
         label = wx.StaticText(d, label=_('Select a tab and memory to diff'),
                               style=wx.ALIGN_CENTER_HORIZONTAL)
         tab = wx.Choice(d, choices=list(tabs.keys()))
+        try:
+            tab.SetStringSelection(self._last_diff_tab)
+        except AttributeError:
+            # No last default
+            pass
         memory = wx.SpinCtrl(d)
         memory.SetMin(0)
         memory.SetMax(2000)
@@ -1146,6 +1151,7 @@ class ChirpMain(wx.Frame):
         vbox.Add(buttons, proportion=0, flag=wx.EXPAND)
         d.CenterOnParent()
         c = d.ShowModal()
+        self._last_diff_tab = tab.GetStringSelection()
         if c == wx.ID_OK:
             mem_a = event.GetEventObject()._radio.get_raw_memory(event.memory)
             editor = tabs[tab.GetStringSelection()]


### PR DESCRIPTION
- **tk280: Add OST backup and direct settings**
- **tk8180: Fix loading settings with multiple zones**
- **Remember last tab for cross-tab raw diff**
- **Allow RSVBoolean to record different mem values**
- **tk8180: Add battery save, warning, pttid settings**
- **tk8180: Support key assignments**
- **Hide more not-a-radio ports on macos**
