### PR TITLE
Update MURS stock config with power levels

### DIFF
--- a/chirp/stock_configs/US MURS Channels.csv
+++ b/chirp/stock_configs/US MURS Channels.csv
@@ -1,6 +1,6 @@
-Location,Name,Frequency,Duplex,Offset,Tone,rToneFreq,cToneFreq,DtcsCode,DtcsPolarity,Mode,TStep,Skip,Comment,URCALL,RPT1CALL,RPT2CALL
-1,MURS 1,151.820000,,0.000000,,88.5,88.5,023,NN,NFM,5.00,,,,,
-2,MURS 2,151.880000,,0.000000,,88.5,88.5,023,NN,NFM,5.00,,,,,
-3,MURS 3,151.940000,,0.000000,,88.5,88.5,023,NN,NFM,5.00,,,,,
-4,Blue Dot,154.570000,,0.000000,,88.5,88.5,023,NN,FM,5.00,,,,,
-5,Green Dot,154.600000,,0.000000,,88.5,88.5,023,NN,FM,5.00,,,,,
+Location,Name,Frequency,Duplex,Offset,Tone,rToneFreq,cToneFreq,DtcsCode,DtcsPolarity,RxDtcsCode,CrossMode,Mode,TStep,Skip,Power,Comment,URCALL,RPT1CALL,RPT2CALL,DVCODE
+1,MURS 1,151.820000,,0.000000,,88.5,88.5,023,NN,023,Tone->Tone,NFM,5.00,,2.0W,,,,,
+2,MURS 2,151.880000,,0.000000,,88.5,88.5,023,NN,023,Tone->Tone,NFM,5.00,,2.0W,,,,,
+3,MURS 3,151.940000,,0.000000,,88.5,88.5,023,NN,023,Tone->Tone,NFM,5.00,,2.0W,,,,,
+4,Blue Dot,154.570000,,0.000000,,88.5,88.5,023,NN,023,Tone->Tone,FM,5.00,,2.0W,,,,,
+5,Green Dot,154.600000,,0.000000,,88.5,88.5,023,NN,023,Tone->Tone,FM,5.00,,2.0W,,,,,


### PR DESCRIPTION
This has existed in CHIRP since before we had power levels in CSV.
Now they appear to all default at 50W which is not correct.

Fixes #11861
