### PR TITLE
kg816/818: Fix query string processing

### DIFF
--- a/chirp/drivers/wouxun.py
+++ b/chirp/drivers/wouxun.py
@@ -60,7 +60,7 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
     MODEL = "KG-UVD1P"
     _model = b"KG669V"
 
-    _querymodel = (b"HiWOUXUN\x02", b"PROGUV6X\x02")
+    _querymodels = (b"HiWOUXUN\x02", b"PROGUV6X\x02")
 
     CHARSET = list("0123456789") + \
         [chr(x + ord("A")) for x in range(0, 26)] + list("?+-")
@@ -227,22 +227,11 @@ class KGUVD1PRadio(chirp_common.CloneModeRadio,
             "6. Click OK to upload image to device.\n")
         return rp
 
-    @classmethod
-    def _get_querymodel(cls):
-        if isinstance(cls._querymodel, str):
-            while True:
-                yield cls._querymodel
-        else:
-            i = 0
-            while True:
-                yield cls._querymodel[i % len(cls._querymodel)]
-                i += 1
-
     def _identify(self):
         """Do the original Wouxun identification dance"""
-        query = self._get_querymodel()
         for _i in range(0, 10):
-            self.pipe.write(next(query))
+            model = self._querymodels[_i % len(self._querymodels)]
+            self.pipe.write(model)
             resp = self.pipe.read(9)
             if len(resp) != 9:
                 LOG.debug("Got:\n%s" % util.hexprint(resp))
@@ -909,7 +898,7 @@ class KGUV6DRadio(KGUVD1PRadio):
     """Wouxun KG-UV6 (D and X variants)"""
     MODEL = "KG-UV6"
 
-    _querymodel = (b"HiWXUVD1\x02", b"HiKGUVD1\x02")
+    _querymodels = (b"HiWXUVD1\x02", b"HiKGUVD1\x02")
 
     _MEM_FORMAT = """
         #seekto 0x0010;
@@ -1436,7 +1425,7 @@ class KG816Radio(KGUVD1PRadio, chirp_common.ExperimentalRadio):
     """Wouxun KG-816"""
     MODEL = "KG-816"
 
-    _querymodel = b"HiWOUXUN\x02"
+    _querymodels = (b"HiWOUXUN\x02", )
 
     _MEM_FORMAT = """
         #seekto 0x0010;


### PR DESCRIPTION
Sometime between legacy and now, the strings in wouxun.py were changed to bytes. Most radios in this file define a tuple of bytes to be sent to the radio....if one doesn't work, the next one is tried. For the 816/818, only one `bytes` object is defined. The code that processes this checked if the input was a `str`. It failed on a `bytes` object and started processing the input as an iterable.

Related to #11208

This is why the person in issue 11208 got an error reading their radio, even though chirp doesn't directly support it. Several users in several forums suggest using the 816 driver to program the 805 at their own 
risk.