### PR TITLE
tk8180: Fix 12.5kHz-required step frequencies

### DIFF
--- a/chirp/drivers/tk8180.py
+++ b/chirp/drivers/tk8180.py
@@ -1003,7 +1003,8 @@ class KenwoodTKx180Radio(chirp_common.CloneModeRadio):
         step_lookup = {
             2.5: 0x1,
             6.25: 0x3,
-            12.5: 0x3,
+            12.5: 0x6,
+            10.0: 0x5,
             5: 0x2,
         }
         # Default to 5kHz if we don't know any better


### PR DESCRIPTION
Previously it was not clear there was a difference between 6.25kHz and
12.5kHz step frequencies in this radio, but there is when it matters.
