### PR TITLE
Fix TK-x81 redelete

### DIFF
--- a/chirp/drivers/tk481.py
+++ b/chirp/drivers/tk481.py
@@ -287,6 +287,9 @@ class TKx80_Trunked(tk280.KenwoodTKx80):
         except IndexError:
             system = self._parent._expand_system(self._system)
             _mem = system.channels[system.sys.channels - 1]
+            # Immediately set the channel number on the new memory in case
+            # fail to do anything below (or delete it immediately)
+            _mem.number = mem.number
 
         if mem.empty:
             self._parent._reduce_system(self._system, mem.number)

--- a/chirp/drivers/tk481.py
+++ b/chirp/drivers/tk481.py
@@ -247,7 +247,7 @@ class TKx80_Trunked(tk280.KenwoodTKx80):
                 self, TKx80System, i,
                 to_copy,
                 VARIANT=str(getattr(self._memobj,
-                                    'system%i' % i).sys.name).strip())(
+                                    'system%i' % i).sys.name).strip(' \xFF'))(
                     self, i + 1)
             for i in range(32)
             if self._memobj.trunk.sys_start[i] != 0xFFFF]
@@ -335,12 +335,13 @@ class TKx80_Trunked(tk280.KenwoodTKx80):
             rsg.append(rse)
             if rse.value:
                 _, _, system = self._get_system_info(i)
-                name = str(system.sys.name)
+                name = str(system.sys.name).strip()
             else:
                 name = ''
 
             rs = RadioSetting('system-%i-name' % i, 'Name',
-                              RadioSettingValueString(0, 10, name))
+                              RadioSettingValueString(
+                                  0, 10, name.strip(' \xFF')))
             rs.value.set_mutable(bool(rse.value))
             rsg.append(rs)
 

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -2277,7 +2277,9 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
                     _('Some memories are not deletable'))
             with self.undo_context(_('Cut %i memories') % len(mems)):
                 for mem in mems:
-                    self.erase_memory(mem.number)
+                    # No need to delete empty memories
+                    if not mem.empty:
+                        self.erase_memory(mem.number)
 
         if cut:
             wx.PostEvent(self, common.EditorChanged(self.GetId()))
@@ -2387,7 +2389,11 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
             mem.immutable = immutable
             row += 1
             try:
-                if mem.empty:
+                if mem.empty and existing.empty:
+                    # No need to delete this
+                    LOG.debug('Skipping re-deleting empty memory %i',
+                              existing.number)
+                elif mem.empty:
                     self.erase_memory(mem.number)
                     self._radio.check_set_memory_immutable_policy(existing,
                                                                   mem)

--- a/tests/test_edges.py
+++ b/tests/test_edges.py
@@ -107,6 +107,22 @@ class TestCaseEdges(base.DriverTest):
                                 'to delete location %i' % loc)
                 break
 
+    def test_redelete_memory(self):
+        m = self.get_mem()
+        if 'empty' in m.immutable:
+            self.skipTest('Test memory is not deletable')
+
+        # Delete this memory
+        m.empty = True
+        self.radio.set_memory(m)
+
+        # Try to delete it again
+        self.radio.set_memory(m)
+
+        # Make sure it appears deleted
+        m2 = self.radio.get_memory(m.number)
+        self.assertTrue(m2.empty)
+
     def test_get_set_specials(self):
         if not self.rf.valid_special_chans:
             self.skipTest('Radio has no specials')


### PR DESCRIPTION
- **tk481: Properly strip non-space padding**
- **tk481: Fix re-deleting memory corrupting data structures**
- **Make UI avoid re-deleting memories for cut/paste**
