### PR TITLE
Fix GMRS negative offset in band plan

### DIFF
--- a/chirp/bandplan.py
+++ b/chirp/bandplan.py
@@ -69,7 +69,7 @@ class Band(object):
             return self
         limits = (self.limits[0] + self.offset, self.limits[1] + self.offset)
         offset = -1 * self.offset
-        if self.duplex in '+-':
+        if self.duplex and self.duplex in '+-':
             duplex = '+' if self.duplex == '-' else '-'
             return Band(limits, self.name, self.mode, self.step_khz,
                         input_offset=offset, tones=self.tones, duplex=duplex)

--- a/chirp/drivers/tdh8.py
+++ b/chirp/drivers/tdh8.py
@@ -2641,7 +2641,7 @@ class TDH8_GMRS(TDH8):
         if 31 <= mem.number <= 54:
             if mem.freq not in GMRS_FREQS:
                 msgs.append(chirp_common.ValidationError(
-                    "The frequency in channels 31-54 must be between"
+                    "The frequency in channels 31-54 must be between "
                     "462.55000-462.72500 in 0.025 increments."))
             if mem.duplex not in ('', '+', 'off') or (
                     mem.duplex == '+' and mem.offset != 5000000):


### PR DESCRIPTION
A bug in the bandplan module would reverse the non-duplex GMRS band
to have some -5MHz channels which are not right and should not be
suggested to the user.

Also fix an error message missing a space in the TDH3, which is the
radio that was affected by this bug (probably the only one).

Related to bug #11396
