### PR TITLE
ic9700: Decode cross tone modes

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -1770,91 +1770,65 @@ def make_is(stephz):
     return validator
 
 
-def required_step(freq, allowed=None, max=False):
+def required_step(freq, allowed=None):
     """Returns the simplest tuning step that is required to reach @freq"""
     if allowed is None:
-        allowed = [5.0, 10.0, 12.5, 6.25, 2.5, 8.33]
+        allowed = [5.0, 10.0, 12.5, 6.25, 2.5, 1.0, 0.5, 8.33, 0.25]
 
-    # These should be in order of most common to least common
-    steps = {
-        5.0: make_is(5000),
-        10.0: make_is(10000),
-        12.5: make_is(12500),
-        6.25: make_is(6250),
-        2.5: make_is(2500),
-        1.0: make_is(1000),
-        0.5: make_is(500),
-        0.25: make_is(250),
-        8.33: is_8_33,
-    }
-
-    if max:
-        steps = {k: steps[k] for k in reversed(sorted(steps.keys()))}
-
-    # Try the above "standard" steps first in order
-    required_step = None
-    for step, validate in steps.items():
-        if step in allowed and validate(freq):
-            return step
-        elif validate(freq) and required_step is None:
-            required_step = step
-
-    # Try any additional steps in the allowed list
+    special = {8.33: is_8_33}
     for step in allowed:
-        if step in steps:
-            # Already tried
-            continue
-        if make_is(int(step * 1000))(freq):
-            LOG.debug('Chose non-standard step %s for %s' % (
-                step, format_freq(freq)))
+        if step in special:
+            validate = special[step]
+        else:
+            validate = make_is(int(step * 1000))
+        if validate(freq):
+            LOG.debug('Chose step %s for %s' % (step, format_freq(freq)))
             return step
 
-    if required_step is not None:
-        raise errors.InvalidDataError((
-            'Frequency %s requires step %.2f, '
-            'which is not supported') % (
-                format_freq(freq), required_step))
-    else:
-        raise errors.InvalidDataError("Unable to find a supported " +
-                                      "tuning step for %s" % format_freq(freq))
+    raise errors.InvalidDataError("Unable to find a supported " +
+                                  "tuning step for %s" % format_freq(freq))
 
 
 def fix_rounded_step(freq):
     """Some radios imply the last bit of 12.5 kHz and 6.25 kHz step
     frequencies. Take the base @freq and return the corrected one"""
-    try:
-        required_step(freq)
-        return freq
-    except errors.InvalidDataError:
-        pass
+    allowed = [12.5, 6.25]
 
     try:
-        required_step(freq + 500)
+        required_step(freq + 500, allowed=allowed)
         return freq + 500
     except errors.InvalidDataError:
         pass
 
     try:
-        required_step(freq + 250)
+        required_step(freq + 250, allowed=allowed)
         return freq + 250
     except errors.InvalidDataError:
         pass
 
     try:
-        required_step(freq + 750)
+        required_step(freq + 750, allowed=allowed)
         return float(freq + 750)
     except errors.InvalidDataError:
         pass
 
     try:
-        required_step(freq + 330)
+        required_step(freq + 330, allowed=allowed)
         return float(freq + 330)
     except errors.InvalidDataError:
         pass
 
     try:
-        required_step(freq + 660)
+        required_step(freq + 660, allowed=allowed)
         return float(freq + 660)
+    except errors.InvalidDataError:
+        pass
+
+    # These radios can all resolve 5kHz, so make sure what we are left with
+    # is 5kHz-aligned, else we refuse below.
+    try:
+        required_step(freq, allowed=[5.0])
+        return freq
     except errors.InvalidDataError:
         pass
 

--- a/chirp/directory.py
+++ b/chirp/directory.py
@@ -64,7 +64,6 @@ def enable_reregistrations():
 
 def register(cls):
     """Register radio @cls with the directory"""
-    global DRV_TO_RADIO
     ident = radio_class_id(cls)
     if ident in list(DRV_TO_RADIO.keys()):
         if ALLOW_DUPS:

