### PR TITLE
Remove TH-350 from the unsupported list

### DIFF
--- a/tests/py3-untested-drivers.txt
+++ b/tests/py3-untested-drivers.txt
@@ -36,7 +36,6 @@ Kenwood_TS-850
 Puxing_PX-2R
 RT_Systems_CSV
 Sainsonic_AP510
-TYT_TH-350
 TYT_TH-7800_File
 TYT_TH-9800_File
 TYT_TH-UV3R


### PR DESCRIPTION
This was supposed to be removed but it wasn't. Working for cloning
based on #11881.
