### PR TITLE
Fix repeaterbook query loading

### DIFF
--- a/chirp/wxui/config.py
+++ b/chirp/wxui/config.py
@@ -195,5 +195,15 @@ def get_for_radio(radio):
         rclass = radio
     else:
         rclass = radio.__class__
-    registered_id = directory.registered_class(rclass)
+    try:
+        registered_id = directory.registered_class(rclass)
+    except KeyError:
+        # Network sources and any other special cases where a radio is not
+        # registered. Try to get a driver id if possible, otherwise combine
+        # into a single config blob
+        try:
+            registered_id = directory.radio_class_id(rclass)
+        except Exception:
+            LOG.warning('Unable to get radio-specific config for %s', rclass)
+            registered_id = 'other'
     return get(section='radio_%s' % registered_id)

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -2034,6 +2034,7 @@ GNU General Public License for more details."""
             for shortname, name in plans:
                 CONF.set_bool(shortname, shortname == selected, 'bandplan')
 
+    @common.error_proof()
     def _do_network_query(self, query_cls):
         self.enable_bugreport()
         d = query_cls(self, title=_('Query %s') % query_cls.NAME)


### PR DESCRIPTION
This fixes the config.get_for_radio() failure when loading non-
registered radios, like NetworkSource children.

Fixes: #11863
