### PR TITLE
Fix: windows wx requirements and remove of last __future__

### DIFF
--- a/chirp/drivers/uvb5.py
+++ b/chirp/drivers/uvb5.py
@@ -13,8 +13,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from __future__ import division
-
 import struct
 import logging
 from chirp import chirp_common, directory, bitwise, memmap, errors, util

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wxPython>=4.0,<4.2.0 ; platform_system=="Linux" # See https://github.com/wxWidgets/Phoenix/issues/2225
-wxPython==4.2.0 ; platform_system!="Linux"
+wxPython>=4.2.0 ; platform_system!="Linux"
 pyserial
 requests
 pywin32; platform_system=="Windows"


### PR DESCRIPTION
With these changes you can install chirp on windows in python3.13

also removes last import of __future__.