### PR TITLE
update requirements.txt no issue wxPython on Linux 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-wxPython>=4.0,<4.2.0 ; platform_system=="Linux" # See https://github.com/wxWidgets/Phoenix/issues/2225
-wxPython==4.2.0 ; platform_system!="Linux"
+wxPython
 pyserial
 requests
 pywin32; platform_system=="Windows"


### PR DESCRIPTION
there is no need to separate package versions between linux and windows anymore 
Issue https://github.com/wxWidgets/Phoenix/issues/2225 is closed now
**wxPython** in version **4.2.2** works fine on linux
I suggest you go back to the latest version of wxPython