--- a/chirp/drivers/tk280.py
+++ b/chirp/drivers/tk280.py
@@ -1653,20 +1653,20 @@ class KenwoodTKx80(chirp_common.CloneModeRadio):
             _mem.txfreq = mem.freq // self._freqmult
 
         step_lookup = {
-            2.5: 0x0,
-            6.25: 0x2,
             12.5: 0x5,
+            6.25: 0x2,
             5.0: 0x1,
+            2.5: 0x0,
         }
         try:
             _mem.rx_step = step_lookup[chirp_common.required_step(
-                int(_mem.rxfreq) * 10)]
+                int(_mem.rxfreq) * 10, allowed=step_lookup.keys())]
         except errors.InvalidDataError:
             LOG.warning('Unknown step for rx freq, defaulting to 5kHz')
             _mem.rx_step = 0x1
         try:
             _mem.tx_step = step_lookup[chirp_common.required_step(
-                int(_mem.txfreq) * 10)]
+                int(_mem.txfreq) * 10, allowed=step_lookup.keys())]
         except errors.InvalidDataError:
             LOG.warning('Unknown step for tx freq, defaulting to 5kHz')
             _mem.tx_step = 0x1

--- a/chirp/drivers/tk8180.py
+++ b/chirp/drivers/tk8180.py
@@ -992,22 +992,20 @@ class KenwoodTKx180Radio(chirp_common.CloneModeRadio):
             raise errors.RadioError('Unsupported duplex mode %r' % mem.duplex)
 
         step_lookup = {
-            2.5: 0x1,
-            6.25: 0x3,
             12.5: 0x6,
             10.0: 0x5,
+            6.25: 0x3,
             5: 0x2,
+            2.5: 0x1,
         }
         try:
             tx_step = chirp_common.required_step(int(_mem.tx_freq) * 10,
-                                                 allowed=step_lookup.keys(),
-                                                 max=True)
+                                                 allowed=step_lookup.keys())
         except errors.InvalidDataError:
             tx_step = 5
         try:
             rx_step = chirp_common.required_step(int(_mem.rx_freq) * 10,
-                                                 allowed=step_lookup.keys(),
-                                                 max=True)
+                                                 allowed=step_lookup.keys())
         except errors.InvalidDataError:
             rx_step = 5
 

--- a/chirp/import_logic.py
+++ b/chirp/import_logic.py
@@ -71,7 +71,7 @@ def ensure_has_calls(radio, memory):
 
 def _import_freq(dst_radio, _srcrf, mem):
     dst_bands = dst_radio.get_features().valid_bands
-    if not any(lo < mem.freq <= hi for (lo, hi) in dst_bands):
+    if not any(lo <= mem.freq <= hi for (lo, hi) in dst_bands):
         raise DestNotCompatible(
             _('Frequency %s is out of supported range') % (
                 chirp_common.format_freq(mem.freq)))

--- a/chirp/wxui/report.py
+++ b/chirp/wxui/report.py
@@ -81,8 +81,6 @@ def with_session(fn):
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
-        global DISABLED
-
         if DISABLED:
             return
 

--- a/tests/unit/test_chirp_common.py
+++ b/tests/unit/test_chirp_common.py
@@ -504,7 +504,7 @@ class TestStepFunctions(base.BaseTest):
                  6.25: self._625,
                  12.5: self._125,
                  }
-        allowed = [6.25, 12.5]
+        allowed = [12.5, 6.25]
         for step, freqs in list(steps.items()):
             for freq in freqs:
                 # We don't support 5.0, so any of the frequencies in that
@@ -520,7 +520,7 @@ class TestStepFunctions(base.BaseTest):
     def test_required_step_finds_suitable(self):
         # If we support 5.0, we should get it as the step for those
         self.assertEqual(5.0, chirp_common.required_step(self._005[0],
-                                                         allowed=[2.5, 5.0]))
+                                                         allowed=[5.0, 2.5]))
         # If we support 2.5 and not 5.0, then we should find 2.5 as a suitable
         # alternative
         self.assertEqual(2.5, chirp_common.required_step(self._005[0],
@@ -534,7 +534,7 @@ class TestStepFunctions(base.BaseTest):
     def test_required_step_fail(self):
         self.assertRaises(errors.InvalidDataError,
                           chirp_common.required_step,
-                          146520500)
+                          146520500, allowed=[5.0, 10.0, 12.5])
 
     def test_fix_rounded_step_250(self):
         self.assertEqual(146106250,
@@ -547,6 +547,10 @@ class TestStepFunctions(base.BaseTest):
     def test_fix_rounded_step_750(self):
         self.assertEqual(146118750,
                          chirp_common.fix_rounded_step(146118000))
+
+    def test_fix_rounded_step_no_change(self):
+        self.assertEqual(146520000,
+                         chirp_common.fix_rounded_step(146520000))
 
 
 class TestImageMetadata(base.BaseTest):


### PR DESCRIPTION
Note that this does not work for setting these modes as the radio
appears to reject even an exact copy of a memory it has itself returned
to us.

Related to #11911
