### PR TITLE
icf520.py: Clarify display inhibit and tx inhibit

### DIFF
--- a/chirp/drivers/icf520.py
+++ b/chirp/drivers/icf520.py
@@ -687,6 +687,7 @@ class ICF621_2Radio(icf.IcomCloneModeRadio):
         rf.valid_modes = list(MODES)
         rf.has_offset = True
         rf.has_tuning_step = False
+        rf.valid_tuning_steps = chirp_common.TUNING_STEPS
         rf.valid_duplexes = list(DUPLEX)
         rf.valid_bands = list(self._valid_bands)
         rf.can_odd_split = True


### PR DESCRIPTION
For the user:
Display inhibit column name changed from "Inhibit" to "Mask", useful doc string was added, and enable choice changed from "Inhibit" to "Yes".

For the developer:
Variable "inhibit" changed to "disp_inhibit".  Similar changes to related variables.

Variable "inhibit_tx" changed to "tx_inhibit" to be consistent with "disp_inhibit" and "compander_inhibit".

Comment about using 0 MHz as an unused memory changed to reflect these changes.