### PR TITLE
Try to parse TSV lines from a paste

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -523,7 +523,7 @@ class Memory:
         self.name = vals[1]
 
         try:
-            self.freq = float(vals[2])
+            self.freq = to_MHz(float(vals[2]))
         except Exception:
             raise errors.InvalidDataError("Frequency is not a valid number")
 
@@ -533,7 +533,7 @@ class Memory:
             raise errors.InvalidDataError("Duplex is not +,-, or empty")
 
         try:
-            self.offset = float(vals[4])
+            self.offset = to_MHz(float(vals[4]))
         except Exception:
             raise errors.InvalidDataError("Offset is not a valid number")
 
@@ -563,30 +563,32 @@ class Memory:
         if self.dtcs not in DTCS_CODES:
             raise errors.InvalidDataError("DTCS code is not valid")
 
-        try:
-            self.rx_dtcs = int(vals[8], 10)
-        except Exception:
-            raise errors.InvalidDataError("DTCS Rx code is not a valid number")
-        if self.rx_dtcs not in DTCS_CODES:
-            raise errors.InvalidDataError("DTCS Rx code is not valid")
-
         if vals[9] in ["NN", "NR", "RN", "RR"]:
             self.dtcs_polarity = vals[9]
         else:
             raise errors.InvalidDataError("DtcsPolarity is not valid")
 
-        if vals[10] in MODES:
-            self.mode = vals[10]
+        try:
+            self.rx_dtcs = int(vals[10], 10)
+        except Exception:
+            raise errors.InvalidDataError("DTCS Rx code is not a valid number")
+        if self.rx_dtcs not in DTCS_CODES:
+            raise errors.InvalidDataError("DTCS Rx code is not valid")
+
+        self.cross_mode = vals[11]
+
+        if vals[12] in MODES:
+            self.mode = vals[12]
         else:
-            raise errors.InvalidDataError("Mode is not valid")
+            raise errors.InvalidDataError("Mode %r is not valid" % vals[10])
 
         try:
-            self.tuning_step = float(vals[11])
+            self.tuning_step = float(vals[13])
         except Exception:
             raise errors.InvalidDataError("Tuning step is invalid")
 
         try:
-            self.skip = vals[12]
+            self.skip = vals[14]
         except Exception:
             raise errors.InvalidDataError("Skip value is not valid")
 
@@ -2079,7 +2081,23 @@ def urlretrieve(url, fn):
         f.write(resp.read())
 
 
+def mem_from_tsv(tsv_text):
+    fields = tsv_text.split('\t')
+    if len(fields) < 13:
+        raise ValueError('Not enough fields to be a memory')
+    mem = Memory()
+    mem.really_from_csv(fields)
+    print('Parsed %s from tsv' % mem)
+    return mem
+
+
 def mem_from_text(text):
+    if text.count('\t') > 10:
+        # Seems like plausible TSV, return if it parses
+        try:
+            return mem_from_tsv(text)
+        except Exception:
+            pass
     m = Memory()
     freqs = re.findall(r'\b(\d{1,3}\.\d{2,6})\b', text)
     if not freqs:

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -2456,19 +2456,21 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
             self._cb_paste_memories(payload)
         elif wx.DF_UNICODETEXT in data.GetAllFormats():
             try:
-                mem = chirp_common.mem_from_text(
-                    data.GetText())
+                mems = [chirp_common.mem_from_text(line)
+                        for line in data.GetText().split('\n')
+                        if line.strip()]
             except Exception as e:
                 LOG.warning('Failed to parse pasted data %r: %s' % (
                     data.GetText(), e))
                 return
             # Since matching the offset is kinda iffy, set our band plan
             # set the offset, if a rule exists.
-            if mem.duplex in ('-', '+'):
-                self._set_memory_defaults(mem, 'offset')
+            for mem in mems:
+                if mem.duplex in ('-', '+'):
+                    self._set_memory_defaults(mem, 'offset')
             LOG.debug('Generic text paste %r: %s' % (
-                data.GetText(), mem))
-            self._cb_paste_memories({'mems': [mem],
+                data.GetText(), mems))
+            self._cb_paste_memories({'mems': mems,
                                      'features': self._features})
         else:
             LOG.warning('Unknown data format %s paste' % (

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -78,6 +78,11 @@ class TestUtilityFunctions(base.BaseTest):
         self.assertEqual(140, chirp_common.from_MHz(14000001))
         self.assertEqual(140, chirp_common.from_kHz(14001))
 
+    def test_mem_to_from_csv(self):
+        mem1 = chirp_common.Memory()
+        mem2 = chirp_common.Memory._from_csv(','.join(mem1.to_csv()))
+        self.assertEqual(str(mem1), str(mem2))
+
     def test_mem_from_text_rb1(self):
         text = '145.2500 	-0.6 MHz 	97.4 	OPEN'
         mem = chirp_common.mem_from_text(text)
@@ -226,6 +231,24 @@ class TestUtilityFunctions(base.BaseTest):
         self.assertEqual(450000000, mem.freq)
         self.assertEqual(150000000, mem.offset)
         self.assertEqual('split', mem.duplex)
+
+    def test_mem_from_text_tsv(self):
+        from_lo = """8	Mt Scott	147.28	+	0.6	TSQL	88.5	167.9	23	NN	23	Tone->Tone	FM	5		50W	TayDan Emergency Step #2
+9	Mt Tabor	145.39	-	0.6	TSQL	88.5	100	23	NN	23	Tone->Tone	FM	5		50W	TayDan Emergency Step #1
+10	Timberline V	147.12	+	0.6	TSQL	103.5	100	23	NN	23	Tone->Tone	FM	5		50W	TayDan Emergency Step #4
+11	Timberline U	444.225	+	5	TSQL	88.5	100	23	NN	23	Tone->Tone	FM	5		50W	K7RPT Timberline, Linked to VHF side, AC7QE-R echolink
+12	GovtCamp	443.875	+	5	TSQL	88.5	103.5	23	NN	23	Tone->Tone	FM	5		50W"""  # noqa
+
+        lines = from_lo.split('\n')
+        mem = chirp_common.mem_from_text(lines[0])
+        self.assertEqual('Mt Scott', mem.name)
+        self.assertEqual('TSQL', mem.tmode)
+        self.assertEqual('+', mem.duplex)
+        self.assertEqual(600000, mem.offset)
+        self.assertEqual(147280000, mem.freq)
+        self.assertEqual(8, mem.number)
+        for line in from_lo.split('\n'):
+            chirp_common.mem_from_text(line)
 
     def test_mem_to_text1(self):
         mem = chirp_common.Memory()


### PR DESCRIPTION
Some spreadsheets put cells on the clipboard as unformatted TSV lines.
If these are *exactly* our CSV format, but in TSV, then try to
consume them, but fail quietly. Also support multiple lines from a
plaintext paste.
