### PR TITLE
Add a link in the about box to open online documentation

### DIFF
--- a/chirp/locale/bg_BG.po
+++ b/chirp/locale/bg_BG.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2025-04-17 10:00+0200\n"
 "Last-Translator: Стоян <stoyanster от гмаил>\n"
 "Language-Team: Bulgarian <dict@ludost.net>\n"
@@ -26,28 +26,33 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: ../wxui/query_sources.py:63
 #, python-format
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s трябва да бъде между %(min)i и %(max)i"
 
+#: ../wxui/memedit.py:2141
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i запис и преместване всички нагоре"
 msgstr[1] "%i записа и преместване всички нагоре"
 
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i запис"
 msgstr[1] "%i записа"
 
+#: ../wxui/memedit.py:2136
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
 msgstr[0] "%i запис и преместване блока нагоре"
 msgstr[1] "%i записа и преместване блока нагоре"
 
+#: ../wxui/main.py:1511
 #, python-format
 msgid "%s has not been saved. Save before closing?"
 msgstr ""
@@ -55,25 +60,32 @@ msgstr ""
 "\n"
 "Да бъдат ли запазени преди затваряне?"
 
+#: ../wxui/bugreport.py:469
 msgid "(Describe what actually happened instead)"
 msgstr "(Опишете какво се случи вместо това)"
 
+#: ../wxui/bugreport.py:467
 msgid "(Describe what you expected to happen)"
 msgstr "(Опишете какво очаквахте да се случи)"
 
+#: ../wxui/bugreport.py:465
 msgid "(Describe what you were doing)"
 msgstr "(Опишете какво направихте)"
 
+#: ../wxui/bugreport.py:471
 msgid "(Has this ever worked before? New radio? Does it work with OEM software?)"
 msgstr "(Работило ли е това устройство някога преди? Нова станция? Работи ли с фабричния софтуер?)"
 
+#: ../wxui/radioinfo.py:50
 msgid "(none)"
 msgstr "(няма)"
 
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr "…и още %i"
 
+#: ../drivers/ft4.py:726
 msgid ""
 "1. Connect programming cable to MIC jack.\n"
 "2. Press OK."
@@ -81,6 +93,7 @@ msgstr ""
 "1. Включете кабела за програмиране в жака за микрофон.\n"
 "2. Натиснете бутона „Добре“."
 
+#: ../drivers/alinco.py:605 ../drivers/alinco.py:614
 msgid ""
 "1. Ensure your firmware version is 4_10 or higher\n"
 "2. Turn radio off\n"
@@ -92,6 +105,7 @@ msgid ""
 "7. Click OK\n"
 msgstr ""
 
+#: ../drivers/ft2900.py:1253
 msgid ""
 "1. Turn Radio off.\n"
 "2. Connect data cable.\n"
@@ -99,6 +113,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press \"SET MHz\" to send image.\n"
 msgstr ""
 
+#: ../drivers/ft2900.py:1258
 msgid ""
 "1. Turn Radio off.\n"
 "2. Connect data cable.\n"
@@ -111,6 +126,7 @@ msgid ""
 "      radio, then start back at step 1.\n"
 msgstr ""
 
+#: ../drivers/ft8100.py:94
 msgid ""
 "1. Turn Radio off.\n"
 "2. Connect data cable.\n"
@@ -118,6 +134,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press \"RPT\" to send image.\n"
 msgstr ""
 
+#: ../drivers/ft8100.py:99
 msgid ""
 "1. Turn Radio off.\n"
 "2. Connect data cable.\n"
@@ -126,6 +143,7 @@ msgid ""
 "5. Click OK to start transfer.\n"
 msgstr ""
 
+#: ../drivers/ft7100.py:1130
 msgid ""
 "1. Turn Radio off.\n"
 "2. Connect data cable.\n"
@@ -133,6 +151,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press \"TONE\" to send image.\n"
 msgstr ""
 
+#: ../drivers/ft7100.py:1135
 msgid ""
 "1. Turn Radio off.\n"
 "2. Connect data cable.\n"
@@ -142,6 +161,7 @@ msgid ""
 "6. Click OK to start transfer.\n"
 msgstr ""
 
+#: ../drivers/ft2800.py:206
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable\n"
@@ -151,6 +171,7 @@ msgid ""
 "    (\"TX\" will appear on the LCD). \n"
 msgstr ""
 
+#: ../drivers/ft2800.py:216
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable\n"
@@ -160,6 +181,7 @@ msgid ""
 "6. Click OK."
 msgstr ""
 
+#: ../drivers/ft450d.py:430
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to ACC jack.\n"
@@ -170,6 +192,7 @@ msgid ""
 "    send image.\n"
 msgstr ""
 
+#: ../drivers/ft817.py:281
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to ACC jack.\n"
@@ -179,6 +202,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the [A] key to send image.\n"
 msgstr ""
 
+#: ../drivers/ft450d.py:439
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to ACC jack.\n"
@@ -189,6 +213,7 @@ msgid ""
 "    (\"Receiving\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/ft857.py:450
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to ACC jack.\n"
@@ -198,6 +223,7 @@ msgid ""
 "4. Press the [A](RCV) key (\"receiving\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/ft817.py:289
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to ACC jack.\n"
@@ -207,6 +233,7 @@ msgid ""
 "4. Press the [C] key (\"RX\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/ft857.py:441
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to CAT/LINEAR jack.\n"
@@ -217,6 +244,7 @@ msgid ""
 "     press the [C](SEND) key to send image.\n"
 msgstr ""
 
+#: ../drivers/ft7800.py:857
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA jack.\n"
@@ -229,6 +257,7 @@ msgid ""
 "     send image.\n"
 msgstr ""
 
+#: ../drivers/ft7800.py:867
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA jack.\n"
@@ -241,6 +270,7 @@ msgid ""
 "     the display).\n"
 msgstr ""
 
+#: ../drivers/vx8.py:584
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA jack.\n"
@@ -249,6 +279,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the [BAND] key to send image.\n"
 msgstr ""
 
+#: ../drivers/vx8.py:591
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA jack.\n"
@@ -257,6 +288,7 @@ msgid ""
 "4. Press the [MODE] key (\"-WAIT-\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/ft7800.py:282
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA jack.\n"
@@ -269,6 +301,7 @@ msgid ""
 "6. Press the [LOW(ACC)] key (\"--RX--\" will appear on the display).\n"
 msgstr ""
 
+#: ../drivers/ft7800.py:271
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA jack.\n"
@@ -281,6 +314,7 @@ msgid ""
 "6. <b>After clicking OK</b>, press the [V/M(MW)] key to send image.\n"
 msgstr ""
 
+#: ../drivers/ft2d.py:90
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA terminal.\n"
@@ -290,6 +324,7 @@ msgid ""
 "     press the [Send] screen button.\n"
 msgstr ""
 
+#: ../drivers/ft2d.py:97
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA terminal.\n"
@@ -300,6 +335,7 @@ msgid ""
 "5. Finally, press OK button below.\n"
 msgstr ""
 
+#: ../drivers/ft1d.py:891
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA terminal.\n"
@@ -308,6 +344,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the [BAND] key to send image.\n"
 msgstr ""
 
+#: ../drivers/ft1d.py:898
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA terminal.\n"
@@ -316,6 +353,7 @@ msgid ""
 "4. Press the [Dx] key (\"-WAIT-\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/ftm3200d.py:84
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA terminal.\n"
@@ -325,6 +363,7 @@ msgid ""
 "     to send image.\n"
 msgstr ""
 
+#: ../drivers/ftm3200d.py:92
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to DATA terminal.\n"
@@ -334,6 +373,7 @@ msgid ""
 "     (\"-WAIT-\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/ftm7250d.py:84
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC Jack.\n"
@@ -343,6 +383,7 @@ msgid ""
 "     to send image.\n"
 msgstr ""
 
+#: ../drivers/ftm7250d.py:92
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC Jack.\n"
@@ -352,6 +393,7 @@ msgid ""
 "     (\"-WAIT-\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/vx5.py:317
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/EAR jack.\n"
@@ -361,6 +403,7 @@ msgid ""
 "    the image from the radio.\n"
 msgstr ""
 
+#: ../drivers/vx5.py:325
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/EAR jack.\n"
@@ -371,6 +414,7 @@ msgid ""
 "5. Click OK to send image to radio.\n"
 msgstr ""
 
+#: ../drivers/ft50.py:195
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/SP jack.\n"
@@ -379,6 +423,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the [PTT] switch to send image.\n"
 msgstr ""
 
+#: ../drivers/ft50.py:202
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/SP jack.\n"
@@ -388,6 +433,7 @@ msgid ""
 "5. Press OK.\n"
 msgstr ""
 
+#: ../drivers/vx6.py:370 ../drivers/vx3.py:373
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/SP jack.\n"
@@ -396,6 +442,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the [BAND] key to send image.\n"
 msgstr ""
 
+#: ../drivers/vx6.py:377 ../drivers/vx3.py:380
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/SP jack.\n"
@@ -404,6 +451,7 @@ msgid ""
 "4. Press the [V/M] key (\"-WAIT-\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/vx7.py:192
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/SP jack.\n"
@@ -412,6 +460,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the [BAND] key to send image.\n"
 msgstr ""
 
+#: ../drivers/vx7.py:200
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/SP jack.\n"
@@ -420,6 +469,7 @@ msgid ""
 "4. Press the [V/M] key (\"CLONE WAIT\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/ft60.py:354
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/SP jack.\n"
@@ -431,6 +481,7 @@ msgid ""
 "     for one second to send image.\n"
 msgstr ""
 
+#: ../drivers/ft60.py:363
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/SP jack.\n"
@@ -441,6 +492,7 @@ msgid ""
 "6. Press the [MONI] switch (\"--RX--\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/vx170.py:105
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to MIC/SP jack.\n"
@@ -451,6 +503,7 @@ msgid ""
 "    (\"-TX-\" will appear on the LCD). \n"
 msgstr ""
 
+#: ../drivers/ft1802.py:96
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic jack.\n"
@@ -458,6 +511,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the [MHz(SET)] key to send image.\n"
 msgstr ""
 
+#: ../drivers/ft1802.py:103
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic jack.\n"
@@ -465,6 +519,7 @@ msgid ""
 "4. Press the [D/MR(MW)] key (\"--WAIT--\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/ft1500m.py:96
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic jack.\n"
@@ -473,6 +528,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the [MHz(SET)] key to send image.\n"
 msgstr ""
 
+#: ../drivers/ft1500m.py:103
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic jack.\n"
@@ -481,6 +537,7 @@ msgid ""
 "4. Press the [D/MR(MW)] key (\"--WAIT--\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/uv5r.py:834
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -490,6 +547,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
+#: ../drivers/uv5r.py:842
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -499,6 +557,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -508,6 +567,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -517,6 +577,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -524,6 +585,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the key to send image.\n"
 msgstr ""
 
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -531,6 +593,7 @@ msgid ""
 "4. Press the key to receive the image.\n"
 msgstr ""
 
+#: ../drivers/ft90.py:194
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect mic and hold [ACC] on mic while powering on.\n"
@@ -539,6 +602,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the [SET] key to send image.\n"
 msgstr ""
 
+#: ../drivers/ft90.py:201
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect mic and hold [ACC] on mic while powering on.\n"
@@ -548,6 +612,7 @@ msgid ""
 "    (\"R\" will appear on the lower left of LCD).\n"
 msgstr ""
 
+#: ../drivers/bj9900.py:102
 msgid ""
 "1. Turn radio off.\n"
 "2. Remove front head.\n"
@@ -556,6 +621,7 @@ msgid ""
 "4. Click OK.\n"
 msgstr ""
 
+#: ../drivers/vx170.py:116
 msgid ""
 "1. Turn radio off.\n"
 "3. Press and hold in the [moni] key while turning the radio on.\n"
@@ -564,6 +630,7 @@ msgid ""
 "5. Press the [moni] key (\"-RX-\" will appear on the LCD).\n"
 msgstr ""
 
+#: ../drivers/ft70.py:573
 msgid ""
 "1. Turn radio on.\n"
 "2. Connect cable to DATA terminal.\n"
@@ -574,6 +641,7 @@ msgid ""
 "<b>Then click OK</b>"
 msgstr ""
 
+#: ../drivers/ft70.py:565
 msgid ""
 "1. Turn radio on.\n"
 "2. Connect cable to DATA terminal.\n"
@@ -583,6 +651,7 @@ msgid ""
 "5. <b>After clicking OK</b>, press the [BAND] key.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:656
 msgid ""
 "1. Turn radio on.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -592,6 +661,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:663
 msgid ""
 "1. Turn radio on.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -601,132 +671,178 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "Налично е ново издание на CHIRP. За да го изтеглите възможно най-бързо посетете страницата!"
 
+#: ../drivers/ga510.py:1068
 msgid "AM mode does not allow duplex or tone"
 msgstr "Режимът АМ не поддържа дуплекс или тон"
 
+#: ../wxui/main.py:964
 msgid "About"
 msgstr "Относно"
 
+#: ../wxui/main.py:1873
 msgid "About CHIRP"
 msgstr "Относно CHIRP"
 
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr "Съгласяване"
 
+#: ../wxui/query_sources.py:451
 msgid "All"
 msgstr "Всички"
 
+#: ../wxui/main.py:1340
 msgid "All Files"
 msgstr "Всички файлове"
 
+#: ../wxui/main.py:1351
 msgid "All supported formats|"
 msgstr "Всички поддържани формати|"
 
+#: ../wxui/clone.py:614
 msgid "Always start with recent list"
 msgstr "Отваряне на списъка при свързване"
 
+#: ../wxui/query_sources.py:353 ../wxui/query_sources.py:443
 msgid "Amateur"
 msgstr "Любителски"
 
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Възникна грешка"
 
+#: ../wxui/clone.py:143
 msgid "Applying settings"
 msgstr "Прилагане на настройки"
 
+#: ../wxui/main.py:1608
 msgid "Automatic from system"
 msgstr "Автоматично от системата"
 
+#: ../wxui/developer.py:637
 msgid "Available modules"
 msgstr "Достъпни модули"
 
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "Разпределение на честотните ленти"
 
+#: ../wxui/query_sources.py:479 ../wxui/query_sources.py:698
+#: ../wxui/query_sources.py:856
 msgid "Bands"
 msgstr "Честотни ленти"
 
+#: ../wxui/main.py:210
 msgid "Banks"
 msgstr "Банки"
 
+#: ../wxui/developer.py:281
 msgid "Bin"
 msgstr "Bin"
 
+#: ../wxui/main.py:221
 msgid "Browser"
 msgstr "Разглеждане"
 
+#: ../wxui/bugreport.py:447
 #, python-format
 msgid "Bug number %s is closed"
 msgstr ""
 
+#: ../wxui/bugreport.py:436
 msgid "Bug number not found"
 msgstr "Доклад за дефект с този номер не е намерен"
 
+#: ../wxui/bugreport.py:413
 msgid "Bug number:"
 msgstr "Доклад за дефект номер:"
 
+#: ../wxui/bugreport.py:368
 msgid "Bug subject:"
 msgstr "Доклад относно:"
 
+#: ../wxui/developer.py:491
 msgid "Building Radio Browser"
 msgstr "Попълване на екрана за разглеждане"
 
+#: ../wxui/main.py:1637
 msgid "CHIRP must be restarted for the new selection to take effect"
 msgstr "За да влязат сила избраното, CHIRP трябва да рестартира"
 
+#: ../wxui/query_sources.py:177
 #, python-format
 msgid "Cached results can only be included for a proximity query with Latitude, Longitude, and Distance set. Please uncheck \"%s\""
 msgstr ""
 
+#: ../wxui/query_sources.py:1065
 msgid "Canada"
 msgstr "Канада"
 
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Промяната на тази настройка изисква презареждане на настройките от образа, което ще се случи сега."
 
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Канали с еднакви TX и RX %s са представени с режим на тона „%s“."
 
+#: ../wxui/main.py:1339
 msgid "Chirp Image Files"
 msgstr "Файлове с образи на Chirp"
 
+#: ../wxui/memedit.py:460
 msgid "Choice Required"
 msgstr "Необходим е избор"
 
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Изберете код на DTSC за %s"
 
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Изберете тон за %s"
 
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr "Изберете режим на прекръстосване"
 
+#: ../wxui/main.py:1179
 msgid "Choose Diff Target"
 msgstr "Изберете какво ще сравнявате"
 
+#: ../wxui/clone.py:595
 msgid "Choose a recent model"
 msgstr "Изберете модел последно използваните станции"
 
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr "Изберете дуплекс"
 
+#: ../wxui/developer.py:636
 #, python-format
 msgid "Choose the module to load from issue %i:"
 msgstr "Зареждане на модул от докладван дефект %i:"
 
+#: ../wxui/query_sources.py:561
 msgid "City"
 msgstr "Град"
 
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
 msgstr "Прочетете тук целия текст на лиценза"
 
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
+msgstr ""
+
+#: ../drivers/ts590.py:671
 msgid ""
 "Click on the \"Special Channels\" toggle-button of the memory\n"
 "editor to see/set the EXT channels. P-VFO channels 100-109\n"
@@ -736,48 +852,64 @@ msgid ""
 "Ignore the beeps from the radio on upload and download.\n"
 msgstr ""
 
+#: ../drivers/ft817.py:358
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Записването завърши, проверка за паразитни байтове"
 
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Записване"
 
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr "Зареждане от станция…"
 
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr "Записване в станция…"
 
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "Затваряне"
 
+#: ../wxui/memquery.py:151
 msgid "Close String"
 msgstr "Завършване на низ"
 
+#: ../wxui/main.py:1057
 msgid "Close file"
 msgstr "Затваряне на файла"
 
+#: ../wxui/memquery.py:209
 msgid "Close string value with double-quote (\")"
 msgstr "Завършете низа с права двойна кавичка (\")"
 
+#: ../wxui/memedit.py:2200
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
 msgstr[0] "Групиране на %i запис"
 msgstr[1] "Групиране на %i записа"
 
+#: ../wxui/memedit.py:659
 msgid "Comment"
 msgstr "Коментар"
 
+#: ../wxui/clone.py:316
 msgid "Communicate with radio"
 msgstr "Осъществяване на връзка със станция"
 
+#: ../wxui/clone.py:151
 msgid "Complete"
 msgstr "Завършено"
 
+#: ../wxui/memedit.py:141
 msgid "Complex or non-standard tone squelch mode (starts the tone mode selection wizard)"
 msgstr "Сложен или нестандартен режим на тон за шумоподавителя (стартира съветник за избор на режим на тона)"
 
+#: ../drivers/tmd710.py:185 ../drivers/tmd710.py:188
 msgid ""
 "Connect your interface cable to the PC Port on the\n"
 "back of the 'TX/RX' unit. NOT the Com Port on the head.\n"
@@ -785,235 +917,311 @@ msgstr ""
 "Свършете кабела към „PC Port“ на гърба на „TX/RX“\n"
 "модула, а НЕ към „Com Port“ на предния панел.\n"
 
+#: ../wxui/query_sources.py:406
 msgid "Convert to FM"
 msgstr "Превръщане в ЧМ"
 
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Копиране"
 
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr "Преносимо копиране"
 
+#: ../wxui/query_sources.py:351 ../wxui/query_sources.py:567
+#: ../wxui/query_sources.py:657
 msgid "Country"
 msgstr "Държава"
 
+#: ../wxui/memedit.py:642
 msgid "Cross Mode"
 msgstr "Режим на прекръстосване"
 
+#: ../wxui/clone.py:556
 msgid "Custom Port"
 msgstr "Порт по избор"
 
+#: ../wxui/clone.py:41
 msgid "Custom..."
 msgstr "По избор…"
 
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Изрязване"
 
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr "Изрязване %i записа"
 
+#: ../wxui/memedit.py:573
 msgid "DTCS"
 msgstr "DTCS"
 
+#: ../wxui/memedit.py:619
 msgid ""
 "DTCS\n"
 "Polarity"
 msgstr "Полярност на DTCS"
 
+#: ../drivers/uvk5.py:879
 msgid "DTMF decode"
 msgstr "Декодиране на DTMF"
 
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr "Записи за цифрови разговори"
 
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr "Напред е опасно"
 
+#: ../wxui/developer.py:280
 msgid "Dec"
 msgstr "Dec"
 
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Премахване"
 
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr "Премахване на записи"
 
+#: ../wxui/bugreport.py:527
 msgid "Detailed information"
 msgstr "Подробна информация"
 
+#: ../wxui/main.py:969
 msgid "Developer Mode"
 msgstr "Режим за разработчик"
 
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Режимът на разработчик е %s. Приложението трябва да бъде рестартирано"
 
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Разлики в необработеното съдържание на записите"
 
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr "Сравняване с друг редактор"
 
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Цифров код"
 
+#: ../wxui/query_sources.py:410
 msgid "Digital Modes"
 msgstr "Цифрови режими"
 
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr "Изключване на докладването"
 
+#: ../wxui/memedit.py:549
 msgid "Disabled"
 msgstr "Изключено"
 
+#: ../wxui/query_sources.py:103 ../wxui/query_sources.py:382
+#: ../wxui/query_sources.py:680 ../wxui/query_sources.py:838
 msgid "Distance"
 msgstr "Разстояние"
 
+#: ../wxui/clone.py:204
 #, python-format
 msgid "Do not prompt again for %s"
 msgstr "Без повторно питане за %s"
 
+#: ../wxui/clone.py:201
 msgid "Do you accept the risk?"
 msgstr "Приемате ли риска?"
 
+#: ../wxui/bankedit.py:190
 msgid "Double-click to change bank name"
 msgstr "Името на банката може да бъде променено след двойно щракване"
 
+#: ../wxui/main.py:1058
 msgid "Download"
 msgstr "Изтегляне"
 
+#: ../wxui/main.py:1059
 msgid "Download from radio"
 msgstr "Изтегляне от станция"
 
+#: ../wxui/main.py:866
 msgid "Download from radio..."
 msgstr "Изтегляне от станция…"
 
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "Инструкции за изтегляне"
 
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr "Управляващ софтуер"
 
+#: ../drivers/uvk5.py:1297
 msgid "Driver information"
 msgstr "Сведения за управляващия софтуер"
 
+#: ../wxui/main.py:572
 msgid "Driver messages"
 msgstr "Съобщения от управляващия софтуер"
 
+#: ../wxui/query_sources.py:408
 msgid "Dual-mode digital repeaters that support analog will be shown as FM"
 msgstr "Цифровите ретранслатори, поддържащи и аналогов режим ще бъдат показани като ЧМ"
 
+#: ../wxui/memedit.py:512
 msgid "Duplex"
 msgstr "Дуплекс"
 
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Промяна стойностите на %i записа"
 
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Промяна на запис № %i"
 
+#: ../wxui/main.py:913
 msgid "Enable Automatic Edits"
 msgstr "Автоматични промени"
 
+#: ../wxui/memedit.py:549
 msgid "Enabled"
 msgstr "Включено"
 
+#: ../wxui/memedit.py:371
 msgid "Enter Frequency"
 msgstr "Въведете честота"
 
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr "Въведете отместване (МХц)"
 
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr "Въведете честота на предаване (МХц)"
 
+#: ../wxui/bankedit.py:203
 #, python-format
 msgid "Enter a new name for bank %s:"
 msgstr "Въведете ново име за банка %s:"
 
+#: ../wxui/clone.py:555
 msgid "Enter custom port:"
 msgstr "Въведете порт по избор:"
 
+#: ../wxui/bugreport.py:461
 msgid "Enter details about this update. Be descriptive about what you were doing, what you expected to happen, and what actually happened."
 msgstr ""
 
+#: ../wxui/bugreport.py:354
 msgid "Enter information about the bug including a short but meaningful subject and information about the radio model (if applicable) in question. In the next step you will have a chance to add more details about the problem."
 msgstr ""
 
+#: ../wxui/bugreport.py:480
 msgid "Enter information to add to the bug here"
 msgstr ""
 
+#: ../wxui/bugreport.py:404
 msgid "Enter the bug number that should be updated"
 msgstr ""
 
+#: ../wxui/bugreport.py:232
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr "Премахнат е запис № %s"
 
+#: ../wxui/memquery.py:336
 msgid "Error applying filter"
 msgstr "Грешка при прилагане на филтър"
 
+#: ../wxui/settingsedit.py:156
 msgid "Error applying settings"
 msgstr "Грешка при прилагане на настройките"
 
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "Грешка при връзката със станцията"
 
+#: ../wxui/memquery.py:236
 msgid "Example: \"foo\""
 msgstr "Пример: \"низ\""
 
+#: ../wxui/memquery.py:244
 msgid "Example: ( expression )"
 msgstr "Пример: ( израз )"
 
+#: ../wxui/memquery.py:238
 msgid "Example: 123"
 msgstr "Пример: 123"
 
+#: ../wxui/memquery.py:240
 msgid "Example: 146.52"
 msgstr "Пример: 123.45"
 
+#: ../wxui/memquery.py:242
 msgid "Example: AND, OR"
 msgstr "Пример: AND, OR"
 
+#: ../wxui/memquery.py:250
 msgid "Example: freq<146.0,148.0>"
 msgstr "Пример: freq<146.0,148.0>"
 
+#: ../wxui/memquery.py:248
 msgid "Example: name=\"myrepeater"
 msgstr "Пример: name=\"ретранслатор"
 
+#: ../wxui/memquery.py:246
 msgid "Example: name~\"myrepea\""
 msgstr "Пример: name~\"ретрансл\""
 
+#: ../wxui/query_sources.py:403
 msgid "Exclude private and closed repeaters"
 msgstr "Изключване на частните и затворени ретранслатори"
 
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "Изпитателен управляващ софтуер"
 
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr "При изнасяне могат да бъдат запазвани само файлове на CSV"
 
+#: ../wxui/main.py:1496
 msgid "Export to CSV"
 msgstr "Изнасяне в CSV"
 
+#: ../wxui/main.py:738
 msgid "Export to CSV..."
 msgstr "Изнасяне в CSV…"
 
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr "Допълнителни"
 
+#: ../drivers/uvk5.py:1295
 msgid "FM Radio"
 msgstr "Радио ЧМ"
 
+#: ../wxui/query_sources.py:996
 msgid ""
 "FREE repeater database, which provides information\n"
 "about repeaters in Europe. No account is required."
@@ -1021,6 +1229,7 @@ msgstr ""
 "БЕЗПЛАТНА база данни за повторители, която предоставя\n"
 "информация за повторители в Европа. Не е необходим акаунт."
 
+#: ../wxui/query_sources.py:712
 msgid ""
 "FREE repeater database, which provides most up-to-date\n"
 "information about repeaters in Europe. No account is\n"
@@ -1029,59 +1238,79 @@ msgstr ""
 "Безплатен списък с най-новата информация за\n"
 "европейските ретранслатори. Не е необходим профил."
 
+#: ../wxui/developer.py:499
 msgid "Failed to load radio browser"
 msgstr "Грешка при попълване на екрана за разглеждане"
 
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr "Грешка при разбора на резултата"
 
+#: ../wxui/bugreport.py:665
 msgid "Failed to send bug report:"
 msgstr "Грешка при изпращане на доклад за дефект:"
 
+#: ../wxui/radioinfo.py:45
 msgid "Features"
 msgstr "Настройки"
 
+#: ../wxui/bugreport.py:196
 msgid "File a new bug"
 msgstr "Докладване на дефект"
 
+#: ../wxui/main.py:579
 #, python-format
 msgid "File does not exist: %s"
 msgstr "Файлът „%s“ не съществува"
 
+#: ../wxui/main.py:1343 ../wxui/main.py:1423 ../wxui/main.py:1433
+#: ../wxui/main.py:1492 ../wxui/main.py:1843 ../wxui/main.py:1844
 msgid "Files"
 msgstr "файлове"
 
+#: ../wxui/bugreport.py:525
 msgid "Files:"
 msgstr "Файлове:"
 
+#: ../wxui/query_sources.py:388
 msgid "Filter"
 msgstr "Филтър"
 
+#: ../wxui/query_sources.py:386
 msgid "Filter results with location matching this string"
 msgstr "Филтриране на резултатите, чието местоположение съдържат низа"
 
+#: ../wxui/memquery.py:270
 msgid "Filter..."
 msgstr "Филтър…"
 
+#: ../wxui/main.py:1566
 msgid "Find"
 msgstr "Търсене"
 
+#: ../wxui/main.py:806
 msgid "Find Next"
 msgstr "Следващо съвпадение"
 
+#: ../wxui/main.py:792
 msgid "Find..."
 msgstr "Търсене…"
 
+#: ../wxui/memquery.py:155
 msgid "Finish Float"
 msgstr "Довършете стойност с плаваща запетая"
 
+#: ../wxui/memquery.py:211
 msgid "Finish float value like: 146.52"
 msgstr "Довършете стойността с плаваща запетая например 146.52"
 
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Със станцията е завършено е действието „%s“"
 
+#: ../drivers/ts590.py:678
 msgid ""
 "Follow these instructions to download the radio memory:\n"
 "1 - Connect your interface cable\n"
@@ -1090,6 +1319,7 @@ msgid ""
 "3 - Disconnect your interface cable\n"
 msgstr ""
 
+#: ../drivers/ts480.py:517
 msgid ""
 "Follow these instructions to download the radio memory:\n"
 "1 - Connect your interface cable\n"
@@ -1098,6 +1328,7 @@ msgid ""
 "3 - Disconnect your interface cable\n"
 msgstr ""
 
+#: ../drivers/th_uv8000.py:517
 msgid ""
 "Follow these instructions to download the radio memory:\n"
 "1 - Turn off your radio\n"
@@ -1106,6 +1337,7 @@ msgid ""
 "4 - CHIRP Menu - Radio - Download from radio\n"
 msgstr ""
 
+#: ../drivers/ic2730.py:306
 msgid ""
 "Follow these instructions to download your config:\n"
 "1 - Turn off your radio\n"
@@ -1116,6 +1348,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1129,6 +1366,7 @@ msgstr ""
 "3 - Включете радиото\n"
 "4 - Изтеглете информацията\n"
 
+#: ../drivers/tk690.py:575 ../drivers/tk760g.py:683
 msgid ""
 "Follow these instructions to download your radio:\n"
 "1 - Turn off your radio\n"
@@ -1137,6 +1375,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
+#: ../drivers/tk760.py:341
 msgid ""
 "Follow these instructions to read your radio:\n"
 "1 - Turn off your radio\n"
@@ -1145,6 +1384,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
+#: ../drivers/ts590.py:684
 msgid ""
 "Follow these instructions to upload the radio memory:\n"
 "1 - Connect your interface cable\n"
@@ -1153,6 +1393,7 @@ msgid ""
 "3 - Disconnect your interface cable\n"
 msgstr ""
 
+#: ../drivers/ts480.py:523
 msgid ""
 "Follow these instructions to upload the radio memory:\n"
 "1 - Connect your interface cable\n"
@@ -1161,6 +1402,7 @@ msgid ""
 "3 - Disconnect your interface cable\n"
 msgstr ""
 
+#: ../drivers/th_uv8000.py:523
 msgid ""
 "Follow these instructions to upload the radio memory:\n"
 "1 - Turn off your radio\n"
@@ -1169,6 +1411,7 @@ msgid ""
 "4 - CHIRP Menu - Radio - Upload to radio\n"
 msgstr ""
 
+#: ../drivers/ic2730.py:314
 msgid ""
 "Follow these instructions to upload your config:\n"
 "1 - Turn off your radio\n"
@@ -1180,6 +1423,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1193,6 +1437,7 @@ msgstr ""
 "3 - Включете радиото\n"
 "4 - Изпратете информацията\n"
 
+#: ../drivers/tk690.py:581 ../drivers/tk760g.py:689
 msgid ""
 "Follow these instructions to upload your radio:\n"
 "1 - Turn off your radio\n"
@@ -1206,6 +1451,7 @@ msgstr ""
 "3 - Включете радиото (отключете го ако е защитено с парола)\n"
 "4 - Изберете „Добре“\n"
 
+#: ../drivers/tk760.py:347
 msgid ""
 "Follow these instructions to write your radio:\n"
 "1 - Turn off your radio\n"
@@ -1219,6 +1465,7 @@ msgstr ""
 "3 - Включете радиото\n"
 "4 - Изберете „Добре“\n"
 
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1227,6 +1474,7 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
+#: ../drivers/tk270.py:340
 msgid ""
 "Follow this instructions to read your radio:\n"
 "1 - Turn off your radio\n"
@@ -1235,6 +1483,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1243,6 +1496,7 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
+#: ../drivers/tk270.py:346
 msgid ""
 "Follow this instructions to write your radio:\n"
 "1 - Turn off your radio\n"
@@ -1251,300 +1505,406 @@ msgid ""
 "4 - Do the upload of your radio data\n"
 msgstr ""
 
+#: ../wxui/memedit.py:212
 #, python-format
 msgid "Found empty list value for %(name)s: %(value)r"
 msgstr "Намерена е стойност „празен списък“ за %(name)s: %(value)r"
 
+#: ../wxui/memedit.py:317
 msgid "Frequency"
 msgstr "Честота"
 
+#: ../import_logic.py:76
 #, python-format
 msgid "Frequency %s is out of supported range"
 msgstr "Честотата %s е извън поддържания обхват"
 
+#: ../wxui/memedit.py:145
 msgid "Frequency granularity in kHz"
 msgstr "Стъпка на честотата в кХз"
 
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr "Честотата в този обхват не трябва да бъде в режим на АМ"
 
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr "Честотата в този обхват изисква режим на АМ"
 
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr "Честотата извън обхватите на предаване трябва да бъде 'duplex=off'"
 
+#: ../wxui/query_sources.py:354 ../wxui/query_sources.py:434
+#: ../wxui/query_sources.py:534
 msgid "GMRS"
 msgstr "GMRS"
 
+#: ../wxui/settingsedit.py:77
 msgid "Getting settings"
 msgstr "Получаване на настройки"
 
+#: ../wxui/memedit.py:1323
 msgid "Goto Memory"
 msgstr "Към запис"
 
+#: ../wxui/memedit.py:1322
 msgid "Goto Memory:"
 msgstr "Към запис:"
 
+#: ../wxui/memedit.py:1269
 msgid "Goto..."
 msgstr "Към…"
 
+#: ../wxui/main.py:1024
 msgid "Help"
 msgstr "Помощ"
 
+#: ../wxui/clone.py:40
 msgid "Help Me..."
 msgstr "Искам помощ…"
 
+#: ../wxui/developer.py:279
 msgid "Hex"
 msgstr "Hex"
 
+#: ../wxui/memedit.py:1278
 msgid "Hide empty memories"
 msgstr "Скриване на празни зиписи"
 
+#: ../drivers/retevis_rt98.py:1003
 msgid "Honor the CTCSS/DCS receive squelch configuration when enabled, else only carrier squelch"
 msgstr ""
 
+#: ../wxui/memedit.py:148
 msgid "Human-readable comment (not stored in radio)"
 msgstr "Коментар за справка (не се пази в станцията)"
 
+#: ../wxui/query_sources.py:365 ../wxui/query_sources.py:371
+#: ../wxui/query_sources.py:664 ../wxui/query_sources.py:670
+#: ../wxui/query_sources.py:816 ../wxui/query_sources.py:822
 msgid "If set, sort results by distance from these coordinates"
 msgstr "Ако е зададено, сортира резултатите по отдалеченост от тези координати"
 
+#: ../wxui/main.py:1478
 msgid "Import"
 msgstr "Внасяне"
 
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
 
+#: ../wxui/main.py:732
 msgid "Import from file..."
 msgstr "Внасяне от файл…"
 
+#: ../wxui/main.py:1482
 msgid "Import messages"
 msgstr "Съобщения при внасяне"
 
+#: ../wxui/main.py:1476
 msgid "Import not recommended"
 msgstr "Не се препоръчва внасяне"
 
+#: ../wxui/query_sources.py:423
 msgid "Include Cached"
 msgstr ""
 
+#: ../wxui/bankedit.py:62
 msgid "Index"
 msgstr "Пореден номер"
 
+#: ../wxui/main.py:223
 msgid "Info"
 msgstr "Сведения"
 
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr "Сведения"
 
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr "Вмъкване на ред отгоре"
 
+#: ../wxui/__init__.py:59
 msgid "Install desktop icon?"
 msgstr "Добавяне на пикограма към работния плот?"
 
+#: ../wxui/main.py:953
 msgid "Interact with driver"
 msgstr "Взаимодействие с управляващия софтуер"
 
+#: ../wxui/clone.py:799
 msgid "Internal driver error"
 msgstr "Вътрешна грешка на управляващия софтуер"
 
+#: ../wxui/query_sources.py:61
 #, python-format
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Неприемлива стойност „%(value)s“ (използвайте десетични градуси)"
 
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 msgid "Invalid Entry"
 msgstr "Недействителен запис"
 
+#: ../wxui/query_sources.py:150
 msgid "Invalid ZIP code"
 msgstr "Неприемлив пощенски код"
 
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Неприемлива промяна: %s"
 
+#: ../wxui/query_sources.py:123
 msgid "Invalid locator"
 msgstr ""
 
+#: ../wxui/main.py:1840
 msgid "Invalid or unsupported module file"
 msgstr "Недействителен или неподдържан файл на модул"
 
+#: ../wxui/memedit.py:270 ../wxui/memedit.py:276
 #, python-format
 msgid "Invalid value: %r"
 msgstr "Недействителна стойност: %r"
 
+#: ../wxui/developer.py:658
 msgid "Issue number:"
 msgstr "Номер на дефект:"
 
+#: ../wxui/main.py:351
 msgid "LIVE"
 msgstr "НА ЖИВО"
 
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 msgid "Language"
 msgstr "Език"
 
+#: ../wxui/query_sources.py:91 ../wxui/query_sources.py:373
+#: ../wxui/query_sources.py:672 ../wxui/query_sources.py:824
 msgid "Latitude"
 msgstr "Географска ширина"
 
+#: ../wxui/developer.py:260
 #, python-format
 msgid "Length must be %i"
 msgstr "Дължината трябва да бъде %i"
 
+#: ../wxui/query_sources.py:394 ../wxui/query_sources.py:632
+#: ../wxui/query_sources.py:785
 msgid "Limit Bands"
 msgstr "Ограничение по производител"
 
+#: ../wxui/query_sources.py:399
 msgid "Limit Modes"
 msgstr "Ограничение по модел"
 
+#: ../wxui/query_sources.py:647 ../wxui/query_sources.py:800
 msgid "Limit Status"
 msgstr "Ограничение по състояние"
 
+#: ../wxui/query_sources.py:809
 msgid "Limit prefixes"
 msgstr "Ограничение по наставка"
 
+#: ../wxui/query_sources.py:380 ../wxui/query_sources.py:678
+#: ../wxui/query_sources.py:836
 msgid "Limit results to this distance (km) from coordinates"
 msgstr "Ограничаване на резултатите до това разстояние (км) от координатите"
 
+#: ../wxui/query_sources.py:404
 msgid "Limit use"
 msgstr "Ограничаване на използването"
 
+#: ../wxui/main.py:1709
 msgid "Live Radio"
 msgstr "Радио на живо"
 
+#: ../wxui/main.py:744
 msgid "Load Module..."
 msgstr "Зареждане на модул…"
 
+#: ../wxui/developer.py:659
 msgid "Load module from issue"
 msgstr "Зареждане на модул от докладван дефект"
 
+#: ../wxui/main.py:1006
 msgid "Load module from issue..."
 msgstr "Зареждане на модул от докладван дефект…"
 
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr "Зареждането на модул няма да повлияе на отворените раздели. Препоръчва се (освен ако не е указано друго) да затворите всички раздели, преди да зареждате модули."
 
+#: ../wxui/main.py:1847
 msgid "Loading modules can be extremely dangerous, leading to damage to your computer, radio, or both. NEVER load a module from a source you do not trust, and especially not from anywhere other than the main CHIRP website (chirpmyradio.com). Loading a module from another source is akin to giving them direct access to your computer and everything on it! Proceed despite this risk?"
 msgstr "Зареждането на модул може да бъде изключително опасно и да доведе до повреда на компютърa, радиостанцията или и двете. НИКОГА не зареждайте модули от източници, на който нямате доверие и особено от място, различно от основната страница на CHIRP (chirpmyradio.com). Зареждането на модули от други източници е равносилно на това да им дадете пълен достъп до компютъра и всичко в него! Желаете ли да продължите, въпреки риска?"
 
+#: ../wxui/clone.py:145
 msgid "Loading settings"
 msgstr "Зареждане на настройки"
 
+#: ../wxui/query_sources.py:109
 msgid "Locator"
 msgstr ""
 
+#: ../wxui/bugreport.py:326
 msgid "Login failed: Check your username and password"
 msgstr "Грешка при вход: проверете потребителското име и паролата"
 
+#: ../drivers/uvk5.py:1799
 msgid "Logo string 1 (12 characters)"
 msgstr "Логотип низ 1 (12 знака)"
 
+#: ../drivers/uvk5.py:1806
 msgid "Logo string 2 (12 characters)"
 msgstr "Логотип низ 2 (12 знака)"
 
+#: ../wxui/query_sources.py:97 ../wxui/query_sources.py:374
+#: ../wxui/query_sources.py:673 ../wxui/query_sources.py:825
 msgid "Longitude"
 msgstr "Географска дължина"
 
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
 
+#: ../wxui/main.py:202
 msgid "Memories"
 msgstr "Записи"
 
+#: ../drivers/uvk5.py:2118
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr "Записите не могат да бъдат променяни поради неподдържана версия на управляващия софтуер"
 
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Запис № %i не може да бъде премахван"
 
+#: ../wxui/memquery.py:203
 #, python-format
 msgid "Memory field name (one of %s)"
 msgstr "Име на поле от записите (едно от %s)"
 
+#: ../wxui/memedit.py:133
 msgid "Memory label (stored in radio)"
 msgstr "Етикет на записа (пази се в станцията)"
 
+#: ../wxui/bankedit.py:242
 msgid "Memory must be in a bank to be edited"
 msgstr "За да бъде променян, записът трябва да принадлежи към банка"
 
+#: ../drivers/vx5.py:133
 #, python-brace-format
 msgid "Memory {num} not in bank {bank}"
 msgstr "Записът {num} не е в банката {bank}"
 
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 msgid "Mode"
 msgstr "Режим"
 
+#: ../wxui/clone.py:354
 msgid "Model"
 msgstr "Модел"
 
+#: ../wxui/query_sources.py:500
 msgid "Modes"
 msgstr "Режими"
 
+#: ../wxui/main.py:1844
 msgid "Module"
 msgstr "Модул"
 
+#: ../wxui/main.py:1816
 msgid "Module Loaded"
 msgstr "Зареден е модул"
 
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr "Модулът е зареден"
 
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr "Сведения"
 
+#: ../wxui/clone.py:512
 #, python-format
 msgid "More than one port found: %s"
 msgstr "Намерен е повече от един порт: %s"
 
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
 
+#: ../wxui/memedit.py:1265
 msgid "Move Down"
 msgstr "Преместване надолу"
 
+#: ../wxui/memedit.py:1255
 msgid "Move Up"
 msgstr "Преместване нагоре"
 
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Действията за преместване са забранени при сортиран изглед"
 
+#: ../wxui/main.py:690
 msgid "New Window"
 msgstr "Нов прозорец"
 
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "Налично е ново издание"
 
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr "Отдолу липсват празни редове!"
 
+#: ../wxui/memquery.py:254
 #, python-format
 msgid "No example for %s"
 msgstr "Липсва пример за %s"
 
+#: ../wxui/developer.py:674
 msgid "No modules found"
 msgstr "Не са намерени модули"
 
+#: ../wxui/developer.py:673
 #, python-format
 msgid "No modules found in issue %i"
 msgstr "Не са намерени модули в доклад за дефект %i"
 
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr "Няма достатъчно място; някои записи не са приложени"
 
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr "Няма резултати"
 
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr "Няма резултати!"
 
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr "Число"
 
+#: ../wxui/memedit.py:313
 msgid "Offset"
 msgstr "Отместване"
 
+#: ../wxui/memedit.py:311
 msgid ""
 "Offset/\n"
 "TX Freq"
@@ -1552,82 +1912,110 @@ msgstr ""
 "Отместване/\n"
 "честота предав."
 
+#: ../wxui/memquery.py:252
 #, python-format
 msgid "One of: %s"
 msgstr "Едно от: %s"
 
+#: ../wxui/query_sources.py:392 ../wxui/query_sources.py:630
+#: ../wxui/query_sources.py:783
 msgid "Only certain bands"
 msgstr "Само определени производители"
 
+#: ../wxui/query_sources.py:397
 msgid "Only certain modes"
 msgstr "Само определени модели"
 
+#: ../wxui/query_sources.py:807
 msgid "Only certain prefixes"
 msgstr "Само определени наставвки"
 
+#: ../wxui/main.py:332
 msgid "Only memory tabs may be exported"
 msgstr "Само разделите съдържащи записи могат да бъдат изнасяни"
 
+#: ../wxui/query_sources.py:641 ../wxui/query_sources.py:794
 msgid "Only working repeaters"
 msgstr "Само работещи ретранслатори"
 
+#: ../wxui/main.py:1052 ../wxui/main.py:1478
 msgid "Open"
 msgstr "Отваряне"
 
+#: ../wxui/main.py:719
 msgid "Open Recent"
 msgstr "Отваряне на предишни"
 
+#: ../wxui/main.py:701
 msgid "Open Stock Config"
 msgstr "Стандартни настройки"
 
+#: ../wxui/main.py:1053 ../wxui/main.py:1354
 msgid "Open a file"
 msgstr "Отваряне на файл"
 
+#: ../wxui/main.py:1862
 msgid "Open a module"
 msgstr "Отваряне на модул"
 
+#: ../wxui/main.py:990
 msgid "Open debug log"
 msgstr "Отваряне на дневник"
 
+#: ../wxui/main.py:543
 msgid "Open in new window"
 msgstr "Отваряне в нов прозорец"
 
+#: ../wxui/query_sources.py:401
 msgid "Open repeaters only"
 msgstr "Отваряне само на ретранслатори"
 
+#: ../wxui/main.py:648
 msgid "Open stock config directory"
 msgstr "Папка със стандартни настройки"
 
+#: ../wxui/memquery.py:143
 msgid "Operator"
 msgstr "Оператор"
 
+#: ../wxui/query_sources.py:992
 msgid "Option"
 msgstr ""
 
+#: ../wxui/query_sources.py:370 ../wxui/query_sources.py:669
 msgid "Optional: -122.0000"
 msgstr "По желание: -122.0000"
 
+#: ../wxui/query_sources.py:379 ../wxui/query_sources.py:677
+#: ../wxui/query_sources.py:835
 msgid "Optional: 100"
 msgstr "По желание: 100"
 
+#: ../wxui/query_sources.py:821
 msgid "Optional: 20.0000"
 msgstr "По желание: 20.0000"
 
+#: ../wxui/query_sources.py:364 ../wxui/query_sources.py:663
 msgid "Optional: 45.0000"
 msgstr "По желание: 45.0000"
 
+#: ../wxui/query_sources.py:815
 msgid "Optional: 52.0000"
 msgstr "По желание: 52.0000"
 
+#: ../wxui/query_sources.py:829
 msgid "Optional: AA00 - AA00aa11"
 msgstr "По желание: AA00 - AA00aa11"
 
+#: ../wxui/query_sources.py:385
 msgid "Optional: County, Hospital, etc."
 msgstr "По желание: държава, сграда и т.н."
 
+#: ../wxui/memedit.py:2447
 msgid "Overwrite memories?"
 msgstr "Презаписване на записи?"
 
+#: ../drivers/ts480.py:513
 msgid ""
 "P-VFO channels 100-109 are considered Settings.\n"
 "Only a subset of the over 130 available radio settings\n"
@@ -1637,43 +2025,56 @@ msgstr ""
 "Само част от повече от 130-те достъпни настройки на\n"
 "станцията се поддържат от това издание.\n"
 
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr "Разбор"
 
+#: ../wxui/bugreport.py:259
 msgid "Password"
 msgstr "Парола"
 
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Поставяне"
 
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Поставените записи ще презапишат %s съществуващи записа"
 
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Поставените записи ще презапишат записи %s"
 
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Поставените записи ще презапишат запис № %s"
 
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Поставеният запис ще презапише запис № %s"
 
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Излезте от CHIRP преди да инсталирате ново издание!"
 
+#: ../wxui/bugreport.py:444
 msgid "Please check the bug number and try again. If you do actually want to report against this bug, please comment on it via the website and ask for it to be re-opened."
 msgstr ""
 
+#: ../drivers/ftlx011.py:301
 msgid ""
 "Please follow this steps carefully:\n"
 "1 - Turn on your radio\n"
@@ -1688,6 +2089,7 @@ msgid ""
 "get into normal mode.\n"
 msgstr ""
 
+#: ../drivers/ftlx011.py:292
 msgid ""
 "Please follow this steps carefully:\n"
 "1 - Turn on your radio\n"
@@ -1698,92 +2100,122 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr "Внимание! Режимът за разработчици е предназначен за употреба от разработчиците на проекта CHIRP или под ръководството на такъв разработчик. Режимът включва възможности и действия, които могат да повредят компютъра и радиостанцията ви, ако не ги използвате с ИЗКЛЮЧИТЕЛНА предпазливост. Желаете ли да продължите?"
 
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "Изчакайте"
 
+#: ../wxui/clone.py:489
 msgid "Plug in your cable and then click OK"
 msgstr "Включете кабела и натиснете „Добре“"
 
+#: ../wxui/query_sources.py:887
 msgid "Polish repeaters database"
 msgstr "Ретранслатори в Полша"
 
+#: ../wxui/clone.py:339
 msgid "Port"
 msgstr "Порт"
 
+#: ../wxui/memedit.py:392
 msgid "Power"
 msgstr "Мощност"
 
+#: ../wxui/query_sources.py:875
 msgid "Prefixes"
 msgstr "Представки"
 
+#: ../wxui/developer.py:157
 msgid "Press enter to set this in memory"
 msgstr "За да зададете тази стойност на записа, натиснете бутона Enter"
 
+#: ../wxui/main.py:755
 msgid "Print Preview"
 msgstr "Преглед за отпечатване"
 
+#: ../wxui/printing.py:29
 msgid "Printing"
 msgstr "Отпечатване"
 
+#: ../wxui/clone.py:523
 msgid "Prolific USB device"
 msgstr "USB устройство на Prolific"
 
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr "Свойства"
 
+#: ../wxui/memquery.py:139
 msgid "Property Name"
 msgstr "Име на свойство"
 
+#: ../wxui/memquery.py:147
 msgid "Property Value"
 msgstr "Стойност на свойство"
 
+#: ../wxui/query_sources.py:831
 msgid "QTH Locator"
 msgstr ""
 
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr "Заявка към %s"
 
+#: ../wxui/main.py:880
 msgid "Query Source"
 msgstr "Заявки"
 
+#: ../wxui/memquery.py:330
 msgid "Query string is invalid"
 msgstr "Заявката е с неправилен синтаксис"
 
+#: ../wxui/memquery.py:186
 msgid "Query syntax OK"
 msgstr "Заявката е с правилен синтаксис"
 
+#: ../wxui/memquery.py:170
 msgid "Query syntax help"
 msgstr "Помощ за синтаксиса"
 
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr "Търсене"
 
+#: ../wxui/memedit.py:575
 msgid "RX DTCS"
 msgstr "RX DTCS"
 
+#: ../wxui/main.py:1023
 msgid "Radio"
 msgstr "Станция"
 
+#: ../drivers/ft60.py:85 ../drivers/ft450d.py:568 ../drivers/ft817.py:406
 #, python-format
 msgid "Radio did not ack block %i"
 msgstr "Станцията не е приела блок %i"
 
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr "Сведения за станцията"
 
+#: ../wxui/bugreport.py:377
 msgid "Radio model:"
 msgstr "Модел на станция:"
 
+#: ../drivers/ft817.py:363
 msgid "Radio sent data after the last awaited block, this happens when the selected model is a non-US but the radio is a US one. Please choose the correct model and try again."
 msgstr "Станцията изпрати данни след последния очакван блок. Това се случва, когато избраният модел не е предназначен за употреба в САЩ, но станцията е. Изберете правилния модел и опитайте отново."
 
+#: ../wxui/query_sources.py:1212
 msgid "RadioReference Canada requires a login before you can query"
 msgstr "RadioReference Canada изисква да влезете преди на правите заявки"
 
+#: ../wxui/query_sources.py:1023
 msgid ""
 "RadioReference.com is the world's largest\n"
 "radio communications data provider\n"
@@ -1793,212 +2225,278 @@ msgstr ""
 "на данни за радиокомуникации в света.\n"
 "<small>Необходим е платен профил</small>"
 
+#: ../wxui/memedit.py:139
 msgid "Receive DTCS code"
 msgstr "Код на DTCS на приемане"
 
+#: ../wxui/memedit.py:132
 msgid "Receive frequency"
 msgstr "Честота на приемане"
 
+#: ../wxui/clone.py:596
 msgid "Recent"
 msgstr "Последно използвани станции"
 
+#: ../wxui/clone.py:346
 msgid "Recent..."
 msgstr "Последни…"
 
+#: ../drivers/retevis_rt98.py:1219
 msgid "Recommend using 55.2"
 msgstr "Препоръчваме ви да използвате 55.2"
 
+#: ../wxui/memedit.py:983
 msgid "Redo"
 msgstr "Повтаряне"
 
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr "Необходимо е презареждане"
 
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Презареден е запис № %s"
 
+#: ../wxui/main.py:930
 msgid "Reload Driver"
 msgstr "Презареждане на управляващия софтуер"
 
+#: ../wxui/main.py:939
 msgid "Reload Driver and File"
 msgstr "Презареждане на управляващия софтуер и файлове"
 
+#: ../wxui/memedit.py:1310
 msgid "Reload required"
 msgstr "Необходимо е презареждане"
 
+#: ../wxui/clone.py:616
 msgid "Remove"
 msgstr "Премахване"
 
+#: ../wxui/clone.py:617
 msgid "Remove selected model from list"
 msgstr "Премахване на избрания модел от списъка"
 
+#: ../wxui/bankedit.py:205
 msgid "Rename bank"
 msgstr "Преименуване на банка"
 
+#: ../wxui/query_sources.py:328
 msgid ""
 "RepeaterBook is Amateur Radio's most comprehensive,\n"
 "worldwide, FREE repeater directory."
 msgstr "RepeaterBook е най-изчерпателният, безплатен справочник за радиолюбителски ретранслатори в света."
 
+#: ../wxui/main.py:1012
 msgid "Report or update a bug..."
 msgstr "Доклад или промняна на дефект…"
 
+#: ../wxui/bugreport.py:522
 #, python-format
 msgid "Reporting a new bug: %r"
 msgstr "Доклад на нов дефект: %r"
 
+#: ../wxui/main.py:978
 msgid "Reporting enabled"
 msgstr "Докладването е включено"
 
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr "Докладването помага на проекта CHIRP да разполага с данните за кои модели радиостанции и операционни системи да насочи ограничените си ресурси. Високо бихме оценили ако оставите стойността включена. Желаете ли докладването да бъде изключено?"
 
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "Необходим е рестарт"
 
+#: ../wxui/main.py:713
 #, python-format
 msgid "Restore %i tab"
 msgid_plural "Restore %i tabs"
 msgstr[0] "Възстановен е %i раздел"
 msgstr[1] "Възстановени са %i раздела"
 
+#: ../wxui/main.py:845
 msgid "Restore tabs on start"
 msgstr "Възстановяване разделите при стартиране"
 
+#: ../wxui/query_sources.py:414
 msgid "Results from other areas"
 msgstr ""
 
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "Получени настройки"
 
+#: ../wxui/main.py:1054
 msgid "Save"
 msgstr "Запазване"
 
+#: ../wxui/main.py:1513
 msgid "Save before closing?"
 msgstr "Запазване преди затваряне?"
 
+#: ../wxui/main.py:1055 ../wxui/main.py:1437
 msgid "Save file"
 msgstr "Запазване на файл"
 
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "Запазени настройки"
 
+#: ../wxui/memedit.py:146
 msgid "Scan control (skip, include, priority, etc)"
 msgstr "Управление на сканиране (прескачане, включване, приоритет и т.н.)"
 
+#: ../drivers/uvk5.py:893
 msgid "Scanlists"
 msgstr "Списъци за сканиране"
 
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr "Шифроване"
 
+#: ../wxui/developer.py:649
 msgid "Security Risk"
 msgstr "Риск за сигурността"
 
+#: ../wxui/main.py:920
 msgid "Select Bandplan..."
 msgstr "Разпределение на честотните ленти…"
 
+#: ../wxui/query_sources.py:479 ../wxui/query_sources.py:698
+#: ../wxui/query_sources.py:856
 msgid "Select Bands"
 msgstr "Избор на честотни ленти"
 
+#: ../wxui/main.py:1622
 msgid "Select Language"
 msgstr "Избор на език"
 
+#: ../wxui/query_sources.py:500
 msgid "Select Modes"
 msgstr "Избор на режими"
 
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "Изберете разпределението на честотните ленти"
 
+#: ../wxui/main.py:1183
 msgid "Select a tab and memory to diff"
 msgstr "Изберете раздел и запис от паметта, които да бъдат сравнени"
 
+#: ../wxui/query_sources.py:875
 msgid "Select prefixes"
 msgstr "Избор на представка"
 
+#: ../wxui/query_sources.py:356
 msgid "Service"
 msgstr "Услуга"
 
+#: ../wxui/main.py:215
 msgid "Settings"
 msgstr "Настройки"
 
+#: ../drivers/uvk5.py:2122
 msgid "Settings are read-only due to unsupported firmware version"
 msgstr "Настройките не могат да бъдат променяни поради неподдържана версия на управляващия софтуер"
 
+#: ../wxui/memedit.py:144
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Отместване (или честота на предаване) управлявано от дуплекса"
 
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Показване на необработеното съдържание на записа"
 
+#: ../wxui/main.py:996
 msgid "Show debug log location"
 msgstr "Папка с дневник"
 
+#: ../wxui/memedit.py:1274
 msgid "Show extra fields"
 msgstr "Допълнителни полета"
 
+#: ../wxui/main.py:1001
 msgid "Show image backup location"
 msgstr "Папка с резервни копия"
 
+#: ../wxui/memedit.py:650
 msgid "Skip"
 msgstr "Пропускане"
 
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr "Някои от записите са несъвместими със станцията"
 
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr "Някои от записите не могат да бъдат премахвани"
 
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
+#: ../wxui/memedit.py:2185
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Сортиране на %i запис"
 msgstr[1] "Сортиране на %i записа"
 
+#: ../wxui/memedit.py:2189
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Сортиране на %i запис възходящо"
 msgstr[1] "Сортиране на %i записа възходящо"
 
+#: ../wxui/memedit.py:2211
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Сортиране на %i запис низходящо"
 msgstr[1] "Сортиране на %i записа низходящо"
 
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr "Сортиране по колона:"
 
+#: ../wxui/memedit.py:2069
 msgid "Sort memories"
 msgstr "Сортиране на записи"
 
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr "Сортиране"
 
+#: ../wxui/query_sources.py:564
 msgid "State"
 msgstr "Състояние"
 
+#: ../wxui/query_sources.py:359
 msgid "State/Province"
 msgstr "Щат или провинция"
 
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr "Успех"
 
+#: ../wxui/bugreport.py:668
 msgid "Successfully sent bug report:"
 msgstr "Докладът за дефект е изпратен:"
 
+#: ../wxui/memedit.py:315
 msgid "TX Frequency"
 msgstr ""
 
+#: ../wxui/memedit.py:140
 msgid "TX-RX DTCS polarity (normal or reversed)"
 msgstr "Полярност на DTCS при TX-RX (права или обратна)"
 
+#: ../drivers/ft4.py:720
 msgid ""
 "Tested and mostly works, but may give you issues\n"
 "when using lesser common radio variants.\n"
@@ -2011,9 +2509,11 @@ msgstr ""
 "Продължете на свой риск и ако се натъкнете\n"
 "на проблеми ни уведомете!"
 
+#: ../wxui/query_sources.py:572
 msgid "The DMR-MARC Worldwide Network"
 msgstr "Глобална мрежа на DMR-MARC"
 
+#: ../drivers/ft450d.py:416
 msgid ""
 "The FT-450D radio driver loads the 'Special Channels' tab\n"
 "with the PMS scanning range memories (group 11), 60meter\n"
@@ -2030,6 +2530,7 @@ msgid ""
 "'DATA MODE' to select USER-U, USER-L and RTTY \n"
 msgstr ""
 
+#: ../drivers/boblov_x3plus.py:119
 msgid ""
 "The X3Plus driver is currently experimental.\n"
 "There are no known issues but you should proceed with caution.\n"
@@ -2037,46 +2538,61 @@ msgid ""
 "download to a CHIRP Radio Images (*.img) file.\n"
 msgstr ""
 
+#: ../wxui/developer.py:646
 msgid "The author of this module is not a recognized CHIRP developer. It is recommended that you not load this module as it could pose a security risk. Proceed anyway?"
 msgstr "Авторът на този модул не е признат разработчик на CHIRP. Препоръчително е да не зареждате модула, тъй като може да представлява риск за сигурността. Желаете ли да продължите въпреки риска?"
 
+#: ../wxui/bugreport.py:213
 msgid "The debug log file is not available when CHIRP is run interactively from the command-line. Thus, this tool will not upload what you expect. It is recommended that you quit now and run CHIRP non-interactively (or with stdin redirected to /dev/null)"
 msgstr ""
 
+#: ../wxui/bugreport.py:507
 msgid "The following information will be submitted:"
 msgstr "Следните сведения ще бъдат изпратени:"
 
+#: ../wxui/memedit.py:1306
 msgid "The memory editor requires a reload in order to change the workflow. That will happen now. Any other open tabs will be updated the next time they are loaded."
 msgstr ""
 
+#: ../wxui/main.py:1469
 #, python-format
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "Препоръчителната процедура за внасяне на записи е да отворите изходния файл и да копирате/поставите записите от него в таблицата. Ако продължите от тук, CHIRP ще замени всички текущи записи с тези от %(file)s. Желаете ли да отворите този файл, за да копирате/поставите записите ръчно, или да продължите с внасянето?"
 
+#: ../wxui/memedit.py:2146
 msgid "This Memory"
 msgstr "Този запис"
 
+#: ../drivers/id5100.py:332
 msgid "This driver has been tested with v3 of the ID-5100. If your radio is not fully updated please help by opening a bug report with a debug log so we can add support for the other revisions."
 msgstr "Управляващият софтуер е изпробван с ревизия v3 на ID-5100. Ако радиостанцията ви не е напълно обновена, помогнете ни, като направите доклад за грешка с дневник за отстраняване на грешки, за да можем да добавим поддръжка за другите ревизии."
 
+#: ../drivers/radtel_rt490.py:1358 ../drivers/radtel_rt490.py:1360
+#: ../drivers/radtel_rt490.py:1362
 msgid "This driver is in development and should be considered as experimental."
 msgstr "Управляващият софтуер е в процес на разработка и трябва да бъде считан за изпитателен."
 
+#: ../drivers/uvk5.py:721
 msgid "This image is missing firmware information. It may have been generated with an old or modified version of CHIRP. It is advised that you download a fresh image from your radio and use that going forward for the best safety and compatibility."
 msgstr ""
 
+#: ../wxui/main.py:1706
 msgid "This is a live-mode radio, which means changes are sent to the radio in real-time as you make them. Upload is not necessary!"
 msgstr ""
 
+#: ../wxui/main.py:1712
 msgid "This is a radio-independent file and cannot be uploaded directly to a radio. Open a radio image (or download one from a radio) and then copy/paste items from this tab into that one in order to upload"
 msgstr ""
 
+#: ../drivers/th_uv88.py:560
 msgid "This is an early stage beta driver\n"
 msgstr "Управляващият софтуер е в ранен етап на бета\n"
 
+#: ../drivers/th_uv88.py:562
 msgid "This is an early stage beta driver - upload at your own risk\n"
 msgstr "Управляващият софтуер е в ранен етап на бета - изпращайте към станцията на ваша отговорност\n"
 
+#: ../drivers/uvk5.py:648
 msgid ""
 "This is an experimental driver for the Quansheng UV-K5. It may harm your radio, or worse. Use at your own risk.\n"
 "\n"
@@ -2085,6 +2601,7 @@ msgid ""
 "some details are not yet implemented"
 msgstr ""
 
+#: ../drivers/bj9900.py:108
 msgid ""
 "This is experimental support for BJ-9900 which is still under development.\n"
 "Please ensure you have a good backup with OEM software.\n"
@@ -2092,18 +2609,23 @@ msgid ""
 "You have been warned. Proceed at your own risk!"
 msgstr ""
 
+#: ../wxui/bugreport.py:418
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
+#: ../wxui/memedit.py:2150
 msgid "This memory and shift all up"
 msgstr "Този запис преместване всички нагоре"
 
+#: ../wxui/memedit.py:2148
 msgid "This memory and shift block up"
 msgstr "Този запис преместване блока нагоре"
 
+#: ../drivers/uvk5_egzumer.py:1468
 msgid "This option may break your radio! Each radio has a unique set of calibration data and uploading the data from the image will cause physical harm to the radio if it is from a different piece of hardware. Do not use this unless you know what you are doing and accept the risk of destroying your radio!"
 msgstr ""
 
+#: ../drivers/fd268.py:303 ../drivers/fd268.py:309
 msgid ""
 "This radio has a tricky way of enter into program mode,\n"
 "even the original software has a few tries to get inside.\n"
@@ -2112,303 +2634,371 @@ msgid ""
 "If you can get into it, please check the radio and cable.\n"
 msgstr ""
 
+#: ../drivers/uvk5.py:1884
 msgid "This should only be enabled if you are using modified firmware that supports wider frequency coverage. Enabling this will cause CHIRP not to enforce OEM restrictions and may lead to undefined or unregulated behavior. Use at your own risk!"
 msgstr ""
 
+#: ../wxui/bugreport.py:181
 msgid "This tool will upload details about your system to an existing issue on the CHIRP tracker. It requires your username and password for chirpmyradio.com in order to work. Information about your system, including your debug log, config file, and any open image files will be uploaded. An attempt will be made to redact any personal information before it leaves your system."
 msgstr ""
 
+#: ../wxui/developer.py:656
 msgid "This will load a module from a website issue"
 msgstr "От тук се зарежда модул от докладван дефект"
 
+#: ../wxui/memedit.py:478
 msgid "Tone"
 msgstr "Тон"
 
+#: ../wxui/memedit.py:1367
 msgid "Tone Mode"
 msgstr "Режим на тона"
 
+#: ../wxui/memedit.py:480
 msgid "Tone Squelch"
 msgstr "Тон за шумопод."
 
+#: ../wxui/memedit.py:134
 msgid "Tone squelch mode"
 msgstr "Режим на тона за шумоподавителя"
 
+#: ../wxui/memedit.py:147
 msgid "Transmit Power"
 msgstr "Мощност на предаване"
 
+#: ../wxui/memedit.py:143
 msgid "Transmit shift, split mode, or transmit inhibit"
 msgstr "Режим на отместване или разделяне при предаване или забрана за предаване"
 
+#: ../wxui/memedit.py:135
 msgid "Transmit tone"
 msgstr "Тон на предаване"
 
+#: ../wxui/memedit.py:138
 msgid "Transmit/receive DTCS code for DTCS mode, else transmit code"
 msgstr "В режим DTCS код на DTCS на приемане или предаване, в противен случай код на предаване"
 
+#: ../wxui/memedit.py:137
 msgid "Transmit/receive modulation (FM, AM, SSB, etc)"
 msgstr "Модулация на приемане или предаване (ЧМ, АМ, SSB и т.н)"
 
+#: ../wxui/memedit.py:136
 msgid "Transmit/receive tone for TSQL mode, else receive tone"
 msgstr "В режим TSQL тон на приемане или предаване, в противен случай тон на приемане"
 
+#: ../wxui/memedit.py:422 ../wxui/memedit.py:1379
 msgid "Tuning Step"
 msgstr "Стъпка"
 
+#: ../wxui/memquery.py:188
 msgid "Type a simple search string or a formatted query and press enter"
 msgstr "Въведете обикновено търсене или добре форматирана заявка и натиснете Enter"
 
+#: ../wxui/clone.py:483 ../wxui/clone.py:490 ../wxui/clone.py:501
+#: ../wxui/clone.py:509 ../wxui/clone.py:513
 msgid "USB Port Finder"
 msgstr "Търсене на порт на USB"
 
+#: ../wxui/clone.py:499
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Грешка при определяне на порта на кабела. Проверете управляващия софтуер и куплунгите."
 
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Грешка при промяна на запис преди да е зареден от станцията"
 
+#: ../wxui/main.py:1395
 #, python-format
 msgid "Unable to find stock config %r"
 msgstr "Грешка при намиране на стандартните настройки %r"
 
+#: ../wxui/memedit.py:2393
 msgid "Unable to import while the view is sorted"
 msgstr "Грешка при внасяне при сортиран изглед"
 
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr "Грешка при отваряне на междинната памет"
 
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr "Грешка при заявка"
 
+#: ../drivers/ft817.py:320
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr "Последният блок не е прочетен. Това се случва, когато избраният модел e предназначен за употреба в САЩ, но станцията не е (или e с разширен обхват). Изберете правилния модел и опитайте отново."
 
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Грешка при намиране на %s на системата"
 
+#: ../wxui/memedit.py:248
 #, python-format
 msgid "Unable to set %s on this memory"
 msgstr "Грешка при задаване на %s в записа"
 
+#: ../wxui/main.py:1716
 msgid "Unable to upload this file"
 msgstr "Грешка при качване на файла"
 
+#: ../wxui/memedit.py:982
 msgid "Undo"
 msgstr "Отменяне"
 
+#: ../wxui/query_sources.py:1064
 msgid "United States"
 msgstr "САЩ"
 
+#: ../wxui/clone.py:482
 msgid "Unplug your cable (if needed) and then click OK"
 msgstr "Изключете кабела (ако е необходимо) и натиснете бутона„Добре“"
 
+#: ../drivers/thd74.py:327
 #, python-format
 msgid "Unsupported model %r"
 msgstr "Моделът %r не е поддържан"
 
+#: ../wxui/bugreport.py:202
 msgid "Update an existing bug"
 msgstr "Промяна на съществуващ дефект"
 
+#: ../wxui/bugreport.py:524
 #, python-format
 msgid "Updating bug %s"
 msgstr "Промяна на дефект %s"
 
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "Инструкции за изпращане"
 
+#: ../drivers/uvk5.py:2109
 msgid "Upload is disabled due to unsupported firmware version"
 msgstr "Не може да бъде изпращано към станцията поради неподдържана версия на управляващия софтуер"
 
+#: ../wxui/main.py:1061
 msgid "Upload to radio"
 msgstr "Изпращане към станция"
 
+#: ../wxui/main.py:874
 msgid "Upload to radio..."
 msgstr "Изпращане към станция…"
 
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Изпратен е запис № %s"
 
+#: ../wxui/memedit.py:1282
 msgid "Use TX Frequency Workflow"
 msgstr ""
 
+#: ../wxui/main.py:830
 msgid "Use fixed-width font"
 msgstr "Равноширок шрифт"
 
+#: ../wxui/main.py:838
 msgid "Use larger font"
 msgstr "По-едър шрифт"
 
+#: ../wxui/bugreport.py:249
 msgid "Username"
 msgstr "Потребител"
 
+#: ../wxui/developer.py:313
 #, python-format
 msgid "Value does not fit in %i bits"
 msgstr "Стойността не се побира в %i бита"
 
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Стойността трябва да бъде най-малко %.4f"
 
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Стойността трябва да бъде най-много %.4f"
 
+#: ../wxui/developer.py:357
 #, python-format
 msgid "Value must be exactly %i decimal digits"
 msgstr "Стойността трябва да бъде точно %i цифри"
 
+#: ../wxui/developer.py:311 ../wxui/developer.py:355
 msgid "Value must be zero or greater"
 msgstr "Стойността трябва да бъде нула или повече"
 
+#: ../wxui/memquery.py:206
 msgid "Value to search memory field for"
 msgstr "Стойност, която търсите в запис в паметта"
 
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr "Стойности"
 
+#: ../wxui/clone.py:350
 msgid "Vendor"
 msgstr "Производител"
 
+#: ../wxui/main.py:1022
 msgid "View"
 msgstr "Изглед"
 
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr "ВНИМАНИЕ!"
 
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr "Внимание"
 
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr "Внимание: %s"
 
+#: ../wxui/main.py:460
 msgid "Welcome"
 msgstr "Добре дошли"
 
+#: ../wxui/query_sources.py:417
 msgid "With this option checked, a proximity search will include cached results from other localities if they are in range, match other filter parameters, and have been downloaded before."
 msgstr ""
 
+#: ../wxui/__init__.py:58
 msgid "Would you like CHIRP to install a desktop icon for you?"
 msgstr "Желаете ли пряк път към CHIRP на работния плот?"
 
+#: ../wxui/bugreport.py:309
 msgid "You have opened multiple issues within the last week. CHIRP limits the number of issues you can open to avoid abuse. If you really need to open another, please do so via the website."
 msgstr "През изминалите седем дена сте докладвали няколко дефекта. С цел предотвратяване на злоупотреби CHIRP ограничава броя на докладите през приложението. Ако трябва да докладвате нов дефект го направете през страницата."
 
+#: ../wxui/clone.py:520
 msgid "Your Prolific-based USB device will not work without reverting to an older version of the driver. Visit the CHIRP website to read more about how to resolve this?"
 msgstr "USB устройството от Prolific няма да работи преди да върнете по-предно издание на управляващия софтуер. Посещаване страницата на CHIRP, за да прочетете как да решите този проблем?"
 
+#: ../wxui/query_sources.py:830
 msgid "Your QTH Locator"
 msgstr ""
 
+#: ../wxui/clone.py:507
 msgid "Your cable appears to be on port:"
 msgstr "Изглежда кабелът е включен в порт:"
 
+#: ../wxui/developer.py:193
 msgid "bits"
 msgstr "бита"
 
+#: ../wxui/developer.py:189
 msgid "bytes"
 msgstr "байта"
 
+#: ../wxui/developer.py:184
 msgid "bytes each"
 msgstr "байта всеки"
 
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr "изключен"
 
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr "включен"
 
+#: ../drivers/vx5.py:116
 #, python-brace-format
 msgid "{bank} is full"
 msgstr "{bank} е пълна"
 
 # added by hand
-msgid "&Close"
-msgstr "&Затваряне"
+#~ msgid "&Close"
+#~ msgstr "&Затваряне"
 
-msgid "&Copy"
-msgstr "&Копиране"
+#~ msgid "&Copy"
+#~ msgstr "&Копиране"
 
-msgid "&Delete"
-msgstr "Премахва&не"
+#~ msgid "&Delete"
+#~ msgstr "Премахва&не"
 
-msgid "&Edit"
-msgstr "П&роменяне"
+#~ msgid "&Edit"
+#~ msgstr "П&роменяне"
 
-msgid "&File"
-msgstr "&Файл"
+#~ msgid "&File"
+#~ msgstr "&Файл"
 
-msgid "&New"
-msgstr "&Нов"
+#~ msgid "&New"
+#~ msgstr "&Нов"
 
-msgid "&Open..."
-msgstr "&Отваряне…"
+#~ msgid "&Open..."
+#~ msgstr "&Отваряне…"
 
-msgid "&Paste"
-msgstr "&Поставяне"
+#~ msgid "&Paste"
+#~ msgstr "&Поставяне"
 
-msgid "&Print..."
-msgstr "От&печатване…"
+#~ msgid "&Print..."
+#~ msgstr "От&печатване…"
 
-msgid "&Quit"
-msgstr "Из&ход"
+#~ msgid "&Quit"
+#~ msgstr "Из&ход"
 
-msgid "&Save"
-msgstr "&Запазване"
+#~ msgid "&Save"
+#~ msgstr "&Запазване"
 
-msgid "Bank 1"
-msgstr "Банка № 1"
+#~ msgid "Bank 1"
+#~ msgstr "Банка № 1"
 
-msgid "Bank 10"
-msgstr "Банка № 10"
+#~ msgid "Bank 10"
+#~ msgstr "Банка № 10"
 
-msgid "Bank 2"
-msgstr "Банка № 2"
+#~ msgid "Bank 2"
+#~ msgstr "Банка № 2"
 
-msgid "Bank 3"
-msgstr "Банка № 3"
+#~ msgid "Bank 3"
+#~ msgstr "Банка № 3"
 
-msgid "Bank 4"
-msgstr "Банка № 4"
+#~ msgid "Bank 4"
+#~ msgstr "Банка № 4"
 
-msgid "Bank 5"
-msgstr "Банка № 5"
+#~ msgid "Bank 5"
+#~ msgstr "Банка № 5"
 
-msgid "Bank 6"
-msgstr "Банка № 6"
+#~ msgid "Bank 6"
+#~ msgstr "Банка № 6"
 
-msgid "Bank 7"
-msgstr "Банка № 7"
+#~ msgid "Bank 7"
+#~ msgstr "Банка № 7"
 
-msgid "Bank 8"
-msgstr "Банка № 8"
+#~ msgid "Bank 8"
+#~ msgstr "Банка № 8"
 
-msgid "Bank 9"
-msgstr "Банка № 9"
+#~ msgid "Bank 9"
+#~ msgstr "Банка № 9"
 
-msgid "Cancel"
-msgstr "Отказ"
+#~ msgid "Cancel"
+#~ msgstr "Отказ"
 
-msgid "Cu&t"
-msgstr "&Изрязване"
+#~ msgid "Cu&t"
+#~ msgstr "&Изрязване"
 
-msgid "Name"
-msgstr "Име"
+#~ msgid "Name"
+#~ msgstr "Име"
 
-msgid "OK"
-msgstr "Добре"
+#~ msgid "OK"
+#~ msgstr "Добре"
 
-msgid "Save &As..."
-msgstr "Запазване &копие…"
+#~ msgid "Save &As..."
+#~ msgstr "Запазване &копие…"
 
-msgid "Select &All"
-msgstr "Избор &всички"
+#~ msgid "Select &All"
+#~ msgstr "Избор &всички"
 
-msgid "Squelch override"
-msgstr "Отменяне шумопод."
+#~ msgid "Squelch override"
+#~ msgstr "Отменяне шумопод."
 
-msgid "Status"
-msgstr "Състояние"
+#~ msgid "Status"
+#~ msgstr "Състояние"
 
-msgid "Yes"
-msgstr "Да"
+#~ msgid "Yes"
+#~ msgstr "Да"

--- a/chirp/locale/de.po
+++ b/chirp/locale/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2012-10-02 22:11+0100\n"
 "Last-Translator: Benjamin, HB9EUK <hb9euk@hb9d.org>\n"
 "Language-Team: German\n"
@@ -24,21 +24,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Löschen (und nach oben verschieben)"
 msgstr[1] "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Speicher"
 msgstr[1] "Speicher"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -70,7 +70,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -545,7 +545,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -555,7 +555,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -565,7 +565,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -573,7 +573,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the key to send image.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -659,7 +659,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr ""
 
@@ -675,7 +675,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -700,8 +700,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Ein Fehler ist aufgetreten"
 
@@ -718,7 +717,7 @@ msgstr "Automatischer Repeater-Offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr ""
 
@@ -773,11 +772,11 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -790,17 +789,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross Mode"
@@ -814,7 +813,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "Cross Mode"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr ""
 
@@ -827,8 +826,12 @@ msgstr "Importieren von:"
 msgid "City"
 msgstr ""
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -845,23 +848,23 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Klonen"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Download vom Gerät"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Upload zum Gerät"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr ""
 
@@ -877,7 +880,7 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -911,11 +914,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Kopieren"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -937,11 +940,11 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Ausschneiden"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -962,11 +965,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr ""
 
@@ -975,11 +978,11 @@ msgstr ""
 msgid "Dec"
 msgstr "Erkennung"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Löschen"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -993,20 +996,20 @@ msgstr "Abrufen der Speicherbank"
 msgid "Developer Mode"
 msgstr "Entwickler"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Digital Code"
 
@@ -1015,7 +1018,7 @@ msgstr "Digital Code"
 msgid "Digital Modes"
 msgstr "Digital Code"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr ""
 
@@ -1056,12 +1059,12 @@ msgstr "Download vom Gerät"
 msgid "Download from radio..."
 msgstr "Download vom Gerät"
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 #, fuzzy
 msgid "Download instructions"
 msgstr "Download vom Gerät"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr ""
 
@@ -1081,17 +1084,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1110,11 +1113,11 @@ msgstr "Aktiviert"
 msgid "Enter Frequency"
 msgstr "Frequenz"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1147,7 +1150,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "Lösche Speicher {loc}"
@@ -1162,7 +1165,7 @@ msgstr "Fehler beim Setzen der Speicher"
 msgid "Error applying settings"
 msgstr "Fehler beim Setzen der Speicher"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr ""
 
@@ -1202,12 +1205,12 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 #, fuzzy
 msgid "Experimental driver"
 msgstr "Weiter mit dem experimentellen Treiber?"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1221,7 +1224,7 @@ msgstr "In Datei exportieren"
 msgid "Export to CSV..."
 msgstr "In Datei exportieren"
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr ""
 
@@ -1248,8 +1251,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr ""
 
@@ -1316,7 +1319,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1359,11 +1362,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1429,7 +1432,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1456,7 +1459,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1474,11 +1477,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1514,17 +1517,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -1585,7 +1588,7 @@ msgstr ""
 msgid "Import"
 msgstr "Importieren"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1615,11 +1618,11 @@ msgstr "Index"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Zeile oben einfügen"
@@ -1632,7 +1635,7 @@ msgstr ""
 msgid "Interact with driver"
 msgstr ""
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 #, fuzzy
 msgid "Internal driver error"
 msgstr "Interner Fehler"
@@ -1642,8 +1645,8 @@ msgstr "Interner Fehler"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ungültiger Wert. Muss eine ganze Zahl sein."
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ungültiger Wert für dieses Feld"
@@ -1652,7 +1655,7 @@ msgstr "Ungültiger Wert für dieses Feld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1679,7 +1682,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 #, fuzzy
 msgid "Language"
 msgstr "Sprache wählen"
@@ -1740,7 +1743,7 @@ msgstr "Module laden"
 msgid "Load module from issue..."
 msgstr "Module laden"
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
@@ -1773,7 +1776,7 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -1786,7 +1789,7 @@ msgstr "Speicher"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1809,8 +1812,8 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1834,11 +1837,11 @@ msgstr "Module laden"
 msgid "Module Loaded"
 msgstr "Module laden"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr ""
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr ""
 
@@ -1847,7 +1850,7 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -1862,7 +1865,7 @@ msgstr "Nach _Unten"
 msgid "Move Up"
 msgstr "Nach _Oben"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1870,12 +1873,12 @@ msgstr ""
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 #, fuzzy
 msgid "New version available"
 msgstr "Eine neue Version von CHIRP ist verfügbar:"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Zeile unten einfügen"
@@ -1894,20 +1897,20 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr ""
 
@@ -2027,7 +2030,7 @@ msgstr "Optionen"
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Überschreiben?"
@@ -2039,8 +2042,8 @@ msgid ""
 "are supported in this release.\n"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr ""
 
@@ -2048,39 +2051,39 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Einfügen"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -2114,11 +2117,11 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr ""
 
@@ -2159,7 +2162,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr ""
 
@@ -2175,7 +2178,7 @@ msgstr ""
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr ""
@@ -2197,8 +2200,8 @@ msgstr ""
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr ""
 
@@ -2215,7 +2218,7 @@ msgstr "Gerät"
 msgid "Radio did not ack block %i"
 msgstr ""
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 #, fuzzy
 msgid "Radio information"
 msgstr "Abrufen der Speicherbank"
@@ -2266,11 +2269,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
@@ -2320,11 +2323,11 @@ msgstr "Report ist deaktiviert"
 msgid "Reporting enabled"
 msgstr "Report ist deaktiviert"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr ""
 
@@ -2343,7 +2346,7 @@ msgstr ""
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr ""
 
@@ -2359,7 +2362,7 @@ msgstr ""
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 #, fuzzy
 msgid "Saved settings"
 msgstr "Einstellungen"
@@ -2372,7 +2375,7 @@ msgstr ""
 msgid "Scanlists"
 msgstr ""
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr ""
 
@@ -2401,7 +2404,7 @@ msgstr "Spalten auswählen"
 msgid "Select Modes"
 msgstr "Spalten auswählen"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr ""
 
@@ -2430,7 +2433,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Zeige RAW Speicher"
 
@@ -2450,52 +2453,52 @@ msgstr ""
 msgid "Skip"
 msgstr "Überspringen"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Eingefügter Speicher {number} ist nicht mit diesem Gerät kompatibel weil:"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Vergleiche Rohspeicher"
 msgstr[1] "Vergleiche Rohspeicher"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 #, fuzzy
 msgid "Sort memories"
 msgstr "Überschreiben?"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 #, fuzzy
 msgid "Sorting"
 msgstr "Einstellungen"
@@ -2508,7 +2511,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr ""
 
@@ -2581,7 +2584,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 #, fuzzy
 msgid "This Memory"
 msgstr "Zeige RAW Speicher"
@@ -2636,12 +2639,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Löschen (und nach oben verschieben)"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Löschen (und nach oben verschieben)"
@@ -2731,7 +2734,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2740,18 +2743,18 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr "Speichervorgaben öffnen"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Kann Gerät auf {port} nicht erkennen"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "Kann Gerät auf {port} nicht erkennen"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr ""
 
@@ -2759,7 +2762,7 @@ msgstr ""
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr ""
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Keine Änderungen bei diesem Modell möglich"
@@ -2800,7 +2803,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr "Updating URCALL Liste"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr ""
 
@@ -2818,7 +2821,7 @@ msgstr "Upload zum Gerät"
 msgid "Upload to radio..."
 msgstr "Upload zum Gerät"
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
@@ -2844,12 +2847,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2867,7 +2870,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr ""
 
@@ -2880,15 +2883,15 @@ msgstr "Hersteller"
 msgid "View"
 msgstr "_Ansicht"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2933,12 +2936,12 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 #, fuzzy
 msgid "disabled"
 msgstr "Aktiviert"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 #, fuzzy
 msgid "enabled"
 msgstr "Aktiviert"

--- a/chirp/locale/el.po
+++ b/chirp/locale/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2023-02-11 15:12+0200\n"
 "Last-Translator: Sokratis Alichanidis <sv2hzs@posteo.net>\n"
 "Language-Team: Greek\n"
@@ -26,21 +26,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 msgstr[1] "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Μνήμες"
 msgstr[1] "Μνήμες"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -72,7 +72,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(καμία)"
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -547,7 +547,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -557,7 +557,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -567,7 +567,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -575,7 +575,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the key to send image.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -661,7 +661,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "Μία νέα έκδοση του CHIRP είναι διαθέσιμη. Παρακαλούμε επισκεφθείτε την ιστοσελίδα το συντομότερο δυνατό για να την κατεβάσετε!"
 
@@ -677,7 +677,7 @@ msgstr "Σχετικά"
 msgid "About CHIRP"
 msgstr "Σχετικά με το CHIRP"
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -701,8 +701,7 @@ msgstr ""
 msgid "Amateur"
 msgstr "Ραδιοερασιτέχνη"
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Παρουσιάστηκε ένα σφάλμα"
 
@@ -718,7 +717,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "Χάρτης συχνοτήτων"
 
@@ -775,11 +774,11 @@ msgstr ""
 msgid "Canada"
 msgstr "Καναδάς"
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -792,17 +791,17 @@ msgstr "Αρχεία ειδώλου CHIRP"
 msgid "Choice Required"
 msgstr "Απαιτείται επιλογή"
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Επιλέξτε κωδικό DTCS %s"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Επιλέξτε τόνο %s"
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr ""
 
@@ -815,7 +814,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "Επιλέξτε κωδικό DTCS %s"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 #, fuzzy
 msgid "Choose duplex"
 msgstr "Επιλογή duplex"
@@ -829,8 +828,12 @@ msgstr ""
 msgid "City"
 msgstr "Πόλη"
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -847,21 +850,21 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Αντιγραφή"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr "Λήψη από πομποδέκτη"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr "Αποστολή σε πομποδέκτη"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "Κλείσιμο"
 
@@ -878,7 +881,7 @@ msgstr "Κλείσιμο αρχείου"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -911,11 +914,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr ""
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -938,12 +941,12 @@ msgstr "Εισάγετε προσαρμοσμένη θύρα:"
 msgid "Custom..."
 msgstr "Προσαρμοσμένη..."
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 #, fuzzy
 msgid "Cut"
 msgstr "Χώρα"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -964,11 +967,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr "Μνήμη DV"
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr ""
 
@@ -976,11 +979,11 @@ msgstr ""
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Διαγραφή"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -993,20 +996,20 @@ msgstr "Πληροφορίες πομποδέκτη"
 msgid "Developer Mode"
 msgstr "Λειτουργία προγραμματιστή"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 #, fuzzy
 msgid "Digital Code"
 msgstr "Ψηφιακός Κωδικός"
@@ -1016,7 +1019,7 @@ msgstr "Ψηφιακός Κωδικός"
 msgid "Digital Modes"
 msgstr "Ψηφιακός Κωδικός"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 #, fuzzy
 msgid "Disable reporting"
 msgstr "Αναφορές απενεργοποιημένες"
@@ -1056,11 +1059,11 @@ msgstr "Λήψη Από Πομποδέκτη"
 msgid "Download from radio..."
 msgstr "Λήψη Από Πομποδέκτη"
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "Οδηγίες λήψης"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 #, fuzzy
 msgid "Driver"
 msgstr "Επαναφόρτωση Οδηγού"
@@ -1081,17 +1084,17 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Επεξεργασία λεπτομερειών για %i μνήμες"
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Επεξεργασία λεπτομερειών για τη μνήμη %i"
@@ -1109,11 +1112,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Εισάγετε συχνότητα"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr "Εισάγετε συχνότητα εκπομπής (MHz)"
 
@@ -1146,7 +1149,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr "Διεγράφη η μνήμη %s"
@@ -1160,7 +1163,7 @@ msgstr "Σφάλμα εφαρμογής ρυθμίσεων"
 msgid "Error applying settings"
 msgstr "Σφάλμα εφαρμογής ρυθμίσεων"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "Σφάλμα επικοινωνίας με τον πομποδέκτη"
 
@@ -1200,11 +1203,11 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "Πειραματικός οδηγός"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr "Η εξαγωγή είναι δυνατή μόνο σε αρχεία CSV"
 
@@ -1217,7 +1220,7 @@ msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 msgid "Export to CSV..."
 msgstr "Εξαγωγή σε αρχείο μορφής .CSV"
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr "Περισσότερα"
 
@@ -1244,8 +1247,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr "Αδυναμία φόρτωσης περιηγητή πομποδεκτών"
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 #, fuzzy
 msgid "Failed to parse result"
 msgstr "Αδυναμία φόρτωσης περιηγητή πομποδεκτών"
@@ -1312,7 +1315,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Τελείωσε η εργασία %s"
@@ -1355,11 +1358,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1425,7 +1428,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1452,7 +1455,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1470,11 +1473,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1510,17 +1513,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -1581,7 +1584,7 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1610,11 +1613,11 @@ msgstr ""
 msgid "Info"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr "Πληροφορίες"
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr "Εισαγωγή γραμμής επάνω"
 
@@ -1627,7 +1630,7 @@ msgstr ""
 msgid "Interact with driver"
 msgstr "Αλληλεπίδραση με οδηγό"
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 #, fuzzy
 msgid "Internal driver error"
 msgstr "Αλληλεπίδραση με οδηγό"
@@ -1637,8 +1640,8 @@ msgstr "Αλληλεπίδραση με οδηγό"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Μη έγκυρη τιμή: %s"
@@ -1647,7 +1650,7 @@ msgstr "Μη έγκυρη τιμή: %s"
 msgid "Invalid ZIP code"
 msgstr "Μη έγκυρος ΤΚ"
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Μη έγκυρη τιμή: %s"
@@ -1675,7 +1678,7 @@ msgstr ""
 msgid "LIVE"
 msgstr "LIVE"
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 msgid "Language"
 msgstr ""
 
@@ -1738,7 +1741,7 @@ msgstr "Φόρτωση Module"
 msgid "Load module from issue..."
 msgstr "Φόρτωση Module"
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
@@ -1771,7 +1774,7 @@ msgstr ""
 msgid "Longitude"
 msgstr "Γεωγραφικό μήκος"
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -1784,7 +1787,7 @@ msgstr "Μνήμες"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Η μνήμη %i δεν μπορεί να διαγραφεί"
@@ -1807,8 +1810,8 @@ msgstr "Η μνήμη πρέπει να βρίσκεται σε ομάδα γι�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Η μνήμη {num} δεν βρίσκεται στην ομάδα μνημών {bank}"
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 #, fuzzy
 msgid "Mode"
 msgstr "Λειτουργία"
@@ -1830,11 +1833,11 @@ msgstr "Module"
 msgid "Module Loaded"
 msgstr "Module"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr ""
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 #, fuzzy
 msgid "More Info"
 msgstr "Πληροφορίες"
@@ -1844,7 +1847,7 @@ msgstr "Πληροφορίες"
 msgid "More than one port found: %s"
 msgstr "Βρέθηκαν περισσότερες από μία θύρες: %s"
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -1857,7 +1860,7 @@ msgstr ""
 msgid "Move Up"
 msgstr ""
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1865,11 +1868,11 @@ msgstr ""
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "Διαθέσιμη νέα έκδοση"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr "Καμία κενή σειρά από κάτω!"
 
@@ -1887,21 +1890,21 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 #, fuzzy
 msgid "No results"
 msgstr "Κανένα αποτέλεσμα!"
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr "Κανένα αποτέλεσμα!"
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr "Αριθμός"
 
@@ -2020,7 +2023,7 @@ msgstr "Προαιρετικό: -122.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Προαιρετικό: Επαρχία, Νοσοκομείο κλπ"
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 msgid "Overwrite memories?"
 msgstr "Αντικατάσταση μνημών;"
 
@@ -2031,8 +2034,8 @@ msgid ""
 "are supported in this release.\n"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr ""
 
@@ -2040,39 +2043,39 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr ""
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Παρακαλούμε βεβαιωθείτε ότι έχετε κλείσει το CHIRP πριν εγκαταστήσετε την νέα έκδοση!"
 
@@ -2106,11 +2109,11 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "Παρακαλώ περιμένετε"
 
@@ -2150,7 +2153,7 @@ msgstr "Εκτύπωση"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr "Ιδιότητες"
 
@@ -2168,7 +2171,7 @@ msgstr "Ιδιότητες"
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr "Ερώτημα %s"
@@ -2190,8 +2193,8 @@ msgstr "Ερώτημα %s"
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 #, fuzzy
 msgid "Querying"
 msgstr "Ερώτημα %s"
@@ -2209,7 +2212,7 @@ msgstr "Πομποδέκτης"
 msgid "Radio did not ack block %i"
 msgstr "Ο πομποδέκτης δεν επιβεβαίωσε το μπλοκ %i"
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr "Πληροφορίες πομποδέκτη"
 
@@ -2259,12 +2262,12 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 #, fuzzy
 msgid "Refresh required"
 msgstr "Απαιτείται επανεκκίνηση"
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Ανανεώθηκε η μνήμη %s"
@@ -2313,11 +2316,11 @@ msgstr "Αναφορές ενεργοποιημένες"
 msgid "Reporting enabled"
 msgstr "Αναφορές ενεργοποιημένες"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "Απαιτείται επανεκκίνηση"
 
@@ -2337,7 +2340,7 @@ msgstr "Επαναφορά %i καρτελών"
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "Ρυθμίσεις ανακτήθηκαν"
 
@@ -2353,7 +2356,7 @@ msgstr "Αποθήκευση πριν το κλείσιμο;"
 msgid "Save file"
 msgstr "Αποθήκευση αρχείου"
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "Ρυθμίσεις αποθηκεύθηκαν"
 
@@ -2365,7 +2368,7 @@ msgstr ""
 msgid "Scanlists"
 msgstr ""
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr ""
 
@@ -2392,7 +2395,7 @@ msgstr "Επιλογή Μπαντών"
 msgid "Select Modes"
 msgstr ""
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "Επιλογή χάρτη συνοτήτων"
 
@@ -2420,7 +2423,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr ""
 
@@ -2441,51 +2444,51 @@ msgstr "Εμφάνιση τοποθεσίας αρχείου καταγραφή�
 msgid "Skip"
 msgstr ""
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr "Κάποιες μνήμες δεν είναι συμβατές με αυτόν τον πομποδέκτη"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr "Κάποιες μνήμες δεν είναι δυνατόν να διαγραφούν"
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Διαγραφή %i Μνημών"
 msgstr[1] "Διαγραφή %i Μνημών"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 #, fuzzy
 msgid "Sort memories"
 msgstr "Αντικατάσταση μνημών;"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 #, fuzzy
 msgid "Sorting"
 msgstr "Εκτύπωση"
@@ -2498,7 +2501,7 @@ msgstr "Πολιτεία"
 msgid "State/Province"
 msgstr "Πολιτεία / Επαρχία"
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr ""
 
@@ -2571,7 +2574,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 #, fuzzy
 msgid "This Memory"
 msgstr "Μνήμη DV"
@@ -2630,12 +2633,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση όλων προς τα επάνω"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Διαγραφή %i μνημών και μετακίνηση ομάδας προς τα επάνω"
@@ -2723,7 +2726,7 @@ msgstr "Έυρεση θυρών USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2732,17 +2735,17 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Αδυναμία ανοίγματος του πρόχειρου"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr "Αδυναμία ανοίγματος του πρόχειρου"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr ""
 
@@ -2750,7 +2753,7 @@ msgstr ""
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr ""
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
@@ -2791,7 +2794,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr ""
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "Οδηγίες αποστολής"
 
@@ -2808,7 +2811,7 @@ msgstr "Αποστολή Σε Πομποδέκτη"
 msgid "Upload to radio..."
 msgstr "Αποστολή Σε Πομποδέκτη"
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Απεστάλη η μνήμη %s"
@@ -2834,12 +2837,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr "Η τιμή δεν χωράει σε %i bits"
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Η τιμή πρέπει να είναι τουλάχιστον %.4f"
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Η τιμή πρέπει να είναι το πολύ  %.4f"
@@ -2857,7 +2860,7 @@ msgstr "Η τιμή πρέπει να είναι μηδέν ή μεγαλύτε�
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr ""
 
@@ -2869,15 +2872,15 @@ msgstr "Προμηθευτής"
 msgid "View"
 msgstr "Εμφάνιση"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr "Προειδοποίηση"
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr "Προειδοποίηση: %s"
@@ -2922,11 +2925,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "bytes το καθένα"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/en_US.po
+++ b/chirp/locale/en_US.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2011-11-29 16:07-0800\n"
 "Last-Translator: Dan Smith <dan@theine>\n"
 "Language-Team: English\n"
@@ -22,21 +22,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "_Delete"
 msgstr[1] "_Delete"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -68,7 +68,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -543,7 +543,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -553,7 +553,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -563,7 +563,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -571,7 +571,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the key to send image.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -657,7 +657,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -698,8 +698,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr ""
 
@@ -716,7 +715,7 @@ msgstr "Automatic Repeater Offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr ""
 
@@ -771,11 +770,11 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -788,17 +787,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr ""
 
@@ -810,7 +809,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr ""
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr ""
 
@@ -823,8 +822,12 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -841,23 +844,23 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr ""
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Download From Radio"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Upload To Radio"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr ""
 
@@ -873,7 +876,7 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -906,12 +909,12 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 #, fuzzy
 msgid "Copy"
 msgstr "_Copy"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -932,12 +935,12 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 #, fuzzy
 msgid "Cut"
 msgstr "_Cut"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -956,11 +959,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr ""
 
@@ -968,12 +971,12 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 #, fuzzy
 msgid "Delete"
 msgstr "_Delete"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -986,21 +989,21 @@ msgstr ""
 msgid "Developer Mode"
 msgstr "Developer"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Diff raw memories"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr ""
 
@@ -1008,7 +1011,7 @@ msgstr ""
 msgid "Digital Modes"
 msgstr ""
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr ""
 
@@ -1048,12 +1051,12 @@ msgstr "Download From Radio"
 msgid "Download from radio..."
 msgstr "Download From Radio"
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 #, fuzzy
 msgid "Download instructions"
 msgstr "Download From Radio"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr ""
 
@@ -1073,17 +1076,17 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1100,11 +1103,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr ""
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1137,7 +1140,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "E_xchange"
@@ -1150,7 +1153,7 @@ msgstr ""
 msgid "Error applying settings"
 msgstr ""
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr ""
 
@@ -1190,11 +1193,11 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1208,7 +1211,7 @@ msgstr "Import from RFinder"
 msgid "Export to CSV..."
 msgstr "Import from RFinder"
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr ""
 
@@ -1235,8 +1238,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr ""
 
@@ -1300,7 +1303,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1343,11 +1346,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1413,7 +1416,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1440,7 +1443,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1458,11 +1461,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1498,17 +1501,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -1569,7 +1572,7 @@ msgstr ""
 msgid "Import"
 msgstr "Import"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1600,11 +1603,11 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr ""
 
@@ -1616,7 +1619,7 @@ msgstr ""
 msgid "Interact with driver"
 msgstr ""
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 msgid "Internal driver error"
 msgstr ""
 
@@ -1625,8 +1628,8 @@ msgstr ""
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1634,7 +1637,7 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1660,7 +1663,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 msgid "Language"
 msgstr ""
 
@@ -1717,7 +1720,7 @@ msgstr ""
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
@@ -1750,7 +1753,7 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -1764,7 +1767,7 @@ msgstr "Diff raw memories"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1787,8 +1790,8 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 msgid "Mode"
 msgstr ""
 
@@ -1808,11 +1811,11 @@ msgstr ""
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr ""
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr ""
 
@@ -1821,7 +1824,7 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -1836,7 +1839,7 @@ msgstr "Move D_n"
 msgid "Move Up"
 msgstr "Move _Up"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1844,11 +1847,11 @@ msgstr ""
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr ""
 
@@ -1866,20 +1869,20 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr ""
 
@@ -1993,7 +1996,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Diff raw memories"
@@ -2005,8 +2008,8 @@ msgid ""
 "are supported in this release.\n"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr ""
 
@@ -2014,40 +2017,40 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 #, fuzzy
 msgid "Paste"
 msgstr "_Paste"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -2081,11 +2084,11 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr ""
 
@@ -2125,7 +2128,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr ""
 
@@ -2141,7 +2144,7 @@ msgstr ""
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr ""
@@ -2162,8 +2165,8 @@ msgstr ""
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr ""
 
@@ -2181,7 +2184,7 @@ msgstr "_Radio"
 msgid "Radio did not ack block %i"
 msgstr ""
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr ""
 
@@ -2230,11 +2233,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
@@ -2283,11 +2286,11 @@ msgstr "Reporting is disabled"
 msgid "Reporting enabled"
 msgstr "Reporting is disabled"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr ""
 
@@ -2306,7 +2309,7 @@ msgstr ""
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr ""
 
@@ -2322,7 +2325,7 @@ msgstr ""
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr ""
 
@@ -2334,7 +2337,7 @@ msgstr ""
 msgid "Scanlists"
 msgstr ""
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr ""
 
@@ -2363,7 +2366,7 @@ msgstr "Select Columns"
 msgid "Select Modes"
 msgstr "Select Columns"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr ""
 
@@ -2392,7 +2395,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Show raw memory"
@@ -2413,51 +2416,51 @@ msgstr ""
 msgid "Skip"
 msgstr ""
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff raw memories"
 msgstr[1] "Diff raw memories"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 #, fuzzy
 msgid "Sort memories"
 msgstr "Diff raw memories"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr ""
 
@@ -2469,7 +2472,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr ""
 
@@ -2542,7 +2545,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 #, fuzzy
 msgid "This Memory"
 msgstr "Show raw memory"
@@ -2597,12 +2600,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "_Delete"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "_Delete"
@@ -2689,7 +2692,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2698,16 +2701,16 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 msgid "Unable to import while the view is sorted"
 msgstr ""
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr ""
 
@@ -2715,7 +2718,7 @@ msgstr ""
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr ""
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
@@ -2755,7 +2758,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr ""
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr ""
 
@@ -2773,7 +2776,7 @@ msgstr "Upload To Radio"
 msgid "Upload to radio..."
 msgstr "Upload To Radio"
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
@@ -2799,12 +2802,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2822,7 +2825,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr ""
 
@@ -2835,15 +2838,15 @@ msgstr ""
 msgid "View"
 msgstr "_View"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2888,11 +2891,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/es.po
+++ b/chirp/locale/es.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2025-03-26 13:21-0300\n"
 "Last-Translator: MELERIX\n"
 "Language-Team: \n"
@@ -25,21 +25,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s debe estar entre %(min)i y %(max)i"
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Memoria y desplazar todo hacia arriba"
 msgstr[1] "%i Memorias y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Memoria"
 msgstr[1] "%i Memorias"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -71,7 +71,7 @@ msgstr "(¿Ha funcionado esto antes? ¿Radio nueva? ¿Funciona con el software O
 msgid "(none)"
 msgstr "(nada)"
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr "...y %i más"
@@ -829,7 +829,7 @@ msgstr ""
 "5. Asegúrate de que la radio esté sintonizada a un canal sin actividad.\n"
 "6. Cliquea Aceptar para cargar la imagen al dispositivo.\n"
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -845,7 +845,7 @@ msgstr ""
 "5. Asegúrate de que la radio esté sintonizada a un canal sin actividad.\n"
 "6. Cliquea Aceptar para descargar la imagen desde dispositivo.\n"
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -861,7 +861,7 @@ msgstr ""
 "5. Asegúrate de que la radio esté sintonizada a un canal sin actividad.\n"
 "6. Cliquea Aceptar para cargar la imagen al dispositivo.\n"
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -873,7 +873,7 @@ msgstr ""
 "3. Prepara la radio para clonar.\n"
 "4. <b>Después de cliquear Aceptar</b>, presiona la tecla para enviar la imagen.\n"
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -1009,7 +1009,7 @@ msgstr ""
 "\n"
 "Esto podría no funcionar si enciendes la radio con el cable ya conectado"
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "Una nueva versión de CHIRP está disponible, ¡Por favor visita el sitio web tan pronto como sea posible para descargarla!"
 
@@ -1025,7 +1025,7 @@ msgstr "Acerca de"
 msgid "About CHIRP"
 msgstr "Acerca de CHIRP"
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr "De acuerdo"
 
@@ -1049,8 +1049,7 @@ msgstr "Siempre iniciar con la lista reciente"
 msgid "Amateur"
 msgstr "Aficionado"
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Ha ocurrido un error"
 
@@ -1066,7 +1065,7 @@ msgstr "Automático del sistema"
 msgid "Available modules"
 msgstr "Módulos disponibles"
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "Plan de banda"
 
@@ -1121,11 +1120,11 @@ msgstr "Los resultados en caché solo pueden ser incluidos para una consulta de 
 msgid "Canada"
 msgstr "Canada"
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Cambiar este ajuste requiere actualizar los ajustes desde la imagen, lo cual ocurrirá ahora."
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Canales con TX y RX equivalentes %s son representados por modo de tono de \"%s\""
@@ -1138,17 +1137,17 @@ msgstr "Archivos de imagen Chirp"
 msgid "Choice Required"
 msgstr "Elección requerida"
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Elegir %s código DTCS"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Elegir %s tono"
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr "Elegir modo cruzado"
 
@@ -1160,7 +1159,7 @@ msgstr "Elige el objetivo de diferencia"
 msgid "Choose a recent model"
 msgstr "Elegir un modelo reciente"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr "Elegir Dúplex"
 
@@ -1173,9 +1172,13 @@ msgstr "Elige el módulo para cargar desde problema %i:"
 msgid "City"
 msgstr "Ciudad"
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
 msgstr "Cliquea aquí para el texto de licencia completo"
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
+msgstr ""
 
 #: ../drivers/ts590.py:671
 msgid ""
@@ -1197,21 +1200,21 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Clonado completado, comprobando por bytes espurios"
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Clonando"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr "Clonando desde radio"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr "Clonando a radio"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "Cerrar"
 
@@ -1227,7 +1230,7 @@ msgstr "Cerrar archivo"
 msgid "Close string value with double-quote (\")"
 msgstr "Cerrar el valor de la cadena con comillas dobles (\")"
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1262,11 +1265,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Convertir a FM"
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr "Copiar portátil"
 
@@ -1287,11 +1290,11 @@ msgstr "Puerto personalizado"
 msgid "Custom..."
 msgstr "Personalizado..."
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr "Cortar %i memorias"
@@ -1312,11 +1315,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Decodificación DTMF"
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr "Memoria DV"
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr "Peligro adelante"
 
@@ -1324,11 +1327,11 @@ msgstr "Peligro adelante"
 msgid "Dec"
 msgstr "Decimal"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Borrar"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr "Borrar memorias"
 
@@ -1340,20 +1343,20 @@ msgstr "Información detallada"
 msgid "Developer Mode"
 msgstr "Modo desarrollador"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Estado de desarrollador ahora está %s. CHIRP debe ser reiniciado para que tome efecto"
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Diferenciar memorias en bruto"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr "Diferenciar contra otro editor"
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Código digital"
 
@@ -1361,7 +1364,7 @@ msgstr "Código digital"
 msgid "Digital Modes"
 msgstr "Modos digitales"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr "Deshabilitar reportes"
 
@@ -1399,11 +1402,11 @@ msgstr "Descargar desde radio"
 msgid "Download from radio..."
 msgstr "Descargar desde radio..."
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "Descargar instrucciones"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr "Controlador"
 
@@ -1423,17 +1426,17 @@ msgstr "Los repetidores digitales de modo dual que soportan análogo se mostrar�
 msgid "Duplex"
 msgstr "Dúplex"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr "Editar %i memorias"
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Editar detalles para %i memorias"
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editar detalles para memoria %i"
@@ -1450,11 +1453,11 @@ msgstr "Habilitado"
 msgid "Enter Frequency"
 msgstr "Ingresar frecuencia"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr "Ingresar desplazamiento (MHz)"
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr "Ingresar frecuencia TX (MHz)"
 
@@ -1487,7 +1490,7 @@ msgstr "Ingresa el numero de error que debe ser actualizado"
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr "Ingresar tu nombre de usuario y contraseña para chirpmyradio.com. Si no tienes una cuenta cliquea debajo para crear una antes de proceder."
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr "Memoria borrada %s"
@@ -1500,7 +1503,7 @@ msgstr "Error aplicando filtro"
 msgid "Error applying settings"
 msgstr "Error aplicando ajustes"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "Error comunicándose con la radio"
 
@@ -1540,11 +1543,11 @@ msgstr "Ejemplo: nombre~\"mirepe\""
 msgid "Exclude private and closed repeaters"
 msgstr "Excluir repetidores privados y cerrados"
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "Controlador experimental"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr "Exportar sólo puede escribir archivos CSV"
 
@@ -1556,7 +1559,7 @@ msgstr "Exportar a CSV"
 msgid "Export to CSV..."
 msgstr "Exportar a CSV..."
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr "Extra"
 
@@ -1586,8 +1589,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr "Fallo al cargar navegador de radio"
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr "Fallo al analizar el resultado"
 
@@ -1649,7 +1652,7 @@ msgstr "Finalizar flotante"
 msgid "Finish float value like: 146.52"
 msgstr "Finalizar valor flotante como: 146.52"
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Trabajos de radio terminados %s"
@@ -1714,11 +1717,11 @@ msgstr ""
 "5 - ¡Desconecta el cable de interfaz! ¡De lo contrario no habrá\n"
 "    audio del lado derecho!\n"
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1822,7 +1825,7 @@ msgstr ""
 "    audio del lado derecho!\n"
 "6 - Apaga y enciende la radio para salir del modo de clonación\n"
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1864,7 +1867,7 @@ msgstr ""
 "3 - Enciende tu radio\n"
 "4 - Cliquea Aceptar para iniciar\n"
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1892,11 +1895,11 @@ msgstr ""
 "3 - Enciende tu radio\n"
 "4 - Haz la descarga de tus datos de radio\n"
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1942,17 +1945,17 @@ msgstr "La frecuencia %s está fuera del rango soportado"
 msgid "Frequency granularity in kHz"
 msgstr "Granularidad de frecuencia en kHz"
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr "La frecuencia en este rango no debe ser modo AM"
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr "La frecuencia en este rango requiere modo AM"
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr "La frecuencia fuera de las bandas TX debe ser dúplex=off"
 
@@ -2011,7 +2014,7 @@ msgstr "Si se establece, ordenar los resultados por distancia desde estas coorde
 msgid "Import"
 msgstr "Importar"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr "Importar %i memorias"
@@ -2040,11 +2043,11 @@ msgstr "Índice"
 msgid "Info"
 msgstr "Información"
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr "Información"
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr "Insertar fila arriba"
 
@@ -2056,7 +2059,7 @@ msgstr "¿Instalar icono de escritorio?"
 msgid "Interact with driver"
 msgstr "Interactuar con controlador"
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 msgid "Internal driver error"
 msgstr "Error interno del controlador"
 
@@ -2065,8 +2068,8 @@ msgstr "Error interno del controlador"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s inválido (usa grados decimales)"
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 msgid "Invalid Entry"
 msgstr "Entrada inválida"
 
@@ -2074,7 +2077,7 @@ msgstr "Entrada inválida"
 msgid "Invalid ZIP code"
 msgstr "Código postal inválido"
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Edición inválida: %s"
@@ -2100,7 +2103,7 @@ msgstr "Número de problema:"
 msgid "LIVE"
 msgstr "EN VIVO"
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 msgid "Language"
 msgstr "Lenguaje"
 
@@ -2156,7 +2159,7 @@ msgstr "Cargar módulo desde problema"
 msgid "Load module from issue..."
 msgstr "Cargar módulo desde problema..."
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr "Cargar un módulo no afectará las pestañas abiertas. Se recomienda (a menos que se indique lo contrario) cerrar todas las pestañas antes de cargar un módulo."
 
@@ -2189,7 +2192,7 @@ msgstr "Cadena del logotipo 2 (12 caracteres)"
 msgid "Longitude"
 msgstr "Longitud"
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr "Edición manual de la memoria %i"
@@ -2202,7 +2205,7 @@ msgstr "Memorias"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr "Las memorias son de sólo lectura debido a una versión de firmware no soportada"
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La memoria %i no es borrable"
@@ -2225,8 +2228,8 @@ msgstr "La memoria debe estar en un banco para ser editada"
 msgid "Memory {num} not in bank {bank}"
 msgstr "La memoria {num} no está en banco {bank}"
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 msgid "Mode"
 msgstr "Modo"
 
@@ -2246,11 +2249,11 @@ msgstr "Módulo"
 msgid "Module Loaded"
 msgstr "Módulo cargado"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr "Módulo cargado exitosamente"
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr "Más información"
 
@@ -2259,7 +2262,7 @@ msgstr "Más información"
 msgid "More than one port found: %s"
 msgstr "Más de un puerto encontrado: %s"
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr "Mover %i memorias"
@@ -2272,7 +2275,7 @@ msgstr "Mover abajo"
 msgid "Move Up"
 msgstr "Mover arriba"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Las operaciones de movimiento están deshabilitadas mientras la vista es ordenada"
 
@@ -2280,11 +2283,11 @@ msgstr "Las operaciones de movimiento están deshabilitadas mientras la vista es
 msgid "New Window"
 msgstr "Nueva ventana"
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "Nueva versión disponible"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr "¡No hay filas vacías debajo!"
 
@@ -2302,20 +2305,20 @@ msgstr "No se encontraron módulos"
 msgid "No modules found in issue %i"
 msgstr "No se encontraron módulos en problema %i"
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr "No hay más espacio disponible; algunas memorias no fueron aplicadas"
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr "No hay resultados"
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr "¡No hay resultados!"
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr "Numero"
 
@@ -2430,7 +2433,7 @@ msgstr "Opcional: AA00 - AA00aa11"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcional: Condado, Hospital, etc."
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 msgid "Overwrite memories?"
 msgstr "¿Sobrescribir memorias?"
 
@@ -2444,8 +2447,8 @@ msgstr ""
 "Sólo un subconjunto de las más de 130 ajustes de radio disponibles\n"
 "están soportados en este lanzamiento.\n"
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr "Analizando"
 
@@ -2453,39 +2456,39 @@ msgstr "Analizando"
 msgid "Password"
 msgstr "Contraseña"
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Pegar"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr "Pegar memorias externas"
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr "Pegar memorias"
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Las memorias pegadas sobrescribirán %s memorias existentes"
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Las memorias pegadas sobrescribirán memorias %s"
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Las memorias pegadas sobrescribirán la memoria %s"
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria pegada sobrescribirá la memoria %s"
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "¡Por favor asegúrate de salir de CHIRP antes de instalar la nueva versión!"
 
@@ -2537,11 +2540,11 @@ msgstr ""
 "4 - Entonces presiona el botón \"A\" en tu radio para iniciar la clonación.\n"
 "    (Al final la radio emitirá un pitido)\n"
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr "Por favor te en cuenta que el modo desarrollador está pensado para uso por desarrolladores del proyecto CHIRP, o bajo la dirección de un desarrollador. Esto habilita comportamientos y funciones que pueden dañar tu computador y tu radio si no se usan con EXTREMO cuidado. ¡has sido advertido! ¿Proceder de todos modos?"
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "Por favor espera"
 
@@ -2581,7 +2584,7 @@ msgstr "Imprimiendo"
 msgid "Prolific USB device"
 msgstr "Dispositivo USB Prolific"
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr "Propiedades"
 
@@ -2597,7 +2600,7 @@ msgstr "Valor de la propiedad"
 msgid "QTH Locator"
 msgstr "Localizador de QTH"
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr "Consulta %s"
@@ -2618,8 +2621,8 @@ msgstr "Sintaxis de consulta OK"
 msgid "Query syntax help"
 msgstr "Ayuda de la sintaxis de consulta"
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr "Consultando"
 
@@ -2636,7 +2639,7 @@ msgstr "Radio"
 msgid "Radio did not ack block %i"
 msgstr "La radio no reconoció el bloque %i"
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr "Información de radio"
 
@@ -2686,11 +2689,11 @@ msgstr "Se recomienda usar 55.2"
 msgid "Redo"
 msgstr "Rehacer"
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr "Actualización requerida"
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Memoria actualizada %s"
@@ -2740,11 +2743,11 @@ msgstr "Reportando un nuevo error: %r"
 msgid "Reporting enabled"
 msgstr "Reportes habilitados"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr "Reportes ayudan al proyecto CHIRP a saber en cuales modelos de radio y plataformas de SO gastar nuestros limitados esfuerzos. Apreciamos mucho si lo dejas habilitado. ¿Realmente deshabilitar reportes?"
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "Reinicio requerido"
 
@@ -2763,7 +2766,7 @@ msgstr "Restaurar pestañas al iniciar"
 msgid "Results from other areas"
 msgstr "Resultados de otras áreas"
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "Ajustes recuperados"
 
@@ -2779,7 +2782,7 @@ msgstr "¿Guardar antes de cerrar?"
 msgid "Save file"
 msgstr "Guardar archivo"
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "Ajustes guardados"
 
@@ -2791,7 +2794,7 @@ msgstr "Control de escáner (omitir, incluir, prioridad, etc)"
 msgid "Scanlists"
 msgstr "Listas de escaneo"
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr "Codificador"
 
@@ -2816,7 +2819,7 @@ msgstr "Seleccionar lenguaje"
 msgid "Select Modes"
 msgstr "Seleccionar modos"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "Seleccionar plan de banda"
 
@@ -2844,7 +2847,7 @@ msgstr "Los ajustes son de sólo lectura debido a una versión de firmware no so
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Cantidad de desplazamiento (o frecuencia de transmisión) controlada por dúplex"
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Mostrar memoria en bruto"
 
@@ -2864,50 +2867,50 @@ msgstr "Mostrar ubicación de la copia de respaldo de la imagen"
 msgid "Skip"
 msgstr "Omitir"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr "Algunas memorias son incompatibles con esta radio"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr "Algunas memorias no son borrables"
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr "Ordenar %i memorias"
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Ordenar %i memoria"
 msgstr[1] "Ordenar %i memorias"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Ordenar %i memoria de forma ascendente"
 msgstr[1] "Ordenar %i memorias de forma ascendente"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Ordenar %i memoria de forma descendente"
 msgstr[1] "Ordenar %i memorias de forma descendente"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr "Ordenar por columna:"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 msgid "Sort memories"
 msgstr "Ordenar memorias"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr "Ordenando"
 
@@ -2919,7 +2922,7 @@ msgstr "Estado"
 msgid "State/Province"
 msgstr "Estado/Provincia"
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr "Éxito"
 
@@ -3013,7 +3016,7 @@ msgstr "El editor de memoria requiere una recarga para cambiar el flujo de traba
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "El procedimiento recomendado para importar memorias es para abrir el archivo de origen y copiar/pegar memorias desde este en tu imagen objetivo. Si continúas con esta función de importación, CHIRP remplazara todas las memorias de tu archivo actualmente abierto por las de %(file)s. ¿Te gustaría abrir este archivo para copiar/pegar memorias a través de este, o proceder con la importación?"
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 msgid "This Memory"
 msgstr "Esta memoria"
 
@@ -3076,11 +3079,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr "Este es el número de boleto para un problema ya creado en el sitio web chirpmyradio.com"
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 msgid "This memory and shift all up"
 msgstr "Esta memoria y desplazar todo hacia arriba"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 msgid "This memory and shift block up"
 msgstr "Esta memoria y desplazar bloque hacia arriba"
 
@@ -3171,7 +3174,7 @@ msgstr "Buscador de puertos USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "No se puede determinar puerto para tu cable. Comprueba tus controladores y conexiones."
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr "No se puede editar memoria antes de que la radio este cargada"
 
@@ -3180,16 +3183,16 @@ msgstr "No se puede editar memoria antes de que la radio este cargada"
 msgid "Unable to find stock config %r"
 msgstr "No se puede buscar la configuración original %r"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 msgid "Unable to import while the view is sorted"
 msgstr "No se puede importar mientras la vista es ordenada"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr "No se puede abrir el portapapeles"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr "No se puede consultar"
 
@@ -3197,7 +3200,7 @@ msgstr "No se puede consultar"
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr "No se puede leer el último bloque. Esto suele suceder cuando el modelo seleccionado es de EE.UU pero la radio no es una de EE.UU (o de banda ancha). Por favor elije el modelo correcto e intenta de nuevo."
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "No se puede revelar %s en este sistema"
@@ -3237,7 +3240,7 @@ msgstr "Actualizar un error existente"
 msgid "Updating bug %s"
 msgstr "Actualizando error %s"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "Cargar instrucciones"
 
@@ -3253,7 +3256,7 @@ msgstr "Cargar a radio"
 msgid "Upload to radio..."
 msgstr "Cargar a radio..."
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Memoria cargada %s"
@@ -3279,12 +3282,12 @@ msgstr "Nombre de usuario"
 msgid "Value does not fit in %i bits"
 msgstr "Valor no cabe en %i bits"
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Valor debe ser al menos %.4f"
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Valor debe ser como máximo %.4f"
@@ -3302,7 +3305,7 @@ msgstr "Valor debe ser cero o superior"
 msgid "Value to search memory field for"
 msgstr "Valor a buscar en el campo de memoria"
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr "Valores"
 
@@ -3314,15 +3317,15 @@ msgstr "Vendedor"
 msgid "View"
 msgstr "Ver"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr "¡ADVERTENCIA!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr "Advertencia"
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr "Advertencia: %s"
@@ -3367,11 +3370,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "bytes cada"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr "deshabilitado"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr "habilitado"
 

--- a/chirp/locale/fr.po
+++ b/chirp/locale/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2024-05-22 16:39-0400\n"
 "Last-Translator: Alexandre J. Raymond <alexandre.j.raymond@gmail.com>\n"
 "Language-Team: French\n"
@@ -23,21 +23,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s doit être entre %(min)i et %(max)i"
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Mémoires et tout décaler vers le haut"
 msgstr[1] "%i Mémoires et tout décaler vers le haut"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Mémoire"
 msgstr[1] "%i Mémoires"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -69,7 +69,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(vide)"
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr "...et %i de plus"
@@ -815,7 +815,7 @@ msgstr ""
 "5. Assurez-vous que la radio est réglée sur un canal sans activité.\n"
 "6. Cliquez sur OK pour télécharger l'image vers l'appareil.\n"
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -831,7 +831,7 @@ msgstr ""
 "5. Assurez-vous que la radio est réglée sur un canal sans activité.\n"
 "6. Cliquez sur OK pour télécharger l'image depuis l'appareil.\n"
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -847,7 +847,7 @@ msgstr ""
 "5. Assurez-vous que la radio est réglée sur un canal sans activité.\n"
 "6. Cliquez sur OK pour télécharger l'image vers l'appareil.\n"
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -859,7 +859,7 @@ msgstr ""
 "3. Preparez la radio pour le clonage.\n"
 "4. <b>Après avoir cliqué sur OK</b>, appuyez la touche pour recevoir l'image.\n"
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -994,7 +994,7 @@ msgstr ""
 "\n"
 "Cela peut ne pas fonctionner si vous allumez la radio avec le câble déjà branché"
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "Une nouvelle version de CHIRP est disponible. Visitez le site internet dès que possible pour la télécharger!"
 
@@ -1010,7 +1010,7 @@ msgstr "À propos"
 msgid "About CHIRP"
 msgstr "À propos de CHIRP"
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -1034,8 +1034,7 @@ msgstr ""
 msgid "Amateur"
 msgstr "Amateur"
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Une erreur s'est produite"
 
@@ -1051,7 +1050,7 @@ msgstr "Selon le système"
 msgid "Available modules"
 msgstr "Modules disponibles"
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "Plan de fréquences"
 
@@ -1108,11 +1107,11 @@ msgstr ""
 msgid "Canada"
 msgstr "Canada"
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Modifier ce paramètre nécessite de rafraîchir tous les paramètres depuis l'image, ce qui va être fait maintenant."
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Les canaux avec TX et RX équivalents %s sont représentés par le mode de tonalité de \"%s\""
@@ -1125,17 +1124,17 @@ msgstr "Fichiers image Chirp"
 msgid "Choice Required"
 msgstr "Choix nécessaire"
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Choisir code DTCS %s"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Choisir tonalité %s"
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr "Choisir mode cross"
 
@@ -1148,7 +1147,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "Choisir mode cross"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr "Choisir duplex"
 
@@ -1161,8 +1160,12 @@ msgstr "Choisir le module à charger pour le problème %i:"
 msgid "City"
 msgstr "Ville"
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -1185,21 +1188,21 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Clonage terminé, vérification des octets erronés"
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Clonage"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr "Téléchargement depuis la radio - Lire"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr "Téléchargement vers la radio - Écrire"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "Fermer"
 
@@ -1216,7 +1219,7 @@ msgstr "Fermer fichier"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1251,11 +1254,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Convertir en FM"
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Copier"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -1276,11 +1279,11 @@ msgstr "Port personnalisé"
 msgid "Custom..."
 msgstr "Personnalisation..."
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Couper"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -1301,11 +1304,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Décodage DTMF"
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr "Mémoire DV"
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr "Danger"
 
@@ -1313,11 +1316,11 @@ msgstr "Danger"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Supprimer"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -1330,20 +1333,20 @@ msgstr "Informations sur les pilotes"
 msgid "Developer Mode"
 msgstr "Mode développeur"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Le mode développement est maintenant %s. CHIRP doit être redémarré pour que ceci prenne effet"
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Comparaison mémoires brutes"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Code numérique"
 
@@ -1351,7 +1354,7 @@ msgstr "Code numérique"
 msgid "Digital Modes"
 msgstr "Modes numériques"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr "Désactiver le rapport d'utilisation"
 
@@ -1389,11 +1392,11 @@ msgstr "Télécharger depuis la radio"
 msgid "Download from radio..."
 msgstr "Télécharger depuis la radio..."
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "Instructions de téléchargement"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr "Pilote"
 
@@ -1413,17 +1416,17 @@ msgstr "Les répéteurs numériques bimodes supportant l'analogique seront prés
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Éditer les details pour %i mémoires"
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editer les details pour la mémoire %i"
@@ -1440,11 +1443,11 @@ msgstr "Activé"
 msgid "Enter Frequency"
 msgstr "Entrer la fréquence"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr "Saisir le décalage (MHz)"
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr "Saisir la fréquence d'émission (MHz)"
 
@@ -1477,7 +1480,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr "Mémoire %s effacée"
@@ -1491,7 +1494,7 @@ msgstr "Erreur lors de l'application des préférences"
 msgid "Error applying settings"
 msgstr "Erreur lors de l'application des préférences"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "Erreur de communication avec la radio"
 
@@ -1531,11 +1534,11 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "Pilote expérimental"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr "L'exportation ne peut écrire que des fichiers CSV"
 
@@ -1547,7 +1550,7 @@ msgstr "Exporter vers un fichier CSV"
 msgid "Export to CSV..."
 msgstr "Exporter vers un fichier CSV..."
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr "Extra"
 
@@ -1577,8 +1580,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr "Échec du chargement du navigateur de la radio"
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr "Échec d'analyse des résultats"
 
@@ -1643,7 +1646,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Tâche radio %s terminée"
@@ -1708,11 +1711,11 @@ msgstr ""
 "5 - Déconnectez votre câble d'interface! Autrement il n'y aura\n"
 "    pas d'audio du côté droit!\n"
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1816,7 +1819,7 @@ msgstr ""
 "    pas d'audio du côté droit!\n"
 "6 - Éteignez puis rallumez votre radio pour sortir du mode de clonage\n"
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1858,7 +1861,7 @@ msgstr ""
 "3 - Allumez votre radio\n"
 "4 - Cliquez sur OK pour démarrer\n"
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1886,11 +1889,11 @@ msgstr ""
 "3 - Allumez votre radio\n"
 "4 - Téléchargez les données depuis votre radio\n"
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1936,17 +1939,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr "Granularité fréquence en kHz"
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -2005,7 +2008,7 @@ msgstr "Si sélectionné, trier les résultats selon la distance depuis ces coor
 msgid "Import"
 msgstr "Importer"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -2034,11 +2037,11 @@ msgstr "Index"
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr "Information"
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr "Insérer une ligne avant"
 
@@ -2050,7 +2053,7 @@ msgstr "Installer une icône sur le bureau?"
 msgid "Interact with driver"
 msgstr "Intéragir avec le pilote"
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 msgid "Internal driver error"
 msgstr "Erreur interne du pilote"
 
@@ -2059,8 +2062,8 @@ msgstr "Erreur interne du pilote"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Invalide %(value)s (utiliser degrés decimaux)"
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 msgid "Invalid Entry"
 msgstr "Entrée invalide"
 
@@ -2068,7 +2071,7 @@ msgstr "Entrée invalide"
 msgid "Invalid ZIP code"
 msgstr "Code postal invalide"
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Édition invalide: %s"
@@ -2095,7 +2098,7 @@ msgstr "Problème numero:"
 msgid "LIVE"
 msgstr "LIVE"
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 msgid "Language"
 msgstr "Changer la langue"
 
@@ -2153,7 +2156,7 @@ msgstr "Chargement module pour un problème"
 msgid "Load module from issue..."
 msgstr "Chargement module pour un problème..."
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr "Charger un module n'affectera pas les onglets ouverts. Il est recommandé (sauf instructions contraires) de fermer tous les onglets avant de charger un module."
 
@@ -2186,7 +2189,7 @@ msgstr "Texte logo 2 (12 caractères)"
 msgid "Longitude"
 msgstr "Longitude"
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -2199,7 +2202,7 @@ msgstr "Mémoires"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "La mémoire %i n'est pas supprimable"
@@ -2222,8 +2225,8 @@ msgstr "La mémoire doit être dans une banque pour être éditée"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Mémoire {num} pas dans la banque {bank}"
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 msgid "Mode"
 msgstr "Mode"
 
@@ -2243,11 +2246,11 @@ msgstr "Module"
 msgid "Module Loaded"
 msgstr "Module chargé"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr "Module chargé avec succès"
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 #, fuzzy
 msgid "More Info"
 msgstr "Info"
@@ -2257,7 +2260,7 @@ msgstr "Info"
 msgid "More than one port found: %s"
 msgstr "Plus d'un port trouvé: %s"
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -2270,7 +2273,7 @@ msgstr "Descendre"
 msgid "Move Up"
 msgstr "Monter"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Les déplacements sont désactivés lorsque la vue est triée"
 
@@ -2278,11 +2281,11 @@ msgstr "Les déplacements sont désactivés lorsque la vue est triée"
 msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "Nouvelle version disponible"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr "Pas de ligne vide dessous!"
 
@@ -2300,20 +2303,20 @@ msgstr "Aucun module trouvé"
 msgid "No modules found in issue %i"
 msgstr "Aucun module trouvé pour le problème %i"
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr "Aucun résultat"
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr "Aucun résultat!"
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr "Nombre"
 
@@ -2430,7 +2433,7 @@ msgstr "Optionnel: -122.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Optionnel: Comté, Hôpital, etc."
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 msgid "Overwrite memories?"
 msgstr "Écraser les mémoires?"
 
@@ -2444,8 +2447,8 @@ msgstr ""
 "Seul un sous-ensemble des plus de 130 paramètres radio disponibles\n"
 "est pris en charge dans cette version.\n"
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr "Analyse"
 
@@ -2453,39 +2456,39 @@ msgstr "Analyse"
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Coller"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Les mémoires collées vont écraser %s mémoires existantes"
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Les mémoires collées vont écraser les mémoires %s"
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Les mémoires collées vont écraser la mémoire %s"
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La mémoire collee va écraser la mémoire %s"
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Soyez certain de quitter CHIRP avant d'installer la nouvelle version!"
 
@@ -2537,11 +2540,11 @@ msgstr ""
 "4 - Ensuite appuyez sur le bouton \"A\" de votre radio pour démarrer le clonage\n"
 "    (À la fin la radio va sonner)\n"
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr "Veuillez noter que le mode developpeur est destiné à n'être utilisé que par les développeurs du projet CHIRP, ou en suivant les directives d'un developpeur. Il active des comportements et des fonctions qui peuvent endommager votre ordinateur et votre radio s'ils ne sont pas utilisés avec un EXTRÊME soin. Vous êtes prévenu! Continuer malgré tout?"
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "Patientez s'il vous plaît"
 
@@ -2581,7 +2584,7 @@ msgstr "Impression"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr "Propriétés"
 
@@ -2599,7 +2602,7 @@ msgstr "Propriétés"
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr "Interroger %s"
@@ -2621,8 +2624,8 @@ msgstr "Interroger %s"
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 #, fuzzy
 msgid "Querying"
 msgstr "Interroger %s"
@@ -2640,7 +2643,7 @@ msgstr "Radio"
 msgid "Radio did not ack block %i"
 msgstr "La radio n'a pas accusé reception du bloc %i"
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr "Informations de la radio"
 
@@ -2692,11 +2695,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr "Rafraîchissement nécessaire"
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Mémoire %s rafraîchie"
@@ -2746,11 +2749,11 @@ msgstr "Rapport d'utilisation activé"
 msgid "Reporting enabled"
 msgstr "Rapport d'utilisation activé"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr "Le rapport d'utilisation aide le projet CHIRP à savoir quelles radios et systèmes d'exploitation sont utilisés pour concentrer les efforts sur ceux-là. Nous apprécierions vraiment que vous le laissiez actif. Êtes-vous certain de vouloir désactiver le rapport d'utilisation?"
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "Redémarrage nécessaire"
 
@@ -2769,7 +2772,7 @@ msgstr "Restaurer les onglets au démarrage"
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "Préférences récupérées"
 
@@ -2785,7 +2788,7 @@ msgstr "Enregistrer avant de fermer?"
 msgid "Save file"
 msgstr "Enregistrer fichier"
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "Préférences enregistrées"
 
@@ -2797,7 +2800,7 @@ msgstr "Contrôles de scan (sauter, inclure, priorité, etc)"
 msgid "Scanlists"
 msgstr "Lists de scan"
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr "Brouilleur"
 
@@ -2822,7 +2825,7 @@ msgstr "Choisir langue"
 msgid "Select Modes"
 msgstr "Choisir modes"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "Choisir un plan de fréquences"
 
@@ -2851,7 +2854,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Décalage (ou fréquence de transmission) contrôlée par duplex"
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Afficher les données de mémoires brutes"
 
@@ -2871,50 +2874,50 @@ msgstr "Montrer l'emplacement du fichier de débogage"
 msgid "Skip"
 msgstr "Ignorer"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr "Des mémoires sont incompatibles avec cette radio"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr "Des mémoires ne sont pas supprimables"
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Tri %i mémoire"
 msgstr[1] "Tri %i mémoires"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Tri croissant %i mémoire"
 msgstr[1] "Tri croissant %i mémoires"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Tri décroissant %i mémoire"
 msgstr[1] "Tri décroissant %i mémoires"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr "Tri par colonne:"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 msgid "Sort memories"
 msgstr "Tri des mémoires"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr "Tri"
 
@@ -2926,7 +2929,7 @@ msgstr "État"
 msgid "State/Province"
 msgstr "État/Province"
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr "Réussi"
 
@@ -3016,7 +3019,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "La procedure préconisée d'importation des mémoires consiste à ouvrir le fichier source et copier/coller les mémoires depuis celui-ci vers l'image cible. Si vous continuez avec cette fonction d'importation, CHIRP va remplacer toutes les mémoires du fichier actuellement ouvert avec celles de %(file)s. Souhaitez-vous ouvrir ce fichier pour copier/coller entre eux ou l'importer?"
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 msgid "This Memory"
 msgstr "Cette mémoire"
 
@@ -3079,11 +3082,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 msgid "This memory and shift all up"
 msgstr "Cette mémoire et décaler tous vers le haut"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 msgid "This memory and shift block up"
 msgstr "Cette mémoire et décaler le bloc vers le haut"
 
@@ -3174,7 +3177,7 @@ msgstr "Rechercher port USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Impossible de déterminer le port de votre câble. Vérifiez les pilotes et connexions."
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Impossible d'éditer une mémoire avant téléchargement de la radio"
 
@@ -3183,16 +3186,16 @@ msgstr "Impossible d'éditer une mémoire avant téléchargement de la radio"
 msgid "Unable to find stock config %r"
 msgstr "Impossible de trouver la configuration de base %r"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 msgid "Unable to import while the view is sorted"
 msgstr "Impossible d'importer lorsque la vue est triée"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr "Impossible d'ouvrir le presse-papier"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr "Impossible d'interroger"
 
@@ -3200,7 +3203,7 @@ msgstr "Impossible d'interroger"
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr "Impossible de lire le dernier bloc. Ceci se produit fréquemment quand le modèle sélectionné est US mais que la radio n'est pas US (ou large-bande). Sélectionnez le bon modèle et reessayez."
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Impossible de montrer %s sur ce système"
@@ -3240,7 +3243,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr "Mise à jour de la liste URCALL"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "Instruction de téléchargement"
 
@@ -3256,7 +3259,7 @@ msgstr "Télécharger vers la radio"
 msgid "Upload to radio..."
 msgstr "Télécharger vers la radio..."
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Memoire %s téléchargée"
@@ -3282,12 +3285,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr "La valeur ne rentre pas dans %i bits"
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "La valeur doit être d'au moins %.4f"
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "La valeur ne doit pas dépasser %.4f"
@@ -3305,7 +3308,7 @@ msgstr "La valeur doit être zero ou positive"
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr "Valeurs"
 
@@ -3317,15 +3320,15 @@ msgstr "Fabricant"
 msgid "View"
 msgstr "Voir"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr "ATTENTION!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr "Attention"
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr "Attention: %s"
@@ -3370,11 +3373,11 @@ msgstr "octets"
 msgid "bytes each"
 msgstr "octets chacun"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr "desactivé"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr "activé"
 

--- a/chirp/locale/hu.po
+++ b/chirp/locale/hu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2015-01-28 13:47+0100\n"
 "Last-Translator: Attila Joubert <joubert.attila@gmail.com>\n"
 "Language-Team: English\n"
@@ -23,21 +23,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "... és a tömböt felfelé lépteti"
 msgstr[1] "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Memória"
 msgstr[1] "Memória"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -69,7 +69,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, fuzzy, python-format
 msgid "...and %i more"
 msgstr "...és minden memória felfelé lép"
@@ -544,7 +544,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -554,7 +554,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -564,7 +564,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -572,7 +572,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the key to send image.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -658,7 +658,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -699,8 +699,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Hiba történt"
 
@@ -717,7 +716,7 @@ msgstr "Automatic Repeater Offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr ""
 
@@ -772,11 +771,11 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -789,17 +788,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "RX DTCS kód"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Kereszt-üzem"
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "Kereszt-üzem"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr ""
 
@@ -826,8 +825,12 @@ msgstr "Válasszon egy importálandót:"
 msgid "City"
 msgstr ""
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -844,23 +847,23 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Klónozás"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Letöltés a rádióról"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr ""
 
@@ -876,7 +879,7 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -910,11 +913,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Másolás"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -936,11 +939,11 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Kivágás"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -961,12 +964,12 @@ msgstr "DTCS pol."
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 #, fuzzy
 msgid "DV Memory"
 msgstr "ez a memória"
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr ""
 
@@ -975,11 +978,11 @@ msgstr ""
 msgid "Dec"
 msgstr "Érzékelés"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Törlés"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -993,20 +996,20 @@ msgstr "%s információk lekérése"
 msgid "Developer Mode"
 msgstr "Fejlesztői"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Digitális kód"
 
@@ -1015,7 +1018,7 @@ msgstr "Digitális kód"
 msgid "Digital Modes"
 msgstr "Digitális kód"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr ""
 
@@ -1056,12 +1059,12 @@ msgstr "Letöltés a rádióról"
 msgid "Download from radio..."
 msgstr "Letöltés a rádióról"
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 #, fuzzy
 msgid "Download instructions"
 msgstr "{name} Utasítások"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr ""
 
@@ -1081,17 +1084,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, fuzzy, python-format
 msgid "Edit details for %i memories"
 msgstr "Több memória szerkesztése"
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1110,11 +1113,11 @@ msgstr "Engedélyezve"
 msgid "Enter Frequency"
 msgstr "Frekvencia"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1147,7 +1150,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "A(z) {loc}. memóriahely törlése"
@@ -1162,7 +1165,7 @@ msgstr "Hiba a(z) %s érték beállításakor"
 msgid "Error applying settings"
 msgstr "Hiba a(z) %s érték beállításakor"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr ""
 
@@ -1202,12 +1205,12 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 #, fuzzy
 msgid "Experimental driver"
 msgstr "Folytassam kísérleti driver-rel?"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1221,7 +1224,7 @@ msgstr "Export fájlba"
 msgid "Export to CSV..."
 msgstr "Export fájlba"
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr ""
 
@@ -1248,8 +1251,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr ""
 
@@ -1316,7 +1319,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1359,11 +1362,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1429,7 +1432,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1456,7 +1459,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1474,11 +1477,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1514,17 +1517,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -1587,7 +1590,7 @@ msgstr ""
 msgid "Import"
 msgstr "Importálás"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1617,12 +1620,12 @@ msgstr "Sorszám"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 #, fuzzy
 msgid "Information"
 msgstr "%s információk beolvasása"
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Memória beszúrása fölé"
@@ -1635,7 +1638,7 @@ msgstr ""
 msgid "Interact with driver"
 msgstr ""
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 #, fuzzy
 msgid "Internal driver error"
 msgstr "Belső hiba"
@@ -1645,8 +1648,8 @@ msgstr "Belső hiba"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Érvénytelen érték! Egész szám kell legyen."
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Érvénytelen érték %s"
@@ -1655,7 +1658,7 @@ msgstr "Érvénytelen érték %s"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, fuzzy, python-format
 msgid "Invalid edit: %s"
 msgstr "Érvénytelen érték %s"
@@ -1682,7 +1685,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 #, fuzzy
 msgid "Language"
 msgstr "Nyelv választás"
@@ -1743,7 +1746,7 @@ msgstr "Modul betöltése"
 msgid "Load module from issue..."
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
@@ -1776,7 +1779,7 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -1789,7 +1792,7 @@ msgstr "Memória"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1812,8 +1815,8 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 #, fuzzy
 msgid "Mode"
 msgstr "Mód"
@@ -1837,11 +1840,11 @@ msgstr "Modul betöltése"
 msgid "Module Loaded"
 msgstr "Modul betöltése"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr ""
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr ""
 
@@ -1850,7 +1853,7 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -1865,7 +1868,7 @@ msgstr "Lefel_é"
 msgid "Move Up"
 msgstr "Fe_lfelé"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1873,12 +1876,12 @@ msgstr ""
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 #, fuzzy
 msgid "New version available"
 msgstr "A CHIRP egy új verziója érhető el:"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Memória beszúrása alá"
@@ -1897,20 +1900,20 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr ""
 
@@ -2030,7 +2033,7 @@ msgstr "Beállítások"
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Felülírja?"
@@ -2042,8 +2045,8 @@ msgid ""
 "are supported in this release.\n"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr ""
 
@@ -2051,39 +2054,39 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Beillesztés"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -2117,11 +2120,11 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr ""
 
@@ -2162,7 +2165,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr ""
 
@@ -2178,7 +2181,7 @@ msgstr ""
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, fuzzy, python-format
 msgid "Query %s"
 msgstr "Lekérdezés hiba"
@@ -2201,8 +2204,8 @@ msgstr "Lekérdezés hiba"
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 #, fuzzy
 msgid "Querying"
 msgstr "Lekérdezés hiba"
@@ -2221,7 +2224,7 @@ msgstr "Rádió"
 msgid "Radio did not ack block %i"
 msgstr ""
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 #, fuzzy
 msgid "Radio information"
 msgstr "%s információk lekérése"
@@ -2273,11 +2276,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, fuzzy, python-format
 msgid "Refreshed memory %s"
 msgstr "ezek a memóriák"
@@ -2326,11 +2329,11 @@ msgstr "Listázás letiltva"
 msgid "Reporting enabled"
 msgstr "Listázás letiltva"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr ""
 
@@ -2349,7 +2352,7 @@ msgstr ""
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr ""
 
@@ -2365,7 +2368,7 @@ msgstr ""
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 #, fuzzy
 msgid "Saved settings"
 msgstr "Beállítás"
@@ -2378,7 +2381,7 @@ msgstr ""
 msgid "Scanlists"
 msgstr ""
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr ""
 
@@ -2407,7 +2410,7 @@ msgstr "Oszlopok kiválasztása"
 msgid "Select Modes"
 msgstr "Oszlopok kiválasztása"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr ""
 
@@ -2436,7 +2439,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Memóriasor mutatása"
 
@@ -2456,52 +2459,52 @@ msgstr ""
 msgid "Skip"
 msgstr "Ugrás"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "A beillesztett {number}. számú memória nem kompatibilis ezzel a rádióval, mert:"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Memóriasorok összehasonlítása"
 msgstr[1] "Memóriasorok összehasonlítása"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 #, fuzzy
 msgid "Sort memories"
 msgstr "Felülírja?"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 #, fuzzy
 msgid "Sorting"
 msgstr "Beállítás"
@@ -2514,7 +2517,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr ""
 
@@ -2587,7 +2590,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 #, fuzzy
 msgid "This Memory"
 msgstr "ez a memória"
@@ -2642,12 +2645,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "... és a tömböt felfelé lépteti"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "... és a tömböt felfelé lépteti"
@@ -2737,7 +2740,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2746,18 +2749,18 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr "A csoportos beállítás megnyitása"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Nem érzékelek a {port} porton!"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "Nem érzékelek a {port} porton!"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr ""
 
@@ -2765,7 +2768,7 @@ msgstr ""
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr ""
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Ennél a modellnél nem változtatható"
@@ -2806,7 +2809,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr "URCALL lista frissítése."
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 #, fuzzy
 msgid "Upload instructions"
 msgstr "{instructions}"
@@ -2825,7 +2828,7 @@ msgstr "Feltöltés a rádióra"
 msgid "Upload to radio..."
 msgstr "Feltöltés a rádióra"
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
@@ -2851,12 +2854,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2874,7 +2877,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr ""
 
@@ -2887,15 +2890,15 @@ msgstr "Gyártó"
 msgid "View"
 msgstr "Né_zet"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2940,12 +2943,12 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 #, fuzzy
 msgid "disabled"
 msgstr "Engedélyezve"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 #, fuzzy
 msgid "enabled"
 msgstr "Engedélyezve"

--- a/chirp/locale/it.po
+++ b/chirp/locale/it.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-27 11:44+0100\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2025-03-27 11:43+0100\n"
 "Last-Translator: Giovanni Scafora IK5TWZ <scafora.giovanni@gmail.com>\n"
 "Language-Team: CHIRP Italian Translation\n"
@@ -829,7 +829,7 @@ msgstr ""
 "5. Assicurarsi che la radio sia sintonizzata su un canale privo di attività.\n"
 "6. Fare clic su OK per caricare l'immagine sul dispositivo.\n"
 
-#: ../drivers/tg_uv2p.py:232 ../drivers/wouxun.py:213 ../drivers/uvb5.py:288
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -845,7 +845,7 @@ msgstr ""
 "5. Assicurarsi che la radio sia sintonizzata su un canale privo di attività.\n"
 "6. Fare clic su OK per scaricare l'immagine dal dispositivo.\n"
 
-#: ../drivers/tg_uv2p.py:240 ../drivers/wouxun.py:221 ../drivers/uvb5.py:296
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -1009,7 +1009,7 @@ msgstr ""
 "\n"
 "Potrebbe non funzionare, se si accende la radio con il cavo già collegato"
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "È disponibile una nuova versione di CHIRP. Visita il sito per scaricarla!"
 
@@ -1025,7 +1025,7 @@ msgstr "Informazioni"
 msgid "About CHIRP"
 msgstr "Informazioni su CHIRP"
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr "Sono d'accordo"
 
@@ -1049,8 +1049,7 @@ msgstr "Inizia sempre con un elenco recente"
 msgid "Amateur"
 msgstr "Radioamatore"
 
-#: ../wxui/common.py:624 ../wxui/common.py:651 ../wxui/bugreport.py:328
-#: ../wxui/bugreport.py:437
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Si è verificato un errore"
 
@@ -1066,7 +1065,7 @@ msgstr "Automatico dal sistema"
 msgid "Available modules"
 msgstr "Moduli disponibili"
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "Bandplan"
 
@@ -1121,7 +1120,7 @@ msgstr "I risultati della cache possono essere inclusi solo per una query di pro
 msgid "Canada"
 msgstr "Canada"
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Per modificare questa impostazione è necessario aggiornare le impostazioni dall'immagine, cosa che avverrà ora."
 
@@ -1173,9 +1172,13 @@ msgstr "Scegli il modulo da caricare dal sito %i:"
 msgid "City"
 msgstr "Città"
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
 msgstr "Fare clic qui per il testo completo della licenza"
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
+msgstr ""
 
 #: ../drivers/ts590.py:671
 msgid ""
@@ -1197,21 +1200,21 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Clonazione completata, controllo dei byte spuri"
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Clonazione"
 
-#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/bj9900.py:133
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr "Clonazione dalla radio"
 
-#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/bj9900.py:165
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr "Clonazione verso la radio"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "Chiudi"
 
@@ -1316,7 +1319,7 @@ msgstr "Decodifica DTMF"
 msgid "DV Memory"
 msgstr "Memoria DV"
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr "Pericolo in vista"
 
@@ -1340,12 +1343,12 @@ msgstr "Informazioni dettagliate"
 msgid "Developer Mode"
 msgstr "Modalità sviluppatore"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Lo stato dello sviluppatore è ora impostato su %s. Per avere effetto, CHIRP deve essere riavviato"
 
-#: ../wxui/memedit.py:2237 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Diff memorie raw"
 
@@ -1361,7 +1364,7 @@ msgstr "Codice digitale"
 msgid "Digital Modes"
 msgstr "Modi digitali"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr "Disabilita notifiche"
 
@@ -1399,7 +1402,7 @@ msgstr "Scarica dalla radio"
 msgid "Download from radio..."
 msgstr "Scarica dalla radio..."
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "Istruzioni per il download"
 
@@ -1487,7 +1490,7 @@ msgstr "Digita il numero del bug da aggiornare"
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr "Inserisci il nome utente e la password di chirpmyradio.com. Se non disponi di un account, fai clic qui sotto per crearne uno prima di procedere."
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr "Memoria %s eliminata"
@@ -1500,7 +1503,7 @@ msgstr "Si è verificato un errore durante l'applicazione del filtro"
 msgid "Error applying settings"
 msgstr "Si è verificato un errore durante l'applicazione delle impostazioni"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "Errore durante la comunicazione con la radio"
 
@@ -1540,7 +1543,7 @@ msgstr "Esempio: nome~\"mioripetitore\""
 msgid "Exclude private and closed repeaters"
 msgstr "Escludi ripetitori privati e chiusi"
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "Driver sperimentale"
 
@@ -1586,8 +1589,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr "Impossibile caricare il browser della radio"
 
-#: ../sources/przemienniki_net.py:59 ../sources/przemienniki_eu.py:57
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr "Impossibile elaborare il risultato"
 
@@ -1649,7 +1652,7 @@ msgstr "Float finale"
 msgid "Finish float value like: 146.52"
 msgstr "Il valore finale della float è: 146.52"
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Lavoro radio completato %s"
@@ -1714,11 +1717,11 @@ msgstr ""
 "5 - Scollegare il cavo dati dell'interfaccia! In caso contrario, non ci sarà\n"
 "    l'audio del lato destro!\n"
 
-#: ../drivers/bf_t1.py:482 ../drivers/mursv1.py:341
-#: ../drivers/baofeng_wp970i.py:327 ../drivers/baofeng_uv17Pro.py:501
-#: ../drivers/gmrsuv1.py:391 ../drivers/btech.py:693 ../drivers/uv6r.py:339
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv5x3.py:417
-#: ../drivers/gmrsv2.py:363
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1822,7 +1825,7 @@ msgstr ""
 "    l'audio del lato destro!\n"
 "6 - Accendere la radio per uscire dalla modalità clone.\n"
 
-#: ../drivers/bf_t1.py:488 ../drivers/btech.py:699
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1892,11 +1895,11 @@ msgstr ""
 "3 - Accendere la radio\n"
 "4 - Effettuare il download dei dati dalla radio\n"
 
-#: ../drivers/mursv1.py:347 ../drivers/baofeng_wp970i.py:333
-#: ../drivers/baofeng_uv17Pro.py:507 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/vgc.py:604 ../drivers/uv6r.py:345
-#: ../drivers/tdxone_tdq8a.py:462 ../drivers/uv5x3.py:423
-#: ../drivers/gmrsv2.py:369
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1942,17 +1945,17 @@ msgstr "La frequenza %s non rientra nel range supportato"
 msgid "Frequency granularity in kHz"
 msgstr "Granularità della frequenza in kHz"
 
-#: ../drivers/tdh8.py:2616 ../drivers/baofeng_uv17Pro.py:1244
-#: ../drivers/mml_jc8810.py:1393 ../drivers/ga510.py:1072
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr "La frequenza in questo intervallo non deve essere in modalità AM"
 
-#: ../drivers/tdh8.py:2613 ../drivers/baofeng_uv17Pro.py:1240
-#: ../drivers/mml_jc8810.py:1390 ../drivers/ga510.py:1065
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr "La frequenza in questo intervallo richiede la modalità AM"
 
-#: ../drivers/tdh8.py:2620
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr "La frequenza al di fuori delle bande TX deve essere duplex=off"
 
@@ -2056,7 +2059,7 @@ msgstr "Installare l'icona sul desktop?"
 msgid "Interact with driver"
 msgstr "Interagisci con il driver"
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 msgid "Internal driver error"
 msgstr "Errore interno del driver"
 
@@ -2156,7 +2159,7 @@ msgstr "Carica modulo dal sito"
 msgid "Load module from issue..."
 msgstr "Carica modulo dal sito..."
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr "Il caricamento di un modulo non influisce sulle schede aperte. Si consiglia (salvo istruzioni diverse) di chiudere tutte le schede, prima di caricare un modulo."
 
@@ -2246,11 +2249,11 @@ msgstr "Modulo"
 msgid "Module Loaded"
 msgstr "Modulo caricato"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr "Modulo caricato con successo"
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr "Maggiori informazioni"
 
@@ -2280,7 +2283,7 @@ msgstr "Le operazioni di spostamento sono disabilitate quando la visualizzazione
 msgid "New Window"
 msgstr "Nuova finestra"
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "Nuova versione disponibile"
 
@@ -2306,8 +2309,8 @@ msgstr "Nessun modulo trovato nel sito %i"
 msgid "No more space available; some memories were not applied"
 msgstr "Non c'è più spazio disponibile; alcune memorie non sono state inserite"
 
-#: ../sources/przemienniki_net.py:55 ../sources/przemienniki_eu.py:53
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr "Nessun risultato"
 
@@ -2444,8 +2447,8 @@ msgstr ""
 "In questa versione, è supportato solo un sottoinsieme\n"
 "delle oltre 130 impostazioni radio disponibili.\n"
 
-#: ../sources/przemienniki_net.py:50 ../sources/przemienniki_eu.py:48
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr "Elaborazione"
 
@@ -2457,7 +2460,7 @@ msgstr "Password"
 msgid "Paste"
 msgstr "Incolla"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr "Incolla le memorie esterne"
 
@@ -2485,7 +2488,7 @@ msgstr "Le memorie incollate sovrascriveranno la memoria %s"
 msgid "Pasted memory will overwrite memory %s"
 msgstr "La memoria incollata sovrascriverà la memoria %s"
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Chiudere CHIRP prima di installare la nuova versione!"
 
@@ -2537,11 +2540,11 @@ msgstr ""
 "4 - Quindi premere il pulsante \"A\" della radio, per avviare la clonazione.\n"
 "    (Al termine, la radio emetterà un segnale acustico)\n"
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr "Si noti che la modalità sviluppatore è destinata all'uso da parte degli sviluppatori del progetto CHIRP o sotto la direzione di uno sviluppatore. Essa abilita comportamenti e funzioni che possono danneggiare il computer e la radio se non vengono utilizzati con ESTREMA attenzione. Siete stati avvertiti! Vuoi procedere comunque?"
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "Attendere"
 
@@ -2597,7 +2600,7 @@ msgstr "Valore della proprietà"
 msgid "QTH Locator"
 msgstr "QTH Locator"
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr "Interroga %s"
@@ -2618,8 +2621,8 @@ msgstr "La sintassi della query è OK"
 msgid "Query syntax help"
 msgstr "Aiuto per la sintassi delle query"
 
-#: ../sources/przemienniki_net.py:36 ../sources/przemienniki_eu.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr "Interrogazione"
 
@@ -2636,7 +2639,7 @@ msgstr "Radio"
 msgid "Radio did not ack block %i"
 msgstr "La radio non ha accettato il blocco %i"
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr "Informazioni sulla radio"
 
@@ -2686,11 +2689,11 @@ msgstr "Si consiglia di utilizzare 55.2"
 msgid "Redo"
 msgstr "Rifai"
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr "Aggiornamento necessario"
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Memoria aggiornata %s"
@@ -2740,11 +2743,11 @@ msgstr "Segnalazione di un nuovo bug: %r"
 msgid "Reporting enabled"
 msgstr "Reporting abilitato"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr "Le segnalazioni aiutano il progetto CHIRP a sapere su quali modelli di radio e piattaforme OS spendere i nostri limitati sforzi. Vi saremmo grati se le lasciaste abilitate. Vuoi davvero disabilitare le segnalazioni?"
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "Riavvio richiesto"
 
@@ -2763,7 +2766,7 @@ msgstr "Ripristina schede all'avvio"
 msgid "Results from other areas"
 msgstr "Risultati da altre aree"
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "Impostazioni recuperate"
 
@@ -2779,7 +2782,7 @@ msgstr "Salvare prima di chiudere?"
 msgid "Save file"
 msgstr "Salva file"
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "Impostazioni salvate"
 
@@ -2791,7 +2794,7 @@ msgstr "Controllo della scansione (salto, inclusione, priorità, ecc.)"
 msgid "Scanlists"
 msgstr "Elenco delle scansioni"
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr "Scrambler"
 
@@ -2816,7 +2819,7 @@ msgstr "Seleziona la lingua"
 msgid "Select Modes"
 msgstr "Seleziona le modalità"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "Seleziona un blandplan"
 
@@ -2844,7 +2847,7 @@ msgstr "Le impostazioni sono di sola lettura a causa della versione del firmware
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Shift (o frequenza di trasmissione) controllato dal duplex"
 
-#: ../wxui/memedit.py:2229 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Mostra memoria raw"
 
@@ -2906,8 +2909,8 @@ msgstr "Ordina per colonna:"
 msgid "Sort memories"
 msgstr "Ordina memorie"
 
-#: ../sources/przemienniki_net.py:62 ../sources/przemienniki_eu.py:60
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr "Ordinamento"
 
@@ -2919,7 +2922,7 @@ msgstr "Stato"
 msgid "State/Province"
 msgstr "Stato/Provincia"
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr "Successo"
 
@@ -3183,12 +3186,12 @@ msgstr "Impossibile trovare la configurazione standard %r"
 msgid "Unable to import while the view is sorted"
 msgstr "Impossibile importare mentre la visualizzazione è ordinata"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr "Impossibile aprire gli appunti"
 
-#: ../sources/przemienniki_net.py:48 ../sources/przemienniki_eu.py:46
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr "Impossibile eseguire la ricerca"
 
@@ -3196,7 +3199,7 @@ msgstr "Impossibile eseguire la ricerca"
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr "Impossibile leggere l'ultimo blocco. Questo accade spesso, quando il modello selezionato è US, ma la radio è un modello non US (o widebanded). Scegliere il modello corretto e riprovare."
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Impossibile rivelare %s su questo sistema"
@@ -3236,7 +3239,7 @@ msgstr "Aggiorna un bug esistente"
 msgid "Updating bug %s"
 msgstr "Aggiornamento del bug %s"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "Istruzioni per il caricamento"
 
@@ -3252,7 +3255,7 @@ msgstr "Carica sulla radio"
 msgid "Upload to radio..."
 msgstr "Carica sulla radio..."
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Memoria caricata %s"
@@ -3278,12 +3281,12 @@ msgstr "Nome utente"
 msgid "Value does not fit in %i bits"
 msgstr "Il valore non rientra in %i bit"
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Il valore deve essere almeno %.4f"
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Il valore deve essere al massimo %.4f"
@@ -3313,11 +3316,11 @@ msgstr "Produttore"
 msgid "View"
 msgstr "Visualizza"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr "ATTENZIONE!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1949 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr "Attenzione"
 
@@ -3366,11 +3369,11 @@ msgstr "byte"
 msgid "bytes each"
 msgstr "byte ciascuno"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr "disabilitato"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr "abilitato"
 

--- a/chirp/locale/ja_JP.po
+++ b/chirp/locale/ja_JP.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2023-12-03 11:04+0900\n"
 "Last-Translator: weboo <weboo@users.noreply.github.com>\n"
 "Language-Team: Japanese <translation-team-ja@lists.sourceforge.net>\n"
@@ -22,21 +22,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i 件削除して全体を上方向にシフト"
 msgstr[1] "%i 件削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i 件の内容を削除"
 msgstr[1] "%i 件の内容を削除"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -68,7 +68,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -543,7 +543,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -553,7 +553,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -563,7 +563,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -571,7 +571,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the key to send image.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -669,7 +669,7 @@ msgstr ""
 "\n"
 "ケーブルを接続した状態で電源オンにするとうまく動かない場合があります。"
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "新しいバージョンのCHIRPが利用可能です。できるだけ早く更新されることをお勧めします。今すぐ更新しますか？"
 
@@ -685,7 +685,7 @@ msgstr "このアプリについて"
 msgid "About CHIRP"
 msgstr "CHIRP について"
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -709,8 +709,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr ""
 
@@ -726,7 +725,7 @@ msgstr ""
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "バンドプラン"
 
@@ -783,11 +782,11 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -800,17 +799,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr ""
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr ""
 
@@ -822,7 +821,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr ""
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr ""
 
@@ -835,8 +834,12 @@ msgstr ""
 msgid "City"
 msgstr ""
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -853,21 +856,21 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr ""
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr ""
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr ""
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "閉じる"
 
@@ -884,7 +887,7 @@ msgstr "ファイルを閉じる"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -917,11 +920,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "コピー"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -943,11 +946,11 @@ msgstr "ポートを手動で設定"
 msgid "Custom..."
 msgstr "カスタム..."
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "切り取り"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -966,11 +969,11 @@ msgstr "DTCS極性"
 msgid "DTMF decode"
 msgstr "DTMF デコード"
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr ""
 
@@ -978,11 +981,11 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "削除"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -995,20 +998,20 @@ msgstr "ドライバー情報"
 msgid "Developer Mode"
 msgstr "開発者モード"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr ""
 
@@ -1016,7 +1019,7 @@ msgstr ""
 msgid "Digital Modes"
 msgstr ""
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr "診断レポート送信を停止"
 
@@ -1054,11 +1057,11 @@ msgstr "無線機からダウンロード"
 msgid "Download from radio..."
 msgstr "無線機からダウンロード..."
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "ダウンロード手順"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr ""
 
@@ -1078,17 +1081,17 @@ msgstr ""
 msgid "Duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1105,11 +1108,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "周波数を入力"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1142,7 +1145,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr ""
@@ -1155,7 +1158,7 @@ msgstr ""
 msgid "Error applying settings"
 msgstr ""
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "無線機との通信エラー"
 
@@ -1195,11 +1198,11 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "実験的ドライバー"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1211,7 +1214,7 @@ msgstr "CSVにエクスポート"
 msgid "Export to CSV..."
 msgstr "CSVにエクスポート..."
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr ""
 
@@ -1238,8 +1241,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr ""
 
@@ -1302,7 +1305,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "%s の処理が完了しました"
@@ -1345,11 +1348,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1415,7 +1418,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1442,7 +1445,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1460,11 +1463,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1500,17 +1503,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -1569,7 +1572,7 @@ msgstr ""
 msgid "Import"
 msgstr "インポート"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1598,11 +1601,11 @@ msgstr ""
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr "上に1行追加"
 
@@ -1614,7 +1617,7 @@ msgstr ""
 msgid "Interact with driver"
 msgstr ""
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 msgid "Internal driver error"
 msgstr "内部ドライバーエラー"
 
@@ -1623,8 +1626,8 @@ msgstr "内部ドライバーエラー"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr ""
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 msgid "Invalid Entry"
 msgstr ""
 
@@ -1632,7 +1635,7 @@ msgstr ""
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1658,7 +1661,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 msgid "Language"
 msgstr ""
 
@@ -1715,7 +1718,7 @@ msgstr ""
 msgid "Load module from issue..."
 msgstr ""
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
@@ -1748,7 +1751,7 @@ msgstr "起動メッセージ２（半角12文字）"
 msgid "Longitude"
 msgstr "軽度"
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -1761,7 +1764,7 @@ msgstr "メモリー"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "メモリー %i は削除できません"
@@ -1784,8 +1787,8 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 msgid "Mode"
 msgstr "受信モード"
 
@@ -1805,11 +1808,11 @@ msgstr ""
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr ""
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr ""
 
@@ -1818,7 +1821,7 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr "2つ以上のポートが見つかりました: %s"
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -1831,7 +1834,7 @@ msgstr "下に移動"
 msgid "Move Up"
 msgstr "上に移動"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1839,11 +1842,11 @@ msgstr ""
 msgid "New Window"
 msgstr "新規ウィンドウ"
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "新しいバージョンが利用可能です"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr "空の行が見つかりません"
 
@@ -1861,20 +1864,20 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr "行"
 
@@ -1987,7 +1990,7 @@ msgstr ""
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 msgid "Overwrite memories?"
 msgstr "メモリーを上書きしますか？"
 
@@ -1998,8 +2001,8 @@ msgid ""
 "are supported in this release.\n"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr ""
 
@@ -2007,39 +2010,39 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "ペースト"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "ペーストすると %s 件のメモリーが上書きされます"
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "ペーストするとメモリー %s が上書きされます"
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "新しいバージョンをインストールする前に必ずCHIRPを終了してください。"
 
@@ -2073,11 +2076,11 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "お待ちください"
 
@@ -2117,7 +2120,7 @@ msgstr "印刷"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr "プロパティ"
 
@@ -2135,7 +2138,7 @@ msgstr "プロパティ"
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr ""
@@ -2156,8 +2159,8 @@ msgstr ""
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr ""
 
@@ -2174,7 +2177,7 @@ msgstr "無線機"
 msgid "Radio did not ack block %i"
 msgstr ""
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr ""
 
@@ -2224,11 +2227,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr "更新が必要です"
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "%s 件のメモリーを取得しました"
@@ -2276,11 +2279,11 @@ msgstr "診断レポート送信"
 msgid "Reporting enabled"
 msgstr "診断レポート送信"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr "診断レポートは、CHIRPプロジェクトがどの無線機やOSに限られたリソースを使うべきかを判断するのに役立ちます。このまま有効にしておいていただけると有り難いです。本当に無効にしますか？"
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "再起動が必要です"
 
@@ -2299,7 +2302,7 @@ msgstr "起動時にタブを復元"
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "設定を取得しました"
 
@@ -2315,7 +2318,7 @@ msgstr "保存しますか？"
 msgid "Save file"
 msgstr "ファイルに保存"
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "設定を保存"
 
@@ -2327,7 +2330,7 @@ msgstr ""
 msgid "Scanlists"
 msgstr "スキャンリスト"
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr "スクランブル"
 
@@ -2353,7 +2356,7 @@ msgstr "バンドプラン選択"
 msgid "Select Modes"
 msgstr ""
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "バンドプラン選択"
 
@@ -2381,7 +2384,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr ""
 
@@ -2401,50 +2404,50 @@ msgstr "イメージのバックアップを表示"
 msgid "Skip"
 msgstr ""
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr ""
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "並び替え（%i 件）"
 msgstr[1] "並び替え（%i 件）"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "昇順に並び替え（%i 件）"
 msgstr[1] "昇順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "降順に並び替え（%i 件）"
 msgstr[1] "降順に並び替え（%i 件）"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr "カラムを選択"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 msgid "Sort memories"
 msgstr "並び替え"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr "並び替え中"
 
@@ -2456,7 +2459,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr "成功"
 
@@ -2529,7 +2532,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "推奨されるメモリーのインポート方法は、ソースファイルを開き、そこから指定場所にメモリーをコピー＆ペーストすることです。このままこのインポート機能を続行すると、CHIRPは現在開いているファイルにあるすべてのメモリーを %(file)s 内のものに置き換えます。このファイルを開いて「メモリ」をコピー＆ペーストしますか？それともインポートを続けますか？"
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 msgid "This Memory"
 msgstr "この行の内容を削除"
 
@@ -2589,11 +2592,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 msgid "This memory and shift all up"
 msgstr "この行を削除して全体を上方向にシフト"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 msgid "This memory and shift block up"
 msgstr "この行を削除してグループを上方向にシフト"
 
@@ -2680,7 +2683,7 @@ msgstr "USBポート検出"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "ポートを検出できませんでした。ドライバーがインストールされているかと接続状態をもう一度確認してください。"
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2689,16 +2692,16 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr ""
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 msgid "Unable to import while the view is sorted"
 msgstr ""
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr ""
 
@@ -2706,7 +2709,7 @@ msgstr ""
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr ""
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr ""
@@ -2746,7 +2749,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr ""
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "アップロード手順"
 
@@ -2762,7 +2765,7 @@ msgstr "無線機にアップロード"
 msgid "Upload to radio..."
 msgstr "無線機にアップロード..."
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
@@ -2788,12 +2791,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr "値は %i bitにしてください"
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "値は %.4f 以上にしてください"
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "値は %.4f 以下にしてください"
@@ -2811,7 +2814,7 @@ msgstr "値は 0 以上にしてください"
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr "値"
 
@@ -2823,15 +2826,15 @@ msgstr "メーカー"
 msgid "View"
 msgstr "表示"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2876,11 +2879,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr "無効"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr "有効"
 

--- a/chirp/locale/nl.po
+++ b/chirp/locale/nl.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2012-03-18 12:01+0100\n"
 "Last-Translator: Michael Tel <m.tel@xs4all.nl>\n"
 "Language-Team: Dutch\n"
@@ -23,21 +23,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Verwijderen (en naar boven verplaatsen)"
 msgstr[1] "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Kanalen"
 msgstr[1] "Kanalen"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -69,7 +69,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -544,7 +544,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -554,7 +554,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -564,7 +564,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -572,7 +572,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the key to send image.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -658,7 +658,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr ""
 
@@ -674,7 +674,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -699,8 +699,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Er is een fout opgetreden"
 
@@ -717,7 +716,7 @@ msgstr "Automatische repeater offset"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr ""
 
@@ -772,11 +771,11 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -789,17 +788,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS code"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Cross-mode"
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "Cross-mode"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr ""
 
@@ -826,8 +825,12 @@ msgstr "Kies n om vanuit te importeren:"
 msgid "City"
 msgstr ""
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -844,23 +847,23 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Klonen"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Download van radio"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Naar radio uploaden"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr ""
 
@@ -876,7 +879,7 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -910,11 +913,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Kopiëren"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -936,11 +939,11 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Knippen"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -961,11 +964,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr ""
 
@@ -974,11 +977,11 @@ msgstr ""
 msgid "Dec"
 msgstr "Detecteren"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Verwijderen"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -992,20 +995,20 @@ msgstr "Informatie van de bank ophalen"
 msgid "Developer Mode"
 msgstr "Ontwerper"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Digitale code"
 
@@ -1014,7 +1017,7 @@ msgstr "Digitale code"
 msgid "Digital Modes"
 msgstr "Digitale code"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr ""
 
@@ -1054,12 +1057,12 @@ msgstr "Download van radio"
 msgid "Download from radio..."
 msgstr "Download van radio"
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 #, fuzzy
 msgid "Download instructions"
 msgstr "Download van radio"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr ""
 
@@ -1079,17 +1082,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1107,11 +1110,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Frequentie"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1144,7 +1147,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "Wis kanaal {loc}"
@@ -1159,7 +1162,7 @@ msgstr "Fout bij het instellen van het geheugen"
 msgid "Error applying settings"
 msgstr "Fout bij het instellen van het geheugen"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr ""
 
@@ -1199,11 +1202,11 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1217,7 +1220,7 @@ msgstr "Exporteren naar bestand"
 msgid "Export to CSV..."
 msgstr "Exporteren naar bestand"
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr ""
 
@@ -1244,8 +1247,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr ""
 
@@ -1309,7 +1312,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1352,11 +1355,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1422,7 +1425,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1449,7 +1452,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1467,11 +1470,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1507,17 +1510,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -1578,7 +1581,7 @@ msgstr ""
 msgid "Import"
 msgstr "Importeren"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1609,11 +1612,11 @@ msgstr "Index"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Regel hierboven invoegen"
@@ -1626,7 +1629,7 @@ msgstr ""
 msgid "Interact with driver"
 msgstr ""
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 #, fuzzy
 msgid "Internal driver error"
 msgstr "Interne fout"
@@ -1636,8 +1639,8 @@ msgstr "Interne fout"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Ongeldige waarde. Het moet een integer zijn."
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Ongeldige waarde voor dit veld"
@@ -1646,7 +1649,7 @@ msgstr "Ongeldige waarde voor dit veld"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1673,7 +1676,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 #, fuzzy
 msgid "Language"
 msgstr "Taal wijzigen"
@@ -1734,7 +1737,7 @@ msgstr "Toonmodus"
 msgid "Load module from issue..."
 msgstr "Toonmodus"
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
@@ -1767,7 +1770,7 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -1780,7 +1783,7 @@ msgstr "Kanalen"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1803,8 +1806,8 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 #, fuzzy
 msgid "Mode"
 msgstr "Mode"
@@ -1826,11 +1829,11 @@ msgstr ""
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr ""
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr ""
 
@@ -1839,7 +1842,7 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -1854,7 +1857,7 @@ msgstr "Verplaats omlaa_g"
 msgid "Move Up"
 msgstr "Verplaats om_hoog"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1862,11 +1865,11 @@ msgstr ""
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Regel hieronder invoegen"
@@ -1885,20 +1888,20 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr ""
 
@@ -2018,7 +2021,7 @@ msgstr "Opties"
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Overschrijven?"
@@ -2030,8 +2033,8 @@ msgid ""
 "are supported in this release.\n"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr ""
 
@@ -2039,39 +2042,39 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Plakken"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -2105,11 +2108,11 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr ""
 
@@ -2150,7 +2153,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr ""
 
@@ -2166,7 +2169,7 @@ msgstr ""
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr ""
@@ -2187,8 +2190,8 @@ msgstr ""
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr ""
 
@@ -2205,7 +2208,7 @@ msgstr "Radio"
 msgid "Radio did not ack block %i"
 msgstr ""
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 #, fuzzy
 msgid "Radio information"
 msgstr "Informatie van de bank ophalen"
@@ -2256,11 +2259,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
@@ -2310,11 +2313,11 @@ msgstr "Rapportering is uitgeschakeld"
 msgid "Reporting enabled"
 msgstr "Rapportering is uitgeschakeld"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr ""
 
@@ -2333,7 +2336,7 @@ msgstr ""
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr ""
 
@@ -2349,7 +2352,7 @@ msgstr ""
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr ""
 
@@ -2361,7 +2364,7 @@ msgstr ""
 msgid "Scanlists"
 msgstr ""
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr ""
 
@@ -2390,7 +2393,7 @@ msgstr "Kolommen selecteren"
 msgid "Select Modes"
 msgstr "Kolommen selecteren"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr ""
 
@@ -2419,7 +2422,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Toon ruw kanaal"
 
@@ -2439,52 +2442,52 @@ msgstr ""
 msgid "Skip"
 msgstr "Overslaan"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Geplakt kanaal {number} is niet compatibel met deze radio omdat:"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Verschillen ruwe kanalen"
 msgstr[1] "Verschillen ruwe kanalen"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 #, fuzzy
 msgid "Sort memories"
 msgstr "Overschrijven?"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr ""
 
@@ -2496,7 +2499,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr ""
 
@@ -2569,7 +2572,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 #, fuzzy
 msgid "This Memory"
 msgstr "Toon ruw kanaal"
@@ -2624,12 +2627,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Verwijderen (en naar boven verplaatsen)"
@@ -2719,7 +2722,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2728,18 +2731,18 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr "Openen aanwezige configuratie"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Niet in staat om de radio op {port} te detecteren"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "Niet in staat om de radio op {port} te detecteren"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr ""
 
@@ -2747,7 +2750,7 @@ msgstr ""
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr ""
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Niet in staat om wijzigingen voor dit model te maken"
@@ -2788,7 +2791,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr "Bijwerken URCALL lijst"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr ""
 
@@ -2806,7 +2809,7 @@ msgstr "Naar radio uploaden"
 msgid "Upload to radio..."
 msgstr "Naar radio uploaden"
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
@@ -2832,12 +2835,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2855,7 +2858,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr ""
 
@@ -2868,15 +2871,15 @@ msgstr "Merk"
 msgid "View"
 msgstr "Bee_ld"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2921,11 +2924,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/pl.po
+++ b/chirp/locale/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2023-07-12 21:21+0200\n"
 "Last-Translator: szporwolik\n"
 "Language-Team: Polish\n"
@@ -23,7 +23,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s muszą być pomiędzy %(min)i oraz %(max)i"
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -31,7 +31,7 @@ msgstr[0] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[1] "%i pamięci oraz przesuń wszystkie do góry"
 msgstr[2] "%i pamięci oraz przesuń wszystkie do góry"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -39,7 +39,7 @@ msgstr[0] "%i pamięci"
 msgstr[1] "%i pamięci"
 msgstr[2] "%i pamięci"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -72,7 +72,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(brak)"
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr "...oraz %i więcej"
@@ -547,7 +547,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -557,7 +557,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -567,7 +567,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -575,7 +575,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the key to send image.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -673,7 +673,7 @@ msgstr ""
 "\n"
 "Obraz może nie działać, jeśli radio zostanie włączone z podłączonym kablem"
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "Nowa wersja programu CHIRP jest dostępna. Odwiedź stronę internetową projektu i pobierz ją!"
 
@@ -689,7 +689,7 @@ msgstr "O programie"
 msgid "About CHIRP"
 msgstr "O programie CHIRP"
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -713,8 +713,7 @@ msgstr ""
 msgid "Amateur"
 msgstr "Amatorska"
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Wystąpił błąd"
 
@@ -730,7 +729,7 @@ msgstr "Automatyczny z systemu"
 msgid "Available modules"
 msgstr "Dostępne moduły"
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "Bandplan"
 
@@ -785,11 +784,11 @@ msgstr ""
 msgid "Canada"
 msgstr "Kanada"
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Zmiana tego ustawienia wymaga odświeżenia z obrazu, co zostanie teraz wykonane."
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Kanały z takim samym TX oraz RX %s są reprezentowane trybem tonu \"%s\""
@@ -802,17 +801,17 @@ msgstr "Pliki obrazu CHIRP"
 msgid "Choice Required"
 msgstr "Wymagany wybór"
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Wybierz %s kod DTCS "
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Wybierz %s ton"
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr "Wybierz tryb krzyżowy"
 
@@ -825,7 +824,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "Wybierz tryb krzyżowy"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr "Wybierz duplex"
 
@@ -838,8 +837,12 @@ msgstr "Wybierz moduł do zaimportowania ze zgłoszenia %i:"
 msgid "City"
 msgstr "Miasto"
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -856,21 +859,21 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Klonowane zakończone, sprawdzanie niewłaściwych bajtów"
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Klonowanie"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr "Pobieranie z radiostacji"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr "Wysyłanie do radiostacji"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "Zamknij"
 
@@ -887,7 +890,7 @@ msgstr "Zamknij plik"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -921,11 +924,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Kopiuj"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -948,11 +951,11 @@ msgstr "Wprowadź port:"
 msgid "Custom..."
 msgstr "Nietypowy..."
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Wytnij"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -973,11 +976,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr "Pamięć DV"
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr "Niebezpieczeństwo"
 
@@ -985,11 +988,11 @@ msgstr "Niebezpieczeństwo"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Usuń"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -1002,20 +1005,20 @@ msgstr "Informacje o radiostacji"
 msgid "Developer Mode"
 msgstr "Tryb dewelopera"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Tryb developera jest teraz %s. CHIRP musi zostać ponowie uruchomiony, aby zmiany przyniosły efekt"
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Porównaj surowe pamięci"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Kod cyfrowy"
 
@@ -1024,7 +1027,7 @@ msgstr "Kod cyfrowy"
 msgid "Digital Modes"
 msgstr "Kod cyfrowy"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr "Wyłącz raportowanie"
 
@@ -1062,11 +1065,11 @@ msgstr "Pobierz z radiostacji"
 msgid "Download from radio..."
 msgstr "Pobierz z radiostacji..."
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "Instrukcje pobierania"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr "Sterownik"
 
@@ -1086,17 +1089,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Dupleks"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Zmień szczegóły dla %i pamięci"
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Zmień szczególy dla pamięci %i"
@@ -1113,11 +1116,11 @@ msgstr "Włączony"
 msgid "Enter Frequency"
 msgstr "Wprowadź częstotliwość"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr "Wprowadź przesunięcie (MHz)"
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr "Wprowadź częstotliwość nadawania (MHz)"
 
@@ -1150,7 +1153,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr "Skasowano pamięć %s"
@@ -1164,7 +1167,7 @@ msgstr "Błąd stosowania ustawień"
 msgid "Error applying settings"
 msgstr "Błąd stosowania ustawień"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "Błąd komunikacji z radiostacją"
 
@@ -1204,11 +1207,11 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "Sterownik eksperymentalny"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr "Eksport może tylko zapisywać pliki CSV"
 
@@ -1220,7 +1223,7 @@ msgstr "Eksportuj do pliku CSV"
 msgid "Export to CSV..."
 msgstr "Eksportuj do pliku CSV..."
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr "Dodatkowa"
 
@@ -1250,8 +1253,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr "Nie udało się załadować przeglądarki radiostacji"
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr "Parsowanie wyniku nie udało się"
 
@@ -1314,7 +1317,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Zakończono zadanie radiostacji %s"
@@ -1357,11 +1360,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1427,7 +1430,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1454,7 +1457,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1472,11 +1475,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1512,17 +1515,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -1581,7 +1584,7 @@ msgstr "Jeśli ustawiono, sortuje wyniki po odległości od tych współrzędnyc
 msgid "Import"
 msgstr "Importuj"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1610,11 +1613,11 @@ msgstr "Indeks"
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr "Informacja"
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr "Umieść wiersz wyżej"
 
@@ -1626,7 +1629,7 @@ msgstr "Utworzyć skrót pulpitu?"
 msgid "Interact with driver"
 msgstr "Interakcja ze sterownikiem"
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 msgid "Internal driver error"
 msgstr "Wewnętrzny błąd sterownika"
 
@@ -1635,8 +1638,8 @@ msgstr "Wewnętrzny błąd sterownika"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Niewłaściwe %(value)s (używaj stopni dziesiętnych)"
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 msgid "Invalid Entry"
 msgstr "Niewłaściwy wpis: %s"
 
@@ -1644,7 +1647,7 @@ msgstr "Niewłaściwy wpis: %s"
 msgid "Invalid ZIP code"
 msgstr "Niewłaściwy kod pocztowy"
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Niewłaściwa edycja: %s"
@@ -1670,7 +1673,7 @@ msgstr "Numer zgłoszenia:"
 msgid "LIVE"
 msgstr "Na żywo"
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 msgid "Language"
 msgstr "Język"
 
@@ -1728,7 +1731,7 @@ msgstr "Załaduj moduł ze zgłoszenia"
 msgid "Load module from issue..."
 msgstr "Załaduj moduł ze zgłoszenia..."
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
@@ -1761,7 +1764,7 @@ msgstr ""
 msgid "Longitude"
 msgstr "Długość geograficzna"
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -1774,7 +1777,7 @@ msgstr "Pamięci"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Pamięć %i jest nieusuwalna"
@@ -1797,8 +1800,8 @@ msgstr "Pamięć musi być w banku, aby można ją było edytować"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Pamięć {num} nie jest w banku {bank}"
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 msgid "Mode"
 msgstr "Tryb"
 
@@ -1818,11 +1821,11 @@ msgstr "Moduł"
 msgid "Module Loaded"
 msgstr "Załadowano moduł"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr "Pomyślnie załadowano moduł"
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr "Info"
 
@@ -1831,7 +1834,7 @@ msgstr "Info"
 msgid "More than one port found: %s"
 msgstr "Znaleziono więcej niż jeden port: %s"
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -1844,7 +1847,7 @@ msgstr "Przesuń w dół"
 msgid "Move Up"
 msgstr "Przesuń w górę"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1852,11 +1855,11 @@ msgstr ""
 msgid "New Window"
 msgstr "Nowe okno"
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "Nowa wersja jest dostępna"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr "Brak pustych wierszy poniżej!"
 
@@ -1874,20 +1877,20 @@ msgstr "Nie znaleziono modułów"
 msgid "No modules found in issue %i"
 msgstr "Nie znaleziono modułów w zgłoszeniu %i"
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr "Brak wyników"
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr "Brak wyników!"
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr "Numer"
 
@@ -2000,7 +2003,7 @@ msgstr "Opcjonalnie: AA00 - AA00aa11"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opcjonalnie: Szpital, Hrabstwo itp."
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 msgid "Overwrite memories?"
 msgstr "Nadpisać pamięci?"
 
@@ -2011,8 +2014,8 @@ msgid ""
 "are supported in this release.\n"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr "Parsowanie"
 
@@ -2020,39 +2023,39 @@ msgstr "Parsowanie"
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Wklej"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Wklejone pamięci nadpisze %s istniejących pamięci"
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Wklejone pamięci nadpisze pamięci %s"
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Wklejone pamięci nadpiszą pamięć %s"
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Wklejona pamięć nadpisze pamięć %s"
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Proszę wyjdź z programu CHIRP przed instalacją nowej wersji!"
 
@@ -2086,11 +2089,11 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr "Proszę zauważyć, że tryb dewelopera jest przeznaczony dla deweloperów projektu CHIRP lub do użycia pod nadzorem dewelopera. Włącza on zachowania oraz funkcje, które mogą uszkodzić komputer oraz radiostację, jeśli nie będą wykorzystywane z EKSTREMALNĄ uwagą. Zostałeś ostrzeżony! Kontynuować?"
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "Proszę czekać"
 
@@ -2130,7 +2133,7 @@ msgstr "Drukowanie"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr "Właściwości"
 
@@ -2148,7 +2151,7 @@ msgstr "Właściwości"
 msgid "QTH Locator"
 msgstr "QTH Lokator"
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr "Odpytywanie %s"
@@ -2170,8 +2173,8 @@ msgstr "Odpytywanie %s"
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr "Odpytywanie"
 
@@ -2188,7 +2191,7 @@ msgstr "Radiostacja"
 msgid "Radio did not ack block %i"
 msgstr "Radiostacja nie potwierdziła (ack) bloku %i"
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr "Informacje o radiostacji"
 
@@ -2235,11 +2238,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr "Wymagane jest odświeżenie"
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Odświeżono pamięć %s"
@@ -2287,11 +2290,11 @@ msgstr "Raportowanie nowego błędu: %r"
 msgid "Reporting enabled"
 msgstr "Raportowanie jest włączone"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr "Raportowanie pomaga projektowi CHIRP zrozumieć, które modele radiostacji oraz systemów operacyjnych należy traktować priorytetowo. Naprawdę doceniamy zostawienie tej opcji włączonej. Naprawdę wyłączyć raportowanie?"
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "Wymagany jest restart"
 
@@ -2311,7 +2314,7 @@ msgstr "Przywróć zakładki po uruchomieniu"
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "Pobrano ustawienia"
 
@@ -2327,7 +2330,7 @@ msgstr "Zapisać przed zamknięciem?"
 msgid "Save file"
 msgstr "Zapisz plik"
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "Zapisano ustawienia"
 
@@ -2339,7 +2342,7 @@ msgstr ""
 msgid "Scanlists"
 msgstr ""
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr ""
 
@@ -2364,7 +2367,7 @@ msgstr "Wybierz język"
 msgid "Select Modes"
 msgstr "Wybierz tryby"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "Wybierz bandplan"
 
@@ -2392,7 +2395,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Pokaż surową pamięć"
 
@@ -2412,20 +2415,20 @@ msgstr "Pokaż lokalizację backupu pamięci"
 msgid "Skip"
 msgstr "Przeskocz"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr "Niektóre pamięci są niekompatybilne z tą radiostacją"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr "Niektóre pamięci są nieusuwalne"
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -2433,7 +2436,7 @@ msgstr[0] "Sortuj %i pamięci"
 msgstr[1] "Sortuj %i pamięci"
 msgstr[2] "Sortuj %i pamięci"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -2441,7 +2444,7 @@ msgstr[0] "Sortuj %i pamięci rosnąco"
 msgstr[1] "Sortuj %i pamięci rosnąco"
 msgstr[2] "Sortuj %i pamięci rosnąco"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -2449,16 +2452,16 @@ msgstr[0] "Sortuj %i pamięci malejąco"
 msgstr[1] "Sortuj %i pamięci malejąco"
 msgstr[2] "Sortuj %i pamięci malejąco"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr "Sortuj wg kolumny:"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 msgid "Sort memories"
 msgstr "Sortuj pamięci"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr "Sortowanie"
 
@@ -2470,7 +2473,7 @@ msgstr "Stan"
 msgid "State/Province"
 msgstr "Stan/Prowincja"
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr "Sukces"
 
@@ -2543,7 +2546,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "Rekomendowaną procedurą do importowania pamięci jest otworzenie pliku źródłowego i kopiowanie/wklejanie z niego do docelowego pliku obrazu. Kontynuacja importu spowoduje, że CHIRP zastąpi wszystkie pamięci w aktualnie otwartym pliku tymi z %(file)s. Czy chcesz otworzyć ten plik, aby kopiować/wklejać pamięci lub kontynuować import?"
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 msgid "This Memory"
 msgstr "Tą pamięć"
 
@@ -2597,11 +2600,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 msgid "This memory and shift all up"
 msgstr "Tą pamięć i przeusń wszystkie wyżej"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 msgid "This memory and shift block up"
 msgstr "Tą pamięć i przesuń blok wyżej"
 
@@ -2688,7 +2691,7 @@ msgstr "Wykrywacz portów USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Nie można wykryć portu kabla. Należy sprawdzić sterowniki oraz połączenie."
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Przed pobraniem pamięci, nie można jej edytować"
 
@@ -2697,17 +2700,17 @@ msgstr "Przed pobraniem pamięci, nie można jej edytować"
 msgid "Unable to find stock config %r"
 msgstr "Nie znaleziono konfiguracji wstępnej %r"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Przed pobraniem pamięci, nie można jej edytować"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr "Nie można otworzyć schowka"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr "Nie można wykonać zapytania"
 
@@ -2715,7 +2718,7 @@ msgstr "Nie można wykonać zapytania"
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr "Nie można odczytać ostatniego bloku. To występuje najczęściej jeśli wybrano model na rynek US, ale radiostacja jest przeznaczona na inne regiony (lub szerokopasmowa). Należy wybrać właściwy model i spróbować ponownie."
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Nie można odkryć %s na tym systemie"
@@ -2755,7 +2758,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr "Update'owanie bug'a %s"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "Instrukcje wysyłania"
 
@@ -2771,7 +2774,7 @@ msgstr "Wyślij do radiostacji"
 msgid "Upload to radio..."
 msgstr "Wyślij do radiostacji..."
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Wysłano pamięć %s"
@@ -2797,12 +2800,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr "Wartość nie pasuje do %i bitów"
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Wartość musi wynosić przynajmniej %.4f"
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Wartość musi wynosić nie więcej niż %.4f"
@@ -2820,7 +2823,7 @@ msgstr "Wartość musi wynosić zero lub więcej"
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr "Wartości"
 
@@ -2832,15 +2835,15 @@ msgstr "Producent"
 msgid "View"
 msgstr "Widok"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr "UWAGA!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr "Uwaga"
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr "Uwaga: %s"
@@ -2885,11 +2888,11 @@ msgstr "bajtów"
 msgid "bytes each"
 msgstr "bajtów każdy"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr "wyłączony"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr "włączony"
 

--- a/chirp/locale/pt_BR.po
+++ b/chirp/locale/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2013-03-30 22:04-0300\n"
 "Last-Translator: Crezivando <crezivando@gmail.com>\n"
 "Language-Team: Language pt-BR\n"
@@ -22,21 +22,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Apagar (e deslocar)"
 msgstr[1] "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Mem�rias"
 msgstr[1] "Mem�rias"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -68,7 +68,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -543,7 +543,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -553,7 +553,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -563,7 +563,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -571,7 +571,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the key to send image.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -657,7 +657,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -698,8 +698,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Ocorreu um erro"
 
@@ -716,7 +715,7 @@ msgstr "Offset Autom�tico Repetidoras"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr ""
 
@@ -771,11 +770,11 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -788,17 +787,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS Code"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Modo Cross"
@@ -812,7 +811,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "Modo Cross"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr ""
 
@@ -825,8 +824,12 @@ msgstr "Selecionar um para importar de:"
 msgid "City"
 msgstr ""
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -843,23 +846,23 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Clonando"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Descarregar a partir do R�dio"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Carregar para o R�dio"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr ""
 
@@ -875,7 +878,7 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -909,11 +912,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Copiar"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -935,11 +938,11 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Cortar"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -960,11 +963,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr ""
 
@@ -973,11 +976,11 @@ msgstr ""
 msgid "Dec"
 msgstr "Detectar"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Apagar"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -991,20 +994,20 @@ msgstr "Recuperando informa��es do banco"
 msgid "Developer Mode"
 msgstr "Desenvolvedor"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Diff Mem�rias Raw"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "C�digo Digital"
 
@@ -1013,7 +1016,7 @@ msgstr "C�digo Digital"
 msgid "Digital Modes"
 msgstr "C�digo Digital"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr ""
 
@@ -1053,12 +1056,12 @@ msgstr "Descarregar a partir do R�dio"
 msgid "Download from radio..."
 msgstr "Descarregar a partir do R�dio"
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 #, fuzzy
 msgid "Download instructions"
 msgstr "Descarregar a partir do R�dio"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr ""
 
@@ -1078,17 +1081,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1106,11 +1109,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Frequ�ncia"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1143,7 +1146,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "Apagando mem�ria {loc}"
@@ -1158,7 +1161,7 @@ msgstr "Erro gravando mem�ria"
 msgid "Error applying settings"
 msgstr "Erro gravando mem�ria"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr ""
 
@@ -1198,11 +1201,11 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1216,7 +1219,7 @@ msgstr "Exportar Para Arquivo"
 msgid "Export to CSV..."
 msgstr "Exportar Para Arquivo"
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr ""
 
@@ -1243,8 +1246,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr ""
 
@@ -1308,7 +1311,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1351,11 +1354,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1421,7 +1424,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1448,7 +1451,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1466,11 +1469,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1506,17 +1509,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -1577,7 +1580,7 @@ msgstr ""
 msgid "Import"
 msgstr "Importar"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1608,11 +1611,11 @@ msgstr "�ndice"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Inserir row acima"
@@ -1625,7 +1628,7 @@ msgstr ""
 msgid "Interact with driver"
 msgstr ""
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 #, fuzzy
 msgid "Internal driver error"
 msgstr "Erro Interno"
@@ -1635,8 +1638,8 @@ msgstr "Erro Interno"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Valor inv�lido. Deve ser um n�mero inteiro."
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Valor Inv�lido para este campo"
@@ -1645,7 +1648,7 @@ msgstr "Valor Inv�lido para este campo"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1672,7 +1675,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 #, fuzzy
 msgid "Language"
 msgstr "Mudar idioma"
@@ -1733,7 +1736,7 @@ msgstr "Modo Tom"
 msgid "Load module from issue..."
 msgstr "Modo Tom"
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
@@ -1766,7 +1769,7 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -1779,7 +1782,7 @@ msgstr "Mem�rias"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1802,8 +1805,8 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 #, fuzzy
 msgid "Mode"
 msgstr "Modo"
@@ -1825,11 +1828,11 @@ msgstr ""
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr ""
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr ""
 
@@ -1838,7 +1841,7 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -1853,7 +1856,7 @@ msgstr "Mover Abaix_o"
 msgid "Move Up"
 msgstr "Mover _Acima"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1861,11 +1864,11 @@ msgstr ""
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Inserir row abaixo"
@@ -1884,20 +1887,20 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr ""
 
@@ -2017,7 +2020,7 @@ msgstr "Op��es"
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Sobrescrever?"
@@ -2029,8 +2032,8 @@ msgid ""
 "are supported in this release.\n"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr ""
 
@@ -2038,39 +2041,39 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Colar"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -2104,11 +2107,11 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr ""
 
@@ -2149,7 +2152,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr ""
 
@@ -2165,7 +2168,7 @@ msgstr ""
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr ""
@@ -2186,8 +2189,8 @@ msgstr ""
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr ""
 
@@ -2204,7 +2207,7 @@ msgstr "R�dio"
 msgid "Radio did not ack block %i"
 msgstr ""
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 #, fuzzy
 msgid "Radio information"
 msgstr "Recuperando informa��es do banco"
@@ -2255,11 +2258,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
@@ -2309,11 +2312,11 @@ msgstr "Emiss�o de Relat�rios desabilitada"
 msgid "Reporting enabled"
 msgstr "Emiss�o de Relat�rios desabilitada"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr ""
 
@@ -2332,7 +2335,7 @@ msgstr ""
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr ""
 
@@ -2348,7 +2351,7 @@ msgstr ""
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr ""
 
@@ -2360,7 +2363,7 @@ msgstr ""
 msgid "Scanlists"
 msgstr ""
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr ""
 
@@ -2389,7 +2392,7 @@ msgstr "Selecionar Colunas"
 msgid "Select Modes"
 msgstr "Selecionar Colunas"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr ""
 
@@ -2418,7 +2421,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Mostrar Mem�ria Raw"
 
@@ -2438,52 +2441,52 @@ msgstr ""
 msgid "Skip"
 msgstr "Skip"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Mem�ria colada {number} n�o � compat�vel com este r�dio porque:"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Diff Mem�rias Raw"
 msgstr[1] "Diff Mem�rias Raw"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Diff Mem�rias Raw"
 msgstr[1] "Diff Mem�rias Raw"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Diff Mem�rias Raw"
 msgstr[1] "Diff Mem�rias Raw"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 #, fuzzy
 msgid "Sort memories"
 msgstr "Sobrescrever?"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr ""
 
@@ -2495,7 +2498,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr ""
 
@@ -2568,7 +2571,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 #, fuzzy
 msgid "This Memory"
 msgstr "Mostrar Mem�ria Raw"
@@ -2623,12 +2626,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Apagar (e deslocar)"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Apagar (e deslocar)"
@@ -2718,7 +2721,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2727,18 +2730,18 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr "Abrir config do estoque"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Incapaz de detectar r�dio na {port}"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "Incapaz de detectar r�dio na {port}"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr ""
 
@@ -2746,7 +2749,7 @@ msgstr ""
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr ""
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Incapaz de efetuar altera��es para este modelo"
@@ -2787,7 +2790,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr "Atualizando lista URCALL"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr ""
 
@@ -2805,7 +2808,7 @@ msgstr "Carregar para o R�dio"
 msgid "Upload to radio..."
 msgstr "Carregar para o R�dio"
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
@@ -2831,12 +2834,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2854,7 +2857,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr ""
 
@@ -2867,15 +2870,15 @@ msgstr "Fornecedor"
 msgid "View"
 msgstr "_Visualizar"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2920,11 +2923,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/ro_RO.po
+++ b/chirp/locale/ro_RO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2025-02-27 08:00+0200\n"
 "Last-Translator: ThatSINEWAVE\n"
 "Language-Team: Romanian\n"
@@ -22,21 +22,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s trebuie să fie între %(min)i și %(max)i"
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Memorie și deplasare sus toate"
 msgstr[1] "%i Memorii și deplasare sus toate"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Memorie"
 msgstr[1] "%i Memorii"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -68,7 +68,7 @@ msgstr "(A funcționat vreodată acest lucru înainte? Este un radio nou? Funcț
 msgid "(none)"
 msgstr "(niciunul)"
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr "...și încă %i mai multe"
@@ -813,7 +813,7 @@ msgstr ""
 "5. Asigură-te că stația este setată pe un canal fără activitate.\n"
 "6. Apasă OK pentru a încărca imaginea în dispozitiv.\n"
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -829,7 +829,7 @@ msgstr ""
 "5. Asigură-te că stația este setată pe un canal fără activitate.\n"
 "6. Apasă OK pentru a descărca imaginea din dispozitiv.\n"
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -845,7 +845,7 @@ msgstr ""
 "5. Asigură-te că stația este setată pe un canal fără activitate.\n"
 "6. Apasă OK pentru a încărca imaginea în dispozitiv.\n"
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -857,7 +857,7 @@ msgstr ""
 "3. Pregătește stația pentru clonare.\n"
 "4. <b>După ce apesi OK</b>, apasă tasta pentru a trimite imaginea.\n"
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -991,7 +991,7 @@ msgstr ""
 "\n"
 "Poate să nu funcționeze dacă pornești stația cu cablul deja conectat."
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "O nouă versiune CHIRP este disponibilă. Vă rugăm să vizitați site-ul cât mai curând posibil pentru a o descărca!"
 
@@ -1007,7 +1007,7 @@ msgstr "Despre"
 msgid "About CHIRP"
 msgstr "Despre CHIRP"
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr "Sunt de acord"
 
@@ -1031,8 +1031,7 @@ msgstr "Începe întotdeauna cu lista recentă"
 msgid "Amateur"
 msgstr "Amator"
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "A apărut o eroare"
 
@@ -1048,7 +1047,7 @@ msgstr "Automat din sistem"
 msgid "Available modules"
 msgstr "Module disponibile"
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "Plan de benzi"
 
@@ -1103,11 +1102,11 @@ msgstr "Rezultatele cache pot fi incluse doar pentru o interogare de proximitate
 msgid "Canada"
 msgstr "Canada"
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Schimbarea acestei setări necesită reîmprospătarea setărilor din imagine, ceea ce va avea loc acum."
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Canalele cu TX și RX echivalente %s sunt reprezentate de modul de ton \"%s\""
@@ -1120,17 +1119,17 @@ msgstr "Fișiere Imagine Chirp"
 msgid "Choice Required"
 msgstr "Alegere necesară"
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Alege Codul DTCS %s"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Alege Tonul %s"
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr "Alege Modul Cross"
 
@@ -1142,7 +1141,7 @@ msgstr "Alege Ținta Diferenței"
 msgid "Choose a recent model"
 msgstr "Alege un model recent"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr "Alege duplex"
 
@@ -1155,9 +1154,13 @@ msgstr "Alege modulul de încărcat din problema %i:"
 msgid "City"
 msgstr "Oraș"
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
 msgstr "Click aici pentru textul complet al licenței"
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
+msgstr ""
 
 #: ../drivers/ts590.py:671
 msgid ""
@@ -1179,21 +1182,21 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Clonare finalizată, verificare pentru octeți spurii"
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Clonare"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr "Clonare din stație"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr "Clonare către stație"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "Închide"
 
@@ -1209,7 +1212,7 @@ msgstr "Închide fișierul"
 msgid "Close string value with double-quote (\")"
 msgstr "Închide valoarea șirului cu ghilimea (\")"
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1244,11 +1247,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "Convertește la FM"
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Copiază"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -1269,11 +1272,11 @@ msgstr "Port personalizat"
 msgid "Custom..."
 msgstr "Personalizat..."
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Taie"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr "Taie %i memorii"
@@ -1294,11 +1297,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "Decodare DTMF"
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr "Memorie DV"
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr "Pericol în față"
 
@@ -1306,11 +1309,11 @@ msgstr "Pericol în față"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Șterge"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr "Șterge memorii"
 
@@ -1322,20 +1325,20 @@ msgstr "Informații detaliate"
 msgid "Developer Mode"
 msgstr "Mod dezvoltator"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Starea dezvoltatorului este acum %s. CHIRP trebuie repornit pentru a intra în vigoare"
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Diferență memorii brute"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr "Diferență față de un alt editor"
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Cod digital"
 
@@ -1343,7 +1346,7 @@ msgstr "Cod digital"
 msgid "Digital Modes"
 msgstr "Moduri digitale"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr "Dezactivează raportarea"
 
@@ -1381,11 +1384,11 @@ msgstr "Descarcă din stație"
 msgid "Download from radio..."
 msgstr "Descarcă din stație..."
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "Instrucțiuni pentru descărcare"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr "Driver"
 
@@ -1405,17 +1408,17 @@ msgstr "Repetoarele digitale cu mod dublu care suportă analog vor fi afișate c
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr "Editați %i memorii"
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Editați detaliile pentru %i memorii"
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Editați detaliile pentru memoria %i"
@@ -1432,11 +1435,11 @@ msgstr "Activat"
 msgid "Enter Frequency"
 msgstr "Introduceți frecvența"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr "Introduceți offset-ul (MHz)"
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr "Introduceți frecvența TX (MHz)"
 
@@ -1469,7 +1472,7 @@ msgstr "Introduceți numărul bug-ului care trebuie actualizat"
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr "Introduceți numele de utilizator și parola pentru chirpmyradio.com. Dacă nu aveți un cont, faceți clic mai jos pentru a crea unul înainte de a continua."
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr "Memoria ștearsă %s"
@@ -1482,7 +1485,7 @@ msgstr "Eroare la aplicarea filtrului"
 msgid "Error applying settings"
 msgstr "Eroare la aplicarea setărilor"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "Eroare la comunicarea cu stația"
 
@@ -1522,11 +1525,11 @@ msgstr "Exemplu: name~\"myrepea\""
 msgid "Exclude private and closed repeaters"
 msgstr "Exclude repetoarele private și închise"
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "Driver experimental"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr "Exportul poate scrie doar fișiere CSV"
 
@@ -1538,7 +1541,7 @@ msgstr "Exportă în CSV"
 msgid "Export to CSV..."
 msgstr "Exportă în CSV..."
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr "Extra"
 
@@ -1567,8 +1570,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr "Nu s-a reușit încărcarea browserului radio"
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr "Nu s-a reușit analizarea rezultatului"
 
@@ -1630,7 +1633,7 @@ msgstr "Termină Float"
 msgid "Finish float value like: 146.52"
 msgstr "Termină valoarea float ca: 146.52"
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Job-ul stației %s s-a terminat"
@@ -1695,11 +1698,11 @@ msgstr ""
 "5 - Deconectează cablul de interfață! Altfel nu va exista\n"
 "    audio pe partea dreaptă!\n"
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1803,7 +1806,7 @@ msgstr ""
 "    audio pe partea dreaptă!\n"
 "6 - Oprește și pornește din nou stația pentru a ieși din modul de clonare\n"
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1845,7 +1848,7 @@ msgstr ""
 "3 - Pornește stația\n"
 "4 - Apasă OK pentru a începe\n"
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1873,11 +1876,11 @@ msgstr ""
 "3 - Pornește stația\n"
 "4 - Fă descărcarea datelor stației tale\n"
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1923,17 +1926,17 @@ msgstr "Frecvența %s este în afara intervalului acceptat"
 msgid "Frequency granularity in kHz"
 msgstr "Granularitatea frecvenței în kHz"
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr "Frecvența din acest interval nu trebuie să fie în modul AM"
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr "Frecvența din acest interval necesită modul AM"
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr "Frecvența este în afacerea benzilor TX și trebuie să fie duplex=OFF"
 
@@ -1992,7 +1995,7 @@ msgstr "Dacă este setat, sortează rezultatele după distanța față de aceste
 msgid "Import"
 msgstr "Importă"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr "Importă %i memorii"
@@ -2021,11 +2024,11 @@ msgstr "Index"
 msgid "Info"
 msgstr "Info"
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr "Informații"
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr "Inserare linie deasupra"
 
@@ -2037,7 +2040,7 @@ msgstr "Instalare iconiță pe desktop?"
 msgid "Interact with driver"
 msgstr "Interacționează cu driverul"
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 msgid "Internal driver error"
 msgstr "Eroare internă a driverului"
 
@@ -2046,8 +2049,8 @@ msgstr "Eroare internă a driverului"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s invalid (folosiți grade zecimale)"
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 msgid "Invalid Entry"
 msgstr "Intrare invalidă"
 
@@ -2055,7 +2058,7 @@ msgstr "Intrare invalidă"
 msgid "Invalid ZIP code"
 msgstr "Cod poștal invalid"
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Editare invalidă: %s"
@@ -2081,7 +2084,7 @@ msgstr "Număr problemă:"
 msgid "LIVE"
 msgstr "LIVE"
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 msgid "Language"
 msgstr "Limbă"
 
@@ -2137,7 +2140,7 @@ msgstr "Încarcă modul din numărul de problemă..."
 msgid "Load module from issue..."
 msgstr "Încarcă modul din numărul de problemă..."
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr "Încărcarea unui modul nu va afecta tab-urile deschise. Se recomandă (cu excepția cazului în care vi se spune altfel) să închideți toate tab-urile înainte de a încărca un modul."
 
@@ -2170,7 +2173,7 @@ msgstr "Șir logo 2 (12 caractere)"
 msgid "Longitude"
 msgstr "Longitudine"
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr "Editare manuală a memoriei %i"
@@ -2183,7 +2186,7 @@ msgstr "Memorii"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr "Memoriile sunt doar citire din cauza versiunii de firmware neacceptate"
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Memoria %i nu poate fi ștearsă"
@@ -2206,8 +2209,8 @@ msgstr "Memoria trebuie să fie într-o bancă pentru a fi editată"
 msgid "Memory {num} not in bank {bank}"
 msgstr "Memoria {num} nu este în banca {bank}"
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 msgid "Mode"
 msgstr "Mod"
 
@@ -2227,11 +2230,11 @@ msgstr "Modul"
 msgid "Module Loaded"
 msgstr "Modul încărcat"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr "Modul încărcat cu succes"
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr "Mai multe informații"
 
@@ -2240,7 +2243,7 @@ msgstr "Mai multe informații"
 msgid "More than one port found: %s"
 msgstr "Mai multe porturi găsite: %s"
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr "Mută %i memorii"
@@ -2253,7 +2256,7 @@ msgstr "Mută în jos"
 msgid "Move Up"
 msgstr "Mută în sus"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Operațiile de mutare sunt dezactivate în timp ce vizualizarea este sortată"
 
@@ -2261,11 +2264,11 @@ msgstr "Operațiile de mutare sunt dezactivate în timp ce vizualizarea este sor
 msgid "New Window"
 msgstr "Fereastră nouă"
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "Versiune nouă disponibilă"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr "Nu există rânduri goale sub!"
 
@@ -2283,20 +2286,20 @@ msgstr "Nu au fost găsite module"
 msgid "No modules found in issue %i"
 msgstr "Nu au fost găsite module în problema %"
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr "Nu mai este spațiu disponibil; unele memorii nu au fost aplicate"
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr "Niciun rezultat"
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr "Niciun rezultat!"
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr "Număr"
 
@@ -2411,7 +2414,7 @@ msgstr "Opțional: AA00 - AA00aa11"
 msgid "Optional: County, Hospital, etc."
 msgstr "Opțional: Județ, Spital, etc."
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 msgid "Overwrite memories?"
 msgstr "Diff raw memories"
 
@@ -2425,8 +2428,8 @@ msgstr ""
 "Doar un subset din cele peste 130 de setări radio disponibile\n"
 "sunt suportate în această versiune.\n"
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr "Analizare"
 
@@ -2434,39 +2437,39 @@ msgstr "Analizare"
 msgid "Password"
 msgstr "Parolă"
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Lipește"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr "Lipește memoriile externe"
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr "Lipește memoriile"
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Memoriile lipite vor suprascrie %s dintre memoriile existente"
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Memoriile lipite vor suprascrie memoriile %s"
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Memoriile lipite vor suprascrie memoria %s"
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Memoria lipită va suprascrie memoria %s"
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Te rugăm să te asiguri că închizi CHIRP înainte de a instala noua versiune!"
 
@@ -2518,11 +2521,11 @@ msgstr ""
 "4 - Apoi apasă butonul \"A\" de pe stația ta pentru a începe clonarea.\n"
 "    (La final, stația va emite un bip)\n"
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr "Te rugăm să reții că modul de dezvoltator este destinat utilizării de către dezvoltatorii proiectului CHIRP sau sub direcția unui dezvoltator. Aceasta activează comportamente și funcții care pot deteriora computerul tău și stația ta dacă nu sunt folosite cu EXTREMĂ prudență. Ai fost avertizat! Continuă oricum?"
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "Te rugăm să aștepți"
 
@@ -2562,7 +2565,7 @@ msgstr "Tipărire"
 msgid "Prolific USB device"
 msgstr "Dispozitiv USB Prolific"
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr "Proprietăți"
 
@@ -2578,7 +2581,7 @@ msgstr "Valoare proprietate"
 msgid "QTH Locator"
 msgstr "Locator QTH"
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr "Interogare %s"
@@ -2599,8 +2602,8 @@ msgstr "Sintaxă interogare OK"
 msgid "Query syntax help"
 msgstr "Ajutor sintaxă interogare"
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr "Interogare"
 
@@ -2617,7 +2620,7 @@ msgstr "Statie"
 msgid "Radio did not ack block %i"
 msgstr "Stația nu a confirmat blocul %i"
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr "Informații stație"
 
@@ -2667,11 +2670,11 @@ msgstr "Se recomandă utilizarea versiunii 55.2"
 msgid "Redo"
 msgstr "Refă"
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr "Reîmprospătare necesară"
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Memoria %s actualizată"
@@ -2721,11 +2724,11 @@ msgstr "Raportarea unui bug nou: %r"
 msgid "Reporting enabled"
 msgstr "Raportarea activată"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr "Raportarea ajută proiectul CHIRP să știe pe ce modele de stații și platforme OS să aloce eforturile noastre limitate. Am aprecia foarte mult dacă ați lăsa-o activată. Doriți să dezactivați raportarea?"
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "Repornire necesară"
 
@@ -2744,7 +2747,7 @@ msgstr "Restabilește tab-urile la început"
 msgid "Results from other areas"
 msgstr "Rezultate din alte zone"
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "Setări recuperate"
 
@@ -2760,7 +2763,7 @@ msgstr "Vrei să salvezi înainte de a închide?"
 msgid "Save file"
 msgstr "Salvează fișierul"
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "Setări salvate"
 
@@ -2772,7 +2775,7 @@ msgstr "Control scanare (skip, include, prioritate, etc.)"
 msgid "Scanlists"
 msgstr "Liste de scanare"
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr "Scrambler"
 
@@ -2797,7 +2800,7 @@ msgstr "Selectați coloanele"
 msgid "Select Modes"
 msgstr "Selectați coloanele"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "Selectează un plan de bandă"
 
@@ -2825,7 +2828,7 @@ msgstr "Setările sunt doar în citire din cauza versiunii de firmware neaccepta
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Cantitatea de deplasare (sau frecvența de transmisie) controlată de duplex"
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Afișează memoria brută"
 
@@ -2845,50 +2848,50 @@ msgstr "Afișează locația de backup a imaginii"
 msgid "Skip"
 msgstr "Skip"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr "Unele memorii sunt incompatibile cu această stație"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr "Unele memorii nu pot fi șterse"
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr "Sortează %i memorii"
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Sortează %i memorie"
 msgstr[1] "Sortează %i memorii"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Sortează %i memorie ascendent"
 msgstr[1] "Sortează %i memorii ascendente"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Sortează %i memorie ascendent"
 msgstr[1] "Sortează %i memorii ascendente"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr "Sortare după coloană:"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 msgid "Sort memories"
 msgstr "Diferențierea memoriilor brute"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr "Sortare"
 
@@ -2900,7 +2903,7 @@ msgstr "Stat"
 msgid "State/Province"
 msgstr "Județ/Provincie"
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr "Succes"
 
@@ -2993,7 +2996,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "Procedura recomandată pentru importarea memoriilor este să deschizi fișierul sursă și să copiezi/lipiți memoriile din acesta în imaginea țintă. Dacă continui cu această funcție de import, CHIRP va înlocui toate memoriile din fișierul deschis în prezent cu cele din %(file)s. Ai dori să deschizi acest fișier pentru a copia/lipi memoriile sau să continui cu importul?"
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 msgid "This Memory"
 msgstr "Această memorie"
 
@@ -3056,11 +3059,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr "Acesta este numărul tichetului pentru o problemă deja creată pe site-ul chirpmyradio.com"
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 msgid "This memory and shift all up"
 msgstr "Această memorie și blocul de schimbare în sus"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 msgid "This memory and shift block up"
 msgstr "Această memorie și toate schimbările în sus"
 
@@ -3151,7 +3154,7 @@ msgstr "Găsitor de porturi USB"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Nu s-a putut determina portul pentru cablul dvs. Verificați driverele și conexiunile."
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Nu se poate edita memoria înainte de a încărca radioul"
 
@@ -3160,16 +3163,16 @@ msgstr "Nu se poate edita memoria înainte de a încărca radioul"
 msgid "Unable to find stock config %r"
 msgstr "Nu s-a putut găsi configurația implicită %r"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 msgid "Unable to import while the view is sorted"
 msgstr "Nu se poate importa cât timp vizualizarea este sortată"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr "Nu se poate deschide clipboard-ul"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr "Nu se poate interoga"
 
@@ -3177,7 +3180,7 @@ msgstr "Nu se poate interoga"
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr "Nu s-a putut citi ultimul bloc. Acest lucru se întâmplă adesea când modelul selectat este US, dar radioul este unul non-US (sau deblocat pentru frecvențe extinse). Vă rugăm să alegeți modelul corect și să încercați din nou."
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Nu se poate afișa %s pe acest sistem"
@@ -3217,7 +3220,7 @@ msgstr "Actualizează o eroare existentă"
 msgid "Updating bug %s"
 msgstr "Actualizarea erorii %s"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "Instrucțiuni pentru încărcare"
 
@@ -3233,7 +3236,7 @@ msgstr "Încarcă în stație"
 msgid "Upload to radio..."
 msgstr "Încarcă în stație"
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Memorie încărcată %s"
@@ -3259,12 +3262,12 @@ msgstr "Nume utilizator"
 msgid "Value does not fit in %i bits"
 msgstr "Valoarea nu se încadrează în %i biți"
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Valoarea trebuie să fie cel puțin %.4f"
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Valoarea trebuie să fie cel mult %.4f"
@@ -3282,7 +3285,7 @@ msgstr "Valoarea trebuie să fie zero sau mai mare"
 msgid "Value to search memory field for"
 msgstr "Valoare pentru căutarea câmpului de memorie"
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr "Valori"
 
@@ -3294,15 +3297,15 @@ msgstr "Furnizor"
 msgid "View"
 msgstr "Vizualizează"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr "ATENȚIE!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr "Atenție"
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr "Atenție: %s"
@@ -3347,11 +3350,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "bytes fiecare"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr "Dezactivat"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr "Activat"
 

--- a/chirp/locale/ru.po
+++ b/chirp/locale/ru.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2023-10-11 16:47+0300\n"
 "Last-Translator: Olesya Gerasimenko <translation-team@basealt.ru>\n"
 "Language-Team: Basealt Translation Team\n"
@@ -19,7 +19,7 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s должно находиться в диапазоне от %(min)i до %(max)i"
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
@@ -27,7 +27,7 @@ msgstr[0] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[1] "Ячейки памяти (%i) и сдвинуть все вверх"
 msgstr[2] "Ячейки памяти (%i) и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
@@ -35,7 +35,7 @@ msgstr[0] "Ячейки памяти (%i)"
 msgstr[1] "Ячейки памяти (%i)"
 msgstr[2] "Ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -68,7 +68,7 @@ msgstr ""
 msgid "(none)"
 msgstr "(нет)"
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr "...и ещё %i"
@@ -813,7 +813,7 @@ msgstr ""
 "5. Убедитесь, что станция настроена на неактивный канал.\n"
 "6. Нажмите «ОК» для отправки образа на устройство.\n"
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -829,7 +829,7 @@ msgstr ""
 "5. Убедитесь, что станция настроена на неактивный канал.\n"
 "6. Нажмите «ОК» для загрузки образа с устройства.\n"
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -845,7 +845,7 @@ msgstr ""
 "5. Убедитесь, что станция настроена на неактивный канал.\n"
 "6. Нажмите «ОК» для отправки образа на устройство.\n"
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -857,7 +857,7 @@ msgstr ""
 "3. Подготовьте станцию для клонирования.\n"
 "4. <b>После нажатия «ОК»</b> нажмите клавишу для отправки образа.\n"
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -994,7 +994,7 @@ msgstr ""
 "\n"
 "Отправка может не получиться, если вы включите станцию, когда кабель уже подключён"
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "Доступная новая версия программы CHIRP. Как можно скорее загрузите её на веб-сайте!"
 
@@ -1010,7 +1010,7 @@ msgstr "О программе"
 msgid "About CHIRP"
 msgstr "О программе CHIRP"
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -1034,8 +1034,7 @@ msgstr ""
 msgid "Amateur"
 msgstr "Любительская радиосвязь"
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Ошибка"
 
@@ -1052,7 +1051,7 @@ msgstr "Авторазнос для репитера"
 msgid "Available modules"
 msgstr "Доступные модули"
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "Частотный план"
 
@@ -1110,11 +1109,11 @@ msgstr ""
 msgid "Canada"
 msgstr "Канада"
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Для изменения этого параметра требуется обновить параметры из образа, что и будет сейчас выполнено."
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Каналы с эквивалентными TX и RX %s представлены видом субтона «%s»."
@@ -1127,17 +1126,17 @@ msgstr "Файлы образов Chirp"
 msgid "Choice Required"
 msgstr "Необходимо сделать выбор"
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "Выберите код DTCS %s"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr "Выберите тон %s"
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr "Выберите кросс-режим"
 
@@ -1150,7 +1149,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "Выберите кросс-режим"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr "Выберите дуплекс"
 
@@ -1163,8 +1162,12 @@ msgstr "Выберите модуль для загрузки из задачи 
 msgid "City"
 msgstr "Город"
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -1187,21 +1190,21 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Клонирование завершено, проверка наличия ложных байтов"
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Клонирование"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr "Клонирование из станции"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr "Клонирование на станцию"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "Закрыть"
 
@@ -1218,7 +1221,7 @@ msgstr "Закрыть файл"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1254,11 +1257,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Копировать"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -1280,11 +1283,11 @@ msgstr "Пользовательский порт"
 msgid "Custom..."
 msgstr "Пользовательский..."
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Вырезать"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -1305,11 +1308,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr "DV-память"
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr "Впереди опасность"
 
@@ -1317,11 +1320,11 @@ msgstr "Впереди опасность"
 msgid "Dec"
 msgstr "Десятичный"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Удалить"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -1334,20 +1337,20 @@ msgstr "Информация о станции"
 msgid "Developer Mode"
 msgstr "Режим разработчика"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Режим разработчика теперь %s. Для применения изменений необходимо перезапустить CHIRP"
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Сравнить необработанные ячейки памяти"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Цифровой код"
 
@@ -1356,7 +1359,7 @@ msgstr "Цифровой код"
 msgid "Digital Modes"
 msgstr "Цифровой код"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr "Отключить отправку отчётов"
 
@@ -1394,11 +1397,11 @@ msgstr "Загрузить из станции"
 msgid "Download from radio..."
 msgstr "Загрузить из станции..."
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "Инструкции по загрузке"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 #, fuzzy
 msgid "Driver"
 msgstr "Перезагрузить драйвер"
@@ -1419,17 +1422,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "Редактировать сведения о ячейках памяти (%i)"
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "Редактировать сведения о ячейке памяти (%i)"
@@ -1446,11 +1449,11 @@ msgstr "Включено"
 msgid "Enter Frequency"
 msgstr "Введите частоту"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr "Введите смещение (МГц)"
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr "Введите частоту TX (МГц)"
 
@@ -1483,7 +1486,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr "Стёрта ячейка памяти %s"
@@ -1497,7 +1500,7 @@ msgstr "Ошибка применения параметров"
 msgid "Error applying settings"
 msgstr "Ошибка применения параметров"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "Ошибка обмена данными со станцией"
 
@@ -1537,11 +1540,11 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "Экспериментальный драйвер"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr "При экспорте можно выполнять запись только в файлы CSV"
 
@@ -1553,7 +1556,7 @@ msgstr "Экспорт в CSV"
 msgid "Export to CSV..."
 msgstr "Экспорт в CSV..."
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr "Дополнительно"
 
@@ -1583,8 +1586,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr "Не удалось загрузить браузер станций"
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr "Не удалось проанализировать результат"
 
@@ -1649,7 +1652,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "Завершено задание станции %s"
@@ -1715,11 +1718,11 @@ msgstr ""
 "5 - Отключите интерфейсный кабель! Иначе с правой стороны\n"
 "    не будет звука!\n"
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1825,7 +1828,7 @@ msgstr ""
 "6 - Выключите и снова включите питание станции, чтобы выйти\n"
 "    из режима клонирования\n"
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1867,7 +1870,7 @@ msgstr ""
 "3 - Включите вашу станцию\n"
 "4 - Чтобы начать, нажмите «ОК»\n"
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1895,11 +1898,11 @@ msgstr ""
 "3 - Включите вашу станцию\n"
 "4 - Выполните загрузку ваших радиоданных\n"
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1945,17 +1948,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -2014,7 +2017,7 @@ msgstr "Если установлено, упорядочить результа
 msgid "Import"
 msgstr "Импорт"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -2043,11 +2046,11 @@ msgstr "Индекс"
 msgid "Info"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr "Информация"
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr "Вставить строку выше"
 
@@ -2059,7 +2062,7 @@ msgstr "Создать значок на рабочем столе?"
 msgid "Interact with driver"
 msgstr "Обмен данными с драйвером"
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 #, fuzzy
 msgid "Internal driver error"
 msgstr "Ошибка"
@@ -2069,8 +2072,8 @@ msgstr "Ошибка"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "%(value)s — неверно (используйте десятичные градусы)"
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 msgid "Invalid Entry"
 msgstr "Некорректная запись"
 
@@ -2078,7 +2081,7 @@ msgstr "Некорректная запись"
 msgid "Invalid ZIP code"
 msgstr "Неверный почтовый индекс"
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Некорректное изменение: %s"
@@ -2105,7 +2108,7 @@ msgstr "Номер задачи:"
 msgid "LIVE"
 msgstr "В ЭФИРЕ"
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 #, fuzzy
 msgid "Language"
 msgstr "Изменить язык"
@@ -2165,7 +2168,7 @@ msgstr "Загрузить модуль из задачи"
 msgid "Load module from issue..."
 msgstr "Загрузить модуль из задачи..."
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
@@ -2198,7 +2201,7 @@ msgstr ""
 msgid "Longitude"
 msgstr "Долгота"
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -2211,7 +2214,7 @@ msgstr "Ячейки памяти"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Ячейку памяти %i нельзя удалить"
@@ -2234,8 +2237,8 @@ msgstr "Чтобы редактировать ячейку памяти, нео�
 msgid "Memory {num} not in bank {bank}"
 msgstr "Ячейка памяти {num} отсутствует в банке {bank}"
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 msgid "Mode"
 msgstr "Режим"
 
@@ -2255,11 +2258,11 @@ msgstr "Модуль"
 msgid "Module Loaded"
 msgstr "Модуль загружен"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr "Модуль успешно загружен"
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 #, fuzzy
 msgid "More Info"
 msgstr "Информация"
@@ -2269,7 +2272,7 @@ msgstr "Информация"
 msgid "More than one port found: %s"
 msgstr "Найдено более одного порта: %s"
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -2282,7 +2285,7 @@ msgstr "Переместить вниз"
 msgid "Move Up"
 msgstr "Переместить вверх"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -2290,11 +2293,11 @@ msgstr ""
 msgid "New Window"
 msgstr "Новое окно"
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "Доступна новая версия"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr "Ниже нет пустых строк!"
 
@@ -2312,20 +2315,20 @@ msgstr "Модули не найдены"
 msgid "No modules found in issue %i"
 msgstr "В задаче %i не найдены модули"
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr "Нет результатов"
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr "Нет результатов!"
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr "Число"
 
@@ -2442,7 +2445,7 @@ msgstr "Опционально: -122.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "Опционально: округ, больница и т.д."
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 msgid "Overwrite memories?"
 msgstr "Перезаписать ячейки памяти?"
 
@@ -2456,8 +2459,8 @@ msgstr ""
 "В этой версии поддерживается только часть из\n"
 "более чем 130 доступных параметров станции.\n"
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr "Анализ"
 
@@ -2465,39 +2468,39 @@ msgstr "Анализ"
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Вставить"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Вставленные ячейки памяти перезапишут существующие ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейки памяти (%s)"
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Вставленные ячейки памяти перезапишут ячейку памяти %s"
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Вставленная ячейка памяти перезапишет ячейку памяти %s"
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Обязательно выйдите из программы CHIRP перед установкой новой версии!"
 
@@ -2549,11 +2552,11 @@ msgstr ""
 "4 - Затем нажмите кнопку «A» на вашей станции для начала клонирования.\n"
 "    (По завершении станция подаст звуковой сигнал.)\n"
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr "Обратите внимание, что режим разработчика предназначен для использования разработчиками проекта CHIRP или под руководством разработчика. В этом режиме включаются поведение и функции, которые следует использовать КРАЙНЕ осторожно, чтобы не навредить вашему компьютеру и вашей станции. Вы были предупреждены. Всё равно продолжить?"
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "Подождите"
 
@@ -2593,7 +2596,7 @@ msgstr "Печать"
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr "Свойства"
 
@@ -2611,7 +2614,7 @@ msgstr "Свойства"
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr "Запрос %s"
@@ -2633,8 +2636,8 @@ msgstr "Запрос %s"
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 #, fuzzy
 msgid "Querying"
 msgstr "Запрос %s"
@@ -2652,7 +2655,7 @@ msgstr "Станция"
 msgid "Radio did not ack block %i"
 msgstr "Станция не распознала блок %i"
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr "Информация о станции"
 
@@ -2702,11 +2705,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr "Требуется обновление"
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Обновлена ячейки памяти %s"
@@ -2754,11 +2757,11 @@ msgstr "Отправка отчётов включена"
 msgid "Reporting enabled"
 msgstr "Отправка отчётов включена"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr "Отправка отчётов помогает проекту CHIRP получать информацию о том, какие модели станций и платформы ОС требуют нашего внимания. Мы будем очень признательны, если вы оставите эту функцию включённой. Действительно отключить отправку отчётов?"
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "Требуется перезапуск"
 
@@ -2779,7 +2782,7 @@ msgstr "Восстановить вкладки (%i)"
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "Полученные параметры"
 
@@ -2795,7 +2798,7 @@ msgstr "Сохранить перед закрытием?"
 msgid "Save file"
 msgstr "Сохранить файл"
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "Сохранённые параметры"
 
@@ -2807,7 +2810,7 @@ msgstr ""
 msgid "Scanlists"
 msgstr ""
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr ""
 
@@ -2833,7 +2836,7 @@ msgstr "Выбор полос частот"
 msgid "Select Modes"
 msgstr "Выбор режимов"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "Выбор частотного плана"
 
@@ -2862,7 +2865,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Показать необработанную ячейку памяти"
 
@@ -2883,20 +2886,20 @@ msgstr "Показать расположение журнала отладки"
 msgid "Skip"
 msgstr "Пропуск"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr "Некоторые ячейки памяти несовместимы с этой станцией"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr "Некоторые ячейки памяти нельзя удалить"
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
@@ -2904,7 +2907,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i)"
 msgstr[1] "Упорядочить ячейки памяти (%i)"
 msgstr[2] "Упорядочить ячейки памяти (%i)"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
@@ -2912,7 +2915,7 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по возра
 msgstr[1] "Упорядочить ячейки памяти (%i) по возрастанию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по возрастанию"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
@@ -2920,16 +2923,16 @@ msgstr[0] "Упорядочить ячейки памяти (%i) по убыва
 msgstr[1] "Упорядочить ячейки памяти (%i) по убыванию"
 msgstr[2] "Упорядочить ячейки памяти (%i) по убыванию"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr "Сортировать по столбцу:"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 msgid "Sort memories"
 msgstr "Упорядочить ячейки памяти"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr "Сортировка"
 
@@ -2941,7 +2944,7 @@ msgstr "Область"
 msgid "State/Province"
 msgstr "Область/регион"
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr "Успешно"
 
@@ -3029,7 +3032,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "Рекомендуемая процедура импорта ячеек памяти: открыть исходный файл и скопировать/вставить ячейки памяти из него в ваш целевой образ. Если продолжить работу с этой функцией импорта, CHIRP заменит все ячейки памяти в текущем открытом файле на ячейки из %(file)s. Открыть этот файл для копирования/вставки ячеек памяти или продолжить импорт?"
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 msgid "This Memory"
 msgstr "Эта ячейка памяти"
 
@@ -3087,11 +3090,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 msgid "This memory and shift all up"
 msgstr "Эта ячейка памяти и сдвинуть все вверх"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 msgid "This memory and shift block up"
 msgstr "Эта ячейка памяти и сдвинуть блок вверх"
 
@@ -3183,7 +3186,7 @@ msgstr "Поиск USB-портов"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Не удалось определить порт для вашего кабеля. Проверьте драйверы и подключения."
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Перед редактированием ячейки памяти необходимо загрузить станцию"
 
@@ -3192,17 +3195,17 @@ msgstr "Перед редактированием ячейки памяти не
 msgid "Unable to find stock config %r"
 msgstr "Не удалось найти предустановленную конфигурацию %r"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Перед редактированием ячейки памяти необходимо загрузить станцию"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr "Не удалось открыть буфер обмена"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr "Не удалось выполнить запрос"
 
@@ -3210,7 +3213,7 @@ msgstr "Не удалось выполнить запрос"
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr "Невозможно прочитать последний блок. Это часто случается, когда выбрана американская модель, но станция не является американской (или широкополосной). Выберите правильную модель и повторите попытку."
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Невозможно обнаружить %s в этой системе"
@@ -3251,7 +3254,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr "Обновление URCALL"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "Отправка инструкций"
 
@@ -3267,7 +3270,7 @@ msgstr "Отправка на станцию"
 msgid "Upload to radio..."
 msgstr "Отправка на станцию..."
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Отправлена ячейка памяти %s"
@@ -3293,12 +3296,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr "Значение не помещается в %i бит"
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Значение не должно быть меньше %.4f"
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Значение не должно превышать %.4f"
@@ -3316,7 +3319,7 @@ msgstr "Значение должно быть больше или равно н
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr "Значения"
 
@@ -3328,15 +3331,15 @@ msgstr "Изготовитель"
 msgid "View"
 msgstr "Вид"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr "ПРЕДУПРЕЖДЕНИЕ!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr "Предупреждение"
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr "Предупреждение: %s"
@@ -3381,11 +3384,11 @@ msgstr "байт"
 msgid "bytes each"
 msgstr "байт каждый"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr "отключён"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr "включён"
 

--- a/chirp/locale/tr_TR.po
+++ b/chirp/locale/tr_TR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2025-01-19 16:11+0300\n"
 "Last-Translator: Abdullah YILMAZ (TA1AUB) <h.abdullahyilmaz@hotmail.com>\n"
 "Language-Team: TURKISH\n"
@@ -24,21 +24,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s, %(min)i ile %(max)i arasında olmalıdır"
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i Kaydı ve hepsini yukarı kaydır"
 msgstr[1] "%i Kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i Kaydı"
 msgstr[1] "%i Kaydı"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -70,7 +70,7 @@ msgstr "(Bu daha önce işe yaradı mı? Yeni telsiz? OEM yazılımıyla çalı�
 msgid "(none)"
 msgstr "(hiçbiri)"
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr "...ve %i daha"
@@ -781,7 +781,7 @@ msgstr ""
 "5. Telsizin etkin olmayan kanala ayarlandığından emin olun.\n"
 "6. İmajı cihaza yüklemek için TAMAM'a tıklayın.\n"
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -797,7 +797,7 @@ msgstr ""
 "5. Telsizin etkin olmayan kanala ayarlandığından emin olun.\n"
 "6. İmajı cihazdan indirmek için TAMAM'a tıklayın.\n"
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -813,7 +813,7 @@ msgstr ""
 "5. Telsizin etkin olmayan kanala ayarlandığından emin olun.\n"
 "6. İmajı cihaza yüklemek için TAMAM'a tıklayın.\n"
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -825,7 +825,7 @@ msgstr ""
 "3. Telsizi klon için hazırlayın.\n"
 "4. <b>TAMAM'ı tıkladıktan sonra</b>, imaj göndermek için tuşuna basın.\n"
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -959,7 +959,7 @@ msgstr ""
 "\n"
 "Kablo takılıyken telsizi açarsanız çalışmayabilir"
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "Yeni bir CHIRP sürümü mevcut. İndirmek için lütfen en kısa zamanda web sitesini ziyaret edin!"
 
@@ -975,7 +975,7 @@ msgstr "Hakkında"
 msgid "About CHIRP"
 msgstr "CHIRP Hakkında"
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr "Kabul ediyorum"
 
@@ -999,8 +999,7 @@ msgstr "Her zaman son listeyle başla"
 msgid "Amateur"
 msgstr "Amatör"
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Bir hata oluştu"
 
@@ -1016,7 +1015,7 @@ msgstr "Sistemden otomatik"
 msgid "Available modules"
 msgstr "Mevcut modüller"
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "Bant planı"
 
@@ -1071,11 +1070,11 @@ msgstr ""
 msgid "Canada"
 msgstr "Kanada"
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "Bu ayarın değiştirilmesi, imajdaki ayarların yenilenmesini gerektirir, bu işlem şimdi gerçekleşecektir."
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "Eşdeğer TX ve RX %s'ye sahip kanallar, \"%s\" ton modu ile temsil edilir"
@@ -1088,17 +1087,17 @@ msgstr "Chirp İmaj Dosyaları"
 msgid "Choice Required"
 msgstr "Seçim Gerekli"
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "%s DTCS Kodunu Seç"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr "%s Tonunu Seç"
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr "Çapraz Modu Seç"
 
@@ -1110,7 +1109,7 @@ msgstr "Farklı Hedef Seçin"
 msgid "Choose a recent model"
 msgstr "Son modellerden birini seçin"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr "Dubleks seç"
 
@@ -1123,9 +1122,13 @@ msgstr "Sorun %i'den yüklenecek modülü seçin:"
 msgid "City"
 msgstr "Şehir"
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
 msgstr "Tam lisans metni için buraya tıklayın"
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
+msgstr ""
 
 #: ../drivers/ts590.py:671
 msgid ""
@@ -1147,21 +1150,21 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "Klon tamamlandı, sahte baytlar kontrol ediliyor"
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Klonlanıyor"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr "Telsizden klonlanıyor"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr "Telsize klonlanıyor"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "Kapat"
 
@@ -1177,7 +1180,7 @@ msgstr "Dosyayı kapat"
 msgid "Close string value with double-quote (\")"
 msgstr "Dize değerini çift tırnak işaretiyle (\") kapatın"
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1212,11 +1215,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "FM'e dönüştür"
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "Kopyala"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -1237,11 +1240,11 @@ msgstr "Özel Bağlantı Noktası"
 msgid "Custom..."
 msgstr "Özel..."
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "Kes"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -1262,11 +1265,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "DTMF kod çöz"
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr "DV Kaydı"
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr "İleride Tehlike"
 
@@ -1274,11 +1277,11 @@ msgstr "İleride Tehlike"
 msgid "Dec"
 msgstr "Dec"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "Sil"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -1290,20 +1293,20 @@ msgstr "Detaylı bilgi"
 msgid "Developer Mode"
 msgstr "Geliştirici Modu"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "Geliştirici durumu artık %s. Etkili olması için CHIRP yeniden başlatılmalıdır"
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "Farklı Ham Kayıtlar"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr "Başka bir editöre göre fark"
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Dijital Kod"
 
@@ -1311,7 +1314,7 @@ msgstr "Dijital Kod"
 msgid "Digital Modes"
 msgstr "Dijital Modlar"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr "Raporlamayı devre dışı bırak"
 
@@ -1349,11 +1352,11 @@ msgstr "Telsizden indir"
 msgid "Download from radio..."
 msgstr "Telsizden indir..."
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "İndirme talimatları"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr "Sürücü"
 
@@ -1373,17 +1376,17 @@ msgstr "Analogu destekleyen çift modlu dijital tekrarlayıcılar(röleler) FM o
 msgid "Duplex"
 msgstr "Duplex"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "%i kaydı için ayrıntıları düzenle"
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "%i kaydı için ayrıntıları düzenle"
@@ -1400,11 +1403,11 @@ msgstr "Etkin"
 msgid "Enter Frequency"
 msgstr "Frekans Gir"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr "Ofset girin (MHz)"
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr "TX Frekansını girin (MHz)"
 
@@ -1437,7 +1440,7 @@ msgstr "Güncellenmesi gereken hata numarasını girin"
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr "chirpmyradio.com için kullanıcı adınızı ve şifrenizi girin. Hesabınız yoksa devam etmeden önce bir hesap oluşturmak için aşağıya tıklayın."
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr "%s kaydı silindi"
@@ -1450,7 +1453,7 @@ msgstr "Filtre uygulanırken hata oluştu"
 msgid "Error applying settings"
 msgstr "Ayarlar uygulanırken hata oluştu"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "Telsizle iletişim hatası"
 
@@ -1490,11 +1493,11 @@ msgstr "Örnek: name~\"myrepea\""
 msgid "Exclude private and closed repeaters"
 msgstr "Özel ve kapalı röleleri hariç tut"
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "Deneysel sürücü"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr "Dışa aktarma yalnızca CSV dosyalarını yazabilir"
 
@@ -1506,7 +1509,7 @@ msgstr "CSV'ye aktar"
 msgid "Export to CSV..."
 msgstr "CSV'ye aktar..."
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr "Ekstra"
 
@@ -1536,8 +1539,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr "Telsiz tarayıcısı yüklenemedi"
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr "Sonuç ayrıştırılamadı"
 
@@ -1599,7 +1602,7 @@ msgstr "Float'ı bitir"
 msgid "Finish float value like: 146.52"
 msgstr "Float değerini şu şekilde bitirin: 146.52"
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "%s telsiz işleri tamamlandı"
@@ -1661,11 +1664,11 @@ msgstr ""
 "4 - Telsiz > Telsizden İndir\n"
 "5 - Arayüz kablosunu çıkarın! Aksi takdirde, sağ taraf sesi olmayacaktır!\n"
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1766,7 +1769,7 @@ msgstr ""
 "5 - Arayüz kablosunu çıkarın, aksi takdirde sağ tarafta ses olmayacaktır!\n"
 "6 - Klon modundan çıkmak için telsizi kapatıp açın\n"
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1808,7 +1811,7 @@ msgstr ""
 "3 - Telsizinizi açın (şifre korumalıysa engelini kaldırın)\n"
 "4 - Başlatmak için TAMAM'a tıklayın.\n"
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1836,11 +1839,11 @@ msgstr ""
 "3 - Telsizinizi açın\n"
 "4 - Telsiz verilerinizin indirmesini gerçekleştirin\n"
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1886,17 +1889,17 @@ msgstr "Frekans %s desteklenen aralığın dışında"
 msgid "Frequency granularity in kHz"
 msgstr "kHz cinsinden frekans ayrıntı düzeyi"
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr "Bu aralıktaki frekans AM modu olmamalıdır"
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr "Bu aralıktaki frekans AM modunu gerektirir"
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr "TX bantları dışındaki frekanslar dupleks=kapalı olmalıdır"
 
@@ -1955,7 +1958,7 @@ msgstr "Ayarlanırsa, sonuçları bu koordinatlardan uzaklığa göre sırala"
 msgid "Import"
 msgstr "İçe Aktar"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1984,11 +1987,11 @@ msgstr "Dizin"
 msgid "Info"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr "Bilgi"
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr "Yukarıya Satır Ekle"
 
@@ -2000,7 +2003,7 @@ msgstr "Masaüstü simgesi yüklensin mi?"
 msgid "Interact with driver"
 msgstr "Sürücü ile etkileşim"
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 msgid "Internal driver error"
 msgstr "Dahili sürücü hatası"
 
@@ -2009,8 +2012,8 @@ msgstr "Dahili sürücü hatası"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Geçersiz %(value)s (ondalık basamak kullanın)"
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 msgid "Invalid Entry"
 msgstr "Geçersiz Girdi"
 
@@ -2018,7 +2021,7 @@ msgstr "Geçersiz Girdi"
 msgid "Invalid ZIP code"
 msgstr "Geçersiz Posta kodu"
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "Geçersiz düzenleme: %s"
@@ -2044,7 +2047,7 @@ msgstr "Kayıt numarası:"
 msgid "LIVE"
 msgstr "CANLI"
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 msgid "Language"
 msgstr "Dil"
 
@@ -2100,7 +2103,7 @@ msgstr "Kayıttan modül yükle"
 msgid "Load module from issue..."
 msgstr "Kayıttan modül yükle..."
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr "Bir modülün yüklenmesi açık sekmeleri etkilemeyecektir. Bir modülü yüklemeden önce (aksi belirtilmediği sürece) tüm sekmeleri kapatmanız önerilir."
 
@@ -2133,7 +2136,7 @@ msgstr "Logo dizesi 2 (12 karakter)"
 msgid "Longitude"
 msgstr "Boylam"
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -2146,7 +2149,7 @@ msgstr "Kayıtlar"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr "Desteklenmeyen aygıt yazılımı sürümü nedeniyle kayıtlar salt okunurdur"
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "Kayıt %i silinemez"
@@ -2169,8 +2172,8 @@ msgstr "Hafızanın düzenlenebilmesi için bir bankada olması gerekir"
 msgid "Memory {num} not in bank {bank}"
 msgstr "{num} kaydı {bank} bankasında değil"
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 msgid "Mode"
 msgstr "Mod"
 
@@ -2190,11 +2193,11 @@ msgstr "Modül"
 msgid "Module Loaded"
 msgstr "Modül Yüklendi"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr "Modül başarıyla yüklendi"
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr "Daha Fazla Bilgi"
 
@@ -2203,7 +2206,7 @@ msgstr "Daha Fazla Bilgi"
 msgid "More than one port found: %s"
 msgstr "Birden fazla bağlantı noktası bulundu: %s"
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -2216,7 +2219,7 @@ msgstr "Aşağı Taşı"
 msgid "Move Up"
 msgstr "Yukarı Taşı"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr "Görünüm sıralanırken taşıma işlemleri devre dışıdır"
 
@@ -2224,11 +2227,11 @@ msgstr "Görünüm sıralanırken taşıma işlemleri devre dışıdır"
 msgid "New Window"
 msgstr "Yeni Pencere"
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "Yeni sürüm mevcut"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr "Aşağıda boş satır yok!"
 
@@ -2246,20 +2249,20 @@ msgstr "Modül bulunamadı"
 msgid "No modules found in issue %i"
 msgstr "%i kadında modül bulunamadı"
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr "Daha fazla alan yok; bazı kayıtlar uygulanmadı"
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr "Sonuç yok"
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr "Sonuç yok!"
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr "Numara"
 
@@ -2374,7 +2377,7 @@ msgstr "İsteğe bağlı: AA00 - AA00aa11"
 msgid "Optional: County, Hospital, etc."
 msgstr "İsteğe bağlı: bölge, Hastane vb."
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 msgid "Overwrite memories?"
 msgstr "Kayıtların üzerine yazılsın mı?"
 
@@ -2387,8 +2390,8 @@ msgstr ""
 "P-VFO kanalları 100-109  olarak ayarlanabilir.\n"
 "Bu sürümde 130'dan fazla kullanılabilir telsiz ayarının yalnızca bir alt kümesi desteklenmektedir.\n"
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr "Ayrıştırılıyor"
 
@@ -2396,39 +2399,39 @@ msgstr "Ayrıştırılıyor"
 msgid "Password"
 msgstr "Şifre"
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "Yapıştır"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "Yapıştırılan kayıtlar, mevcut %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "Yapıştırılan kayıtlar %s kayıtlarının üzerine yazılacak"
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "Yapıştırılan kayıtlar, %s kaydının üzerine yazılacak"
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "Yapıştırılan kayıt, %s kaydının üzerine yazacak"
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "Lütfen yeni sürümü yüklemeden önce CHIRP'den çıktığınızdan emin olun!"
 
@@ -2477,11 +2480,11 @@ msgstr ""
 "4 - Ardından klonlamaya başlamak için telsizinizdeki \"A\" tuşuna basın.\n"
 "     (Sonunda telsiz bip sesi çıkaracaktır)\n"
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr "Lütfen geliştirici modunun CHIRP projesinin geliştiricileri tarafından veya bir geliştiricinin yönetimi altında kullanılması için tasarlandığını unutmayın. ÇOK DİKKATLİ kullanılmadığı takdirde bilgisayarınıza ve telsizinize zarar verebilecek davranış ve işlevleri mümkün kılar. Uyarıldın! Yine de devam edilsin mi?"
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "Lütfen bekleyin"
 
@@ -2521,7 +2524,7 @@ msgstr "Baskı"
 msgid "Prolific USB device"
 msgstr "Verimli USB aygıtı"
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr "Özellikler"
 
@@ -2537,7 +2540,7 @@ msgstr "Özellik Değeri"
 msgid "QTH Locator"
 msgstr "QTH Bulucu"
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr "%s sorgusu"
@@ -2558,8 +2561,8 @@ msgstr "Sorgu sözdizimi Tamam"
 msgid "Query syntax help"
 msgstr "Sorgu sözdizimi yardımı"
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr "Sorgulama"
 
@@ -2576,7 +2579,7 @@ msgstr "Telsiz"
 msgid "Radio did not ack block %i"
 msgstr "Telsiz %i bloğunu onaylamadı"
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr "Telsiz bilgisi"
 
@@ -2626,11 +2629,11 @@ msgstr "55.2'yi kullanmanızı öneririz"
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr "Yeniden Başlatma Gerekli"
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "Yenilenmiş %s kaydı"
@@ -2680,11 +2683,11 @@ msgstr "Yeni hata bildiriliyor: %r"
 msgid "Reporting enabled"
 msgstr "Raporlama etkinleştirildi"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr "Raporlama, CHIRP projesinin sınırlı çabalarımızı hangi telsiz modellerine ve işletim sistemi platformlarına harcayacağını bilmesine yardımcı olur. Etkin bırakırsanız gerçekten minnettar oluruz. Raporlama gerçekten devre dışı bırakılsın mı?"
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "Yeniden Başlatma Gerekiyor"
 
@@ -2703,7 +2706,7 @@ msgstr "Başlangıçta sekmeleri geri yükle"
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "Alınan ayarlar"
 
@@ -2719,7 +2722,7 @@ msgstr "Kapanmadan önce kaydedilsin mi?"
 msgid "Save file"
 msgstr "Dosyayı kaydet"
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "Kaydedilmiş ayarlar"
 
@@ -2731,7 +2734,7 @@ msgstr "Tarama kontrolü (atlama, dahil etme, öncelik vb.)"
 msgid "Scanlists"
 msgstr "Tarama listeleri"
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr "Karıştırıcı"
 
@@ -2756,7 +2759,7 @@ msgstr "Dil Seçin"
 msgid "Select Modes"
 msgstr "Modları Seç"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "Bir bant planı seçin"
 
@@ -2784,7 +2787,7 @@ msgstr "Desteklenmeyen aygıt yazılımı sürümü nedeniyle ayarlar salt okunu
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "Çift yönlü tarafından kontrol edilen kaydırma miktarı (veya iletim frekansı)"
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "Ham Kaydı Göster"
 
@@ -2804,50 +2807,50 @@ msgstr "İmaj yedekleme konumunu göster"
 msgid "Skip"
 msgstr "Atla"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr "Bazı kayıtlar bu telsizle uyumlu değil"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr "Bazı anılar silinemez"
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "%i kaydı sırala"
 msgstr[1] "%i kaydı sırala"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "%i kaydı artan şekilde sırala"
 msgstr[1] "%i kaydı artan şekilde sırala"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "%i kaydı azalan şekilde sırala"
 msgstr[1] "%i kaydı azalan şekilde sırala"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr "Sütuna göre sırala:"
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 msgid "Sort memories"
 msgstr "Kayıtları sırala"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr "Sıralama"
 
@@ -2859,7 +2862,7 @@ msgstr "Devlet"
 msgid "State/Province"
 msgstr "Eyalet/İl"
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr "Başarılı"
 
@@ -2947,7 +2950,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "Kayıtları içe aktarmak için önerilen prosedür, kaynak dosyayı açmak ve kayıtları bu dosyadan hedef görüntünüze kopyalamak/yapıştırmaktır. Bu içe aktarma işlevine devam ederseniz CHIRP, şu anda açık olan dosyanızdaki tüm kayıtları %(file)s içindekilerle değiştirecektir. Kayıtları kopyalamak/yapıştırmak için bu dosyayı açmak mı yoksa içe aktarma işlemine devam etmek mi istiyorsunuz?"
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 msgid "This Memory"
 msgstr "Bu kaydı"
 
@@ -3010,11 +3013,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr "Bu, chirpmyradio.com web sitesinde önceden oluşturulmuş bir sorun için bilet numarasıdır"
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 msgid "This memory and shift all up"
 msgstr "Bu kaydı ve hepsini yukarı kaydır"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 msgid "This memory and shift block up"
 msgstr "Bu kaydı ve bloğu yukarı kaydır"
 
@@ -3105,7 +3108,7 @@ msgstr "USB Portu Bulucu"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "Kablonuz için bağlantı noktası belirlenemiyor. Sürücülerinizi ve bağlantılarınızı kontrol edin."
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr "Radyo yüklenmeden önce kayıt düzenlenemiyor"
 
@@ -3114,16 +3117,16 @@ msgstr "Radyo yüklenmeden önce kayıt düzenlenemiyor"
 msgid "Unable to find stock config %r"
 msgstr "%r stok yapılandırması bulunamadı"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 msgid "Unable to import while the view is sorted"
 msgstr "Görünüm sıralanmışken içe aktarma yapılamıyor"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr "Pano açılamıyor"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr "Sorgulanamıyor"
 
@@ -3131,7 +3134,7 @@ msgstr "Sorgulanamıyor"
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr "Son blok okunamıyor. Bu genellikle seçilen model ABD olduğunda olur ama telsiz ABD dışı bir telsizdir (veya geniş bantlıdır). Lütfen doğru modeli seçin ve tekrar deneyin."
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "%s bu sistemde gösterilemiyor"
@@ -3171,7 +3174,7 @@ msgstr "Mevcut bir hatayı güncelle"
 msgid "Updating bug %s"
 msgstr "%s hatası güncelleniyor"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "Yükleme talimatları"
 
@@ -3187,7 +3190,7 @@ msgstr "Telsize yükle"
 msgid "Upload to radio..."
 msgstr "Telsize yükle..."
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr "Yüklenen kayıt %s"
@@ -3213,12 +3216,12 @@ msgstr "Kullanıcı adı"
 msgid "Value does not fit in %i bits"
 msgstr "Değer %i bit'e sığmıyor"
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "Değer en az %.4f olmalıdır"
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "Değer en fazla %.4f olmalıdır"
@@ -3236,7 +3239,7 @@ msgstr "Değer sıfır veya daha büyük olmalıdır"
 msgid "Value to search memory field for"
 msgstr "Kayıt alanında arama yapılacak değer"
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr "Değerler"
 
@@ -3248,15 +3251,15 @@ msgstr "Tedarikçi"
 msgid "View"
 msgstr "Göster"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr "UYARI!"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr "Uyarı"
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr "Uyarı: %s"
@@ -3301,11 +3304,11 @@ msgstr "bytes"
 msgid "bytes each"
 msgstr "her biri bayt"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr "devre dışı bırakıldı"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr "etkinleştirildi"
 

--- a/chirp/locale/uk_UA.po
+++ b/chirp/locale/uk_UA.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2015-11-30 10:36+0200\n"
 "Last-Translator: laser <student.laser@gmail.com>\n"
 "Language-Team: laser <student.laser@gmail.com>\n"
@@ -22,21 +22,21 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr ""
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, fuzzy, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "Видалити (та зсунути вгору)"
 msgstr[1] "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, fuzzy, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "Пам'ять"
 msgstr[1] "Пам'ять"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, fuzzy, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -68,7 +68,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr ""
@@ -543,7 +543,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -553,7 +553,7 @@ msgid ""
 "6. Click OK to download image from device.\n"
 msgstr ""
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -563,7 +563,7 @@ msgid ""
 "6. Click OK to upload image to device.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -571,7 +571,7 @@ msgid ""
 "4. <b>After clicking OK</b>, press the key to send image.\n"
 msgstr ""
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -657,7 +657,7 @@ msgid ""
 "It will may not work if you turn on the radio with the cable already attached"
 msgstr ""
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr ""
 msgid "About CHIRP"
 msgstr ""
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr ""
 
@@ -698,8 +698,7 @@ msgstr ""
 msgid "Amateur"
 msgstr ""
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "Сталася помилка"
 
@@ -716,7 +715,7 @@ msgstr "Автоматичний рознос репітера"
 msgid "Available modules"
 msgstr ""
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr ""
 
@@ -771,11 +770,11 @@ msgstr ""
 msgid "Canada"
 msgstr ""
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr ""
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr ""
@@ -788,17 +787,17 @@ msgstr ""
 msgid "Choice Required"
 msgstr ""
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, fuzzy, python-format
 msgid "Choose %s DTCS Code"
 msgstr "DTCS код"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr ""
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 #, fuzzy
 msgid "Choose Cross Mode"
 msgstr "Кросрежим"
@@ -812,7 +811,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "Кросрежим"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr ""
 
@@ -825,8 +824,12 @@ msgstr "Виберіть один для Імпорту з:"
 msgid "City"
 msgstr ""
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
+msgstr ""
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
 msgstr ""
 
 #: ../drivers/ts590.py:671
@@ -843,23 +846,23 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr ""
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "Клонування"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 #, fuzzy
 msgid "Cloning from radio"
 msgstr "Скопіювати з радіостанції"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 #, fuzzy
 msgid "Cloning to radio"
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr ""
 
@@ -875,7 +878,7 @@ msgstr ""
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, fuzzy, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -909,12 +912,12 @@ msgstr ""
 msgid "Convert to FM"
 msgstr ""
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 #, fuzzy
 msgid "Copy"
 msgstr "Копіювати"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -936,12 +939,12 @@ msgstr ""
 msgid "Custom..."
 msgstr ""
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 #, fuzzy
 msgid "Cut"
 msgstr "Вирізати"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -962,11 +965,11 @@ msgstr "DTCS Pol"
 msgid "DTMF decode"
 msgstr ""
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr ""
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr ""
 
@@ -975,12 +978,12 @@ msgstr ""
 msgid "Dec"
 msgstr "Визначити"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 #, fuzzy
 msgid "Delete"
 msgstr "Видалити"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -994,21 +997,21 @@ msgstr "Отримання інформації банку"
 msgid "Developer Mode"
 msgstr "Розробник"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr ""
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 #, fuzzy
 msgid "Diff Raw Memories"
 msgstr "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "Цифровий код"
 
@@ -1017,7 +1020,7 @@ msgstr "Цифровий код"
 msgid "Digital Modes"
 msgstr "Цифровий код"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr ""
 
@@ -1057,12 +1060,12 @@ msgstr "Скопіювати з радіостанції"
 msgid "Download from radio..."
 msgstr "Скопіювати з радіостанції"
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 #, fuzzy
 msgid "Download instructions"
 msgstr "Скопіювати з радіостанції"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr ""
 
@@ -1082,17 +1085,17 @@ msgstr ""
 msgid "Duplex"
 msgstr "Дуплекс"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr ""
@@ -1110,11 +1113,11 @@ msgstr ""
 msgid "Enter Frequency"
 msgstr "Частота"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr ""
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr ""
 
@@ -1147,7 +1150,7 @@ msgstr ""
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr ""
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, fuzzy, python-format
 msgid "Erased memory %s"
 msgstr "Стирання пам'яті {loc}"
@@ -1162,7 +1165,7 @@ msgstr "Помилка настройки пам'яті"
 msgid "Error applying settings"
 msgstr "Помилка настройки пам'яті"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr ""
 
@@ -1202,11 +1205,11 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr ""
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr ""
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr ""
 
@@ -1220,7 +1223,7 @@ msgstr "Експорт до файлу"
 msgid "Export to CSV..."
 msgstr "Експорт до файлу"
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr ""
 
@@ -1247,8 +1250,8 @@ msgstr ""
 msgid "Failed to load radio browser"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr ""
 
@@ -1312,7 +1315,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr ""
@@ -1355,11 +1358,11 @@ msgid ""
 "    no right-side audio!\n"
 msgstr ""
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1425,7 +1428,7 @@ msgid ""
 "6 - Cycle power on the radio to exit clone mode\n"
 msgstr ""
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1452,7 +1455,7 @@ msgid ""
 "4 - Click OK to start\n"
 msgstr ""
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1470,11 +1473,11 @@ msgid ""
 "4 - Do the download of your radio data\n"
 msgstr ""
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1510,17 +1513,17 @@ msgstr ""
 msgid "Frequency granularity in kHz"
 msgstr ""
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr ""
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr ""
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr ""
 
@@ -1581,7 +1584,7 @@ msgstr ""
 msgid "Import"
 msgstr "Імпорт"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1612,11 +1615,11 @@ msgstr "Зміст"
 msgid "Info"
 msgstr ""
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr ""
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 #, fuzzy
 msgid "Insert Row Above"
 msgstr "Додати рядок зверху"
@@ -1629,7 +1632,7 @@ msgstr ""
 msgid "Interact with driver"
 msgstr ""
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 #, fuzzy
 msgid "Internal driver error"
 msgstr "Внутрішня помилка"
@@ -1639,8 +1642,8 @@ msgstr "Внутрішня помилка"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "Неприпустиме значення. Повинно бути цілим числом."
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 #, fuzzy
 msgid "Invalid Entry"
 msgstr "Неприпустиме значення для цього поля"
@@ -1649,7 +1652,7 @@ msgstr "Неприпустиме значення для цього поля"
 msgid "Invalid ZIP code"
 msgstr ""
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr ""
@@ -1676,7 +1679,7 @@ msgstr ""
 msgid "LIVE"
 msgstr ""
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 #, fuzzy
 msgid "Language"
 msgstr "Змінити мову"
@@ -1737,7 +1740,7 @@ msgstr "Тоновий режим"
 msgid "Load module from issue..."
 msgstr "Тоновий режим"
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr ""
 
@@ -1770,7 +1773,7 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -1784,7 +1787,7 @@ msgstr "Пам'ять"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr ""
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr ""
@@ -1807,8 +1810,8 @@ msgstr ""
 msgid "Memory {num} not in bank {bank}"
 msgstr ""
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 #, fuzzy
 msgid "Mode"
 msgstr "Режим"
@@ -1830,11 +1833,11 @@ msgstr ""
 msgid "Module Loaded"
 msgstr ""
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr ""
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr ""
 
@@ -1843,7 +1846,7 @@ msgstr ""
 msgid "More than one port found: %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -1858,7 +1861,7 @@ msgstr "Перемістити В_низ"
 msgid "Move Up"
 msgstr "Перемістити В_гору"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr ""
 
@@ -1866,11 +1869,11 @@ msgstr ""
 msgid "New Window"
 msgstr ""
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr ""
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 #, fuzzy
 msgid "No empty rows below!"
 msgstr "Додати рядок знизу"
@@ -1889,20 +1892,20 @@ msgstr ""
 msgid "No modules found in issue %i"
 msgstr ""
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr ""
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr ""
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr ""
 
@@ -2022,7 +2025,7 @@ msgstr "Опції"
 msgid "Optional: County, Hospital, etc."
 msgstr ""
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 #, fuzzy
 msgid "Overwrite memories?"
 msgstr "Перезаписати?"
@@ -2034,8 +2037,8 @@ msgid ""
 "are supported in this release.\n"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr ""
 
@@ -2043,40 +2046,40 @@ msgstr ""
 msgid "Password"
 msgstr ""
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 #, fuzzy
 msgid "Paste"
 msgstr "Вставити"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr ""
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr ""
 
@@ -2110,11 +2113,11 @@ msgid ""
 "    (At the end radio will beep)\n"
 msgstr ""
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr ""
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr ""
 
@@ -2155,7 +2158,7 @@ msgstr ""
 msgid "Prolific USB device"
 msgstr ""
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr ""
 
@@ -2171,7 +2174,7 @@ msgstr ""
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr ""
@@ -2192,8 +2195,8 @@ msgstr ""
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 msgid "Querying"
 msgstr ""
 
@@ -2211,7 +2214,7 @@ msgstr "Радіостанція"
 msgid "Radio did not ack block %i"
 msgstr ""
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 #, fuzzy
 msgid "Radio information"
 msgstr "Отримання інформації банку"
@@ -2262,11 +2265,11 @@ msgstr ""
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr ""
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr ""
@@ -2316,11 +2319,11 @@ msgstr "Звіти вимкнуто"
 msgid "Reporting enabled"
 msgstr "Звіти вимкнуто"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr ""
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr ""
 
@@ -2339,7 +2342,7 @@ msgstr ""
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr ""
 
@@ -2355,7 +2358,7 @@ msgstr ""
 msgid "Save file"
 msgstr ""
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr ""
 
@@ -2367,7 +2370,7 @@ msgstr ""
 msgid "Scanlists"
 msgstr ""
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr ""
 
@@ -2396,7 +2399,7 @@ msgstr "Виберіть Стовпці"
 msgid "Select Modes"
 msgstr "Виберіть Стовпці"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr ""
 
@@ -2425,7 +2428,7 @@ msgstr ""
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr ""
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 #, fuzzy
 msgid "Show Raw Memory"
 msgstr "Показати Raw пам'ять"
@@ -2446,52 +2449,52 @@ msgstr ""
 msgid "Skip"
 msgstr "Пропустити"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 #, fuzzy
 msgid "Some memories are incompatible with this radio"
 msgstr "Вставлена пам'ять {number} несумісна із цією радіостанцією тому що:"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr ""
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, fuzzy, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, fuzzy, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, fuzzy, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "Порівняти Raw пам'ять"
 msgstr[1] "Порівняти Raw пам'ять"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr ""
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 #, fuzzy
 msgid "Sort memories"
 msgstr "Перезаписати?"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr ""
 
@@ -2503,7 +2506,7 @@ msgstr ""
 msgid "State/Province"
 msgstr ""
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr ""
 
@@ -2576,7 +2579,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr ""
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 #, fuzzy
 msgid "This Memory"
 msgstr "Показати Raw пам'ять"
@@ -2631,12 +2634,12 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr ""
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 #, fuzzy
 msgid "This memory and shift all up"
 msgstr "Видалити (та зсунути вгору)"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 #, fuzzy
 msgid "This memory and shift block up"
 msgstr "Видалити (та зсунути вгору)"
@@ -2726,7 +2729,7 @@ msgstr ""
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr ""
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr ""
 
@@ -2735,18 +2738,18 @@ msgstr ""
 msgid "Unable to find stock config %r"
 msgstr "Відкрити заводські конфігурації"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 #, fuzzy
 msgid "Unable to import while the view is sorted"
 msgstr "Не вдалося виявити радіо на {port}"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 #, fuzzy
 msgid "Unable to open the clipboard"
 msgstr "Не вдалося виявити радіо на {port}"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr ""
 
@@ -2754,7 +2757,7 @@ msgstr ""
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr ""
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, fuzzy, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "Не вдається внести зміни до цієї моделі"
@@ -2795,7 +2798,7 @@ msgstr ""
 msgid "Updating bug %s"
 msgstr "Оновлення списку URCALL"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr ""
 
@@ -2813,7 +2816,7 @@ msgstr "Записати в радіостанцію"
 msgid "Upload to radio..."
 msgstr "Записати в радіостанцію"
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
@@ -2839,12 +2842,12 @@ msgstr ""
 msgid "Value does not fit in %i bits"
 msgstr ""
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr ""
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr ""
@@ -2862,7 +2865,7 @@ msgstr ""
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr ""
 
@@ -2875,15 +2878,15 @@ msgstr "Виробник"
 msgid "View"
 msgstr "В_игляд"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr ""
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr ""
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr ""
@@ -2928,11 +2931,11 @@ msgstr ""
 msgid "bytes each"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr ""
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr ""
 

--- a/chirp/locale/zh_CN.po
+++ b/chirp/locale/zh_CN.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: CHIRP\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-07 15:41-0800\n"
+"POT-Creation-Date: 2025-05-08 21:57+0200\n"
 "PO-Revision-Date: 2024-11-11 02:28+0800\n"
 "Last-Translator: DuckSoft, BH2UEP <realducksoft@gmail.com>\n"
 "Language-Team: \n"
@@ -22,19 +22,19 @@ msgstr ""
 msgid "%(value)s must be between %(min)i and %(max)i"
 msgstr "%(value)s 必须在 %(min)i 和 %(max)i 之间"
 
-#: ../wxui/memedit.py:2136
+#: ../wxui/memedit.py:2141
 #, python-format
 msgid "%i Memories and shift all up"
 msgid_plural "%i Memories and shift all up"
 msgstr[0] "%i 个存储并将所有上移"
 
-#: ../wxui/memedit.py:2127
+#: ../wxui/memedit.py:2132
 #, python-format
 msgid "%i Memory"
 msgid_plural "%i Memories"
 msgstr[0] "%i 个存储"
 
-#: ../wxui/memedit.py:2131
+#: ../wxui/memedit.py:2136
 #, python-format
 msgid "%i Memory and shift block up"
 msgid_plural "%i Memories and shift block up"
@@ -65,7 +65,7 @@ msgstr "（这之前曾经奏效过吗？是新电台吗？使用原厂软件能
 msgid "(none)"
 msgstr "（无）"
 
-#: ../wxui/memedit.py:2528
+#: ../wxui/memedit.py:2533
 #, python-format
 msgid "...and %i more"
 msgstr "...以及其他 %i 个"
@@ -781,7 +781,7 @@ msgstr ""
 "5. 确保电台调到没有活动的频道。\n"
 "6. 点击 OK 上传镜像到设备。\n"
 
-#: ../drivers/uvb5.py:288 ../drivers/wouxun.py:213 ../drivers/tg_uv2p.py:232
+#: ../drivers/tg_uv2p.py:232 ../drivers/uvb5.py:288 ../drivers/wouxun.py:213
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -797,7 +797,7 @@ msgstr ""
 "5. 确保电台调到没有活动的频道。\n"
 "6. 点击 OK 下载设备中的镜像。\n"
 
-#: ../drivers/uvb5.py:296 ../drivers/wouxun.py:221 ../drivers/tg_uv2p.py:240
+#: ../drivers/tg_uv2p.py:240 ../drivers/uvb5.py:296 ../drivers/wouxun.py:221
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect cable to mic/spkr connector.\n"
@@ -813,7 +813,7 @@ msgstr ""
 "5. 确保电台调到没有活动的频道。\n"
 "6. 点击 OK 上传镜像到设备。\n"
 
-#: ../drivers/yaesu_clone.py:241
+#: ../drivers/yaesu_clone.py:239
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -825,7 +825,7 @@ msgstr ""
 "3. 准备克隆电台。\n"
 "4. <b>点击 OK 后</b>，按键发送镜像。\n"
 
-#: ../drivers/yaesu_clone.py:246
+#: ../drivers/yaesu_clone.py:244
 msgid ""
 "1. Turn radio off.\n"
 "2. Connect data cable.\n"
@@ -958,7 +958,7 @@ msgstr ""
 "\n"
 "如果在已连接数据线的情况下打开电台，则可能无法进行"
 
-#: ../wxui/main.py:2089
+#: ../wxui/main.py:2094
 msgid "A new CHIRP version is available. Please visit the website as soon as possible to download it!"
 msgstr "新的 CHIRP 版本已经推出。请尽快访问网站下载！"
 
@@ -974,7 +974,7 @@ msgstr "关于"
 msgid "About CHIRP"
 msgstr "关于CHIRP"
 
-#: ../wxui/main.py:1923
+#: ../wxui/main.py:1928
 msgid "Agree"
 msgstr "同意"
 
@@ -998,8 +998,7 @@ msgstr "总是以最近的列表启动"
 msgid "Amateur"
 msgstr "业余"
 
-#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:624
-#: ../wxui/common.py:651
+#: ../wxui/bugreport.py:328 ../wxui/bugreport.py:437 ../wxui/common.py:625
 msgid "An error has occurred"
 msgstr "发生错误"
 
@@ -1015,7 +1014,7 @@ msgstr "系统自动"
 msgid "Available modules"
 msgstr "可用模块"
 
-#: ../wxui/main.py:2024
+#: ../wxui/main.py:2029
 msgid "Bandplan"
 msgstr "频带计划"
 
@@ -1070,11 +1069,11 @@ msgstr ""
 msgid "Canada"
 msgstr "加拿大"
 
-#: ../wxui/common.py:495
+#: ../wxui/common.py:496
 msgid "Changing this setting requires refreshing the settings from the image, which will happen now."
 msgstr "更改此设置需要从映像中刷新设置，这将立即发生。"
 
-#: ../wxui/memedit.py:1773
+#: ../wxui/memedit.py:1778
 #, python-format
 msgid "Channels with equivalent TX and RX %s are represented by tone mode of \"%s\""
 msgstr "收发一致的 %s 频道使用 \"%s\" 亚音频模式表示"
@@ -1087,17 +1086,17 @@ msgstr "CHIRP 映像文件"
 msgid "Choice Required"
 msgstr "需要选择"
 
-#: ../wxui/memedit.py:1752
+#: ../wxui/memedit.py:1757
 #, python-format
 msgid "Choose %s DTCS Code"
 msgstr "选择 %s DTCS 接收代码"
 
-#: ../wxui/memedit.py:1749
+#: ../wxui/memedit.py:1754
 #, python-format
 msgid "Choose %s Tone"
 msgstr "选择 %s 亚音频"
 
-#: ../wxui/memedit.py:1783
+#: ../wxui/memedit.py:1788
 msgid "Choose Cross Mode"
 msgstr "收发使用不同亚音频"
 
@@ -1109,7 +1108,7 @@ msgstr ""
 msgid "Choose a recent model"
 msgstr "选择一个最近的型号"
 
-#: ../wxui/memedit.py:1813
+#: ../wxui/memedit.py:1818
 msgid "Choose duplex"
 msgstr "选择双工"
 
@@ -1122,9 +1121,13 @@ msgstr "选择要从 issue %i 加载的模块："
 msgid "City"
 msgstr "城市"
 
-#: ../wxui/main.py:1893
+#: ../wxui/main.py:1914
 msgid "Click here for full license text"
 msgstr "点击这里查看完整的许可证文本"
+
+#: ../wxui/main.py:1893
+msgid "Click here for online documentation"
+msgstr ""
 
 #: ../drivers/ts590.py:671
 msgid ""
@@ -1144,21 +1147,21 @@ msgstr ""
 msgid "Clone completed, checking for spurious bytes"
 msgstr "下载完成，正在检查是否有多余的字节"
 
-#: ../wxui/common.py:123
+#: ../wxui/common.py:124
 msgid "Cloning"
 msgstr "正在下载"
 
-#: ../drivers/bj9900.py:133 ../drivers/ft450d.py:507 ../drivers/ft4.py:317
-#: ../drivers/ft817.py:341
+#: ../drivers/ft4.py:317 ../drivers/ft450d.py:507 ../drivers/ft817.py:341
+#: ../drivers/bj9900.py:133
 msgid "Cloning from radio"
 msgstr "从电台下载"
 
-#: ../drivers/bj9900.py:165 ../drivers/ft450d.py:536 ../drivers/ft4.py:318
-#: ../drivers/ft817.py:379
+#: ../drivers/ft4.py:318 ../drivers/ft450d.py:536 ../drivers/ft817.py:379
+#: ../drivers/bj9900.py:165
 msgid "Cloning to radio"
 msgstr "上传到电台"
 
-#: ../wxui/main.py:1056 ../wxui/main.py:1924
+#: ../wxui/main.py:1056 ../wxui/main.py:1929
 msgid "Close"
 msgstr "关闭"
 
@@ -1175,7 +1178,7 @@ msgstr "关闭文件"
 msgid "Close string value with double-quote (\")"
 msgstr ""
 
-#: ../wxui/memedit.py:2195
+#: ../wxui/memedit.py:2200
 #, python-format
 msgid "Cluster %i memory"
 msgid_plural "Cluster %i memories"
@@ -1209,11 +1212,11 @@ msgstr ""
 msgid "Convert to FM"
 msgstr "转换到 FM"
 
-#: ../wxui/memedit.py:2106
+#: ../wxui/memedit.py:2111
 msgid "Copy"
 msgstr "复制"
 
-#: ../wxui/memedit.py:2110
+#: ../wxui/memedit.py:2115
 msgid "Copy portable"
 msgstr ""
 
@@ -1234,11 +1237,11 @@ msgstr "自定义端口"
 msgid "Custom..."
 msgstr "自定义..."
 
-#: ../wxui/memedit.py:2101
+#: ../wxui/memedit.py:2106
 msgid "Cut"
 msgstr "剪切"
 
-#: ../wxui/memedit.py:2372
+#: ../wxui/memedit.py:2377
 #, python-format
 msgid "Cut %i memories"
 msgstr ""
@@ -1259,11 +1262,11 @@ msgstr ""
 msgid "DTMF decode"
 msgstr "DTMF 解码"
 
-#: ../wxui/memedit.py:2820
+#: ../wxui/memedit.py:2825
 msgid "DV Memory"
 msgstr "该存储"
 
-#: ../wxui/main.py:1945
+#: ../wxui/main.py:1950
 msgid "Danger Ahead"
 msgstr "前方危险"
 
@@ -1271,11 +1274,11 @@ msgstr "前方危险"
 msgid "Dec"
 msgstr "探测"
 
-#: ../wxui/memedit.py:2121
+#: ../wxui/memedit.py:2126
 msgid "Delete"
 msgstr "删除"
 
-#: ../wxui/memedit.py:1984
+#: ../wxui/memedit.py:1989
 msgid "Delete memories"
 msgstr ""
 
@@ -1287,20 +1290,20 @@ msgstr "详细信息"
 msgid "Developer Mode"
 msgstr "开发者模式"
 
-#: ../wxui/main.py:1951
+#: ../wxui/main.py:1956
 #, python-format
 msgid "Developer state is now %s. CHIRP must be restarted to take effect"
 msgstr "开发者状态现在是 %s。CHIRP 必须重新启动才能生效"
 
-#: ../wxui/memedit.py:2232 ../wxui/developer.py:97
+#: ../wxui/developer.py:97 ../wxui/memedit.py:2237
 msgid "Diff Raw Memories"
 msgstr "对比原始存储"
 
-#: ../wxui/memedit.py:2240
+#: ../wxui/memedit.py:2245
 msgid "Diff against another editor"
 msgstr ""
 
-#: ../wxui/memedit.py:2737
+#: ../wxui/memedit.py:2742
 msgid "Digital Code"
 msgstr "数字代码"
 
@@ -1308,7 +1311,7 @@ msgstr "数字代码"
 msgid "Digital Modes"
 msgstr "数字模式"
 
-#: ../wxui/main.py:1963
+#: ../wxui/main.py:1968
 msgid "Disable reporting"
 msgstr "禁用报告"
 
@@ -1346,11 +1349,11 @@ msgstr "从电台下载"
 msgid "Download from radio..."
 msgstr "从电台下载……"
 
-#: ../wxui/clone.py:795
+#: ../wxui/clone.py:777
 msgid "Download instructions"
 msgstr "显示指引"
 
-#: ../wxui/radioinfo.py:62
+#: ../wxui/radioinfo.py:63
 msgid "Driver"
 msgstr "驱动程序"
 
@@ -1370,17 +1373,17 @@ msgstr "支持模拟的双模数字中继将显示为 FM"
 msgid "Duplex"
 msgstr "双工"
 
-#: ../wxui/memedit.py:2262
+#: ../wxui/memedit.py:2267
 #, python-format
 msgid "Edit %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2767
+#: ../wxui/memedit.py:2772
 #, python-format
 msgid "Edit details for %i memories"
 msgstr "修改 %i 个存储的详细信息"
 
-#: ../wxui/memedit.py:2765
+#: ../wxui/memedit.py:2770
 #, python-format
 msgid "Edit details for memory %i"
 msgstr "修改存储 %i 的详细信息"
@@ -1397,11 +1400,11 @@ msgstr "已启用"
 msgid "Enter Frequency"
 msgstr "频率"
 
-#: ../wxui/memedit.py:1800
+#: ../wxui/memedit.py:1805
 msgid "Enter Offset (MHz)"
 msgstr "输入频差（MHz）"
 
-#: ../wxui/memedit.py:1792
+#: ../wxui/memedit.py:1797
 msgid "Enter TX Frequency (MHz)"
 msgstr "输入发射频率（MHz）"
 
@@ -1434,7 +1437,7 @@ msgstr "输入要更新的 Bug 编号"
 msgid "Enter your username and password for chirpmyradio.com. If you do not have an account click below to create one before proceeding."
 msgstr "输入您在 chirpmyradio.com 的用户名和密码。如果您没有帐户，请在继续之前单击下面的链接创建一个。"
 
-#: ../wxui/common.py:338
+#: ../wxui/common.py:339
 #, python-format
 msgid "Erased memory %s"
 msgstr "已擦除存储 %s"
@@ -1448,7 +1451,7 @@ msgstr "应用设置时出错"
 msgid "Error applying settings"
 msgstr "应用设置时出错"
 
-#: ../wxui/clone.py:694
+#: ../wxui/clone.py:684
 msgid "Error communicating with radio"
 msgstr "与电台通信时出错"
 
@@ -1488,11 +1491,11 @@ msgstr ""
 msgid "Exclude private and closed repeaters"
 msgstr "排除私有和已关闭的中继"
 
-#: ../wxui/clone.py:754
+#: ../wxui/clone.py:736
 msgid "Experimental driver"
 msgstr "实验性的驱动程序"
 
-#: ../wxui/memedit.py:2690
+#: ../wxui/memedit.py:2695
 msgid "Export can only write CSV files"
 msgstr "只能导出CSV文件"
 
@@ -1504,7 +1507,7 @@ msgstr "以CSV文件格式导出"
 msgid "Export to CSV..."
 msgstr "以CSV文件格式导出……"
 
-#: ../wxui/memedit.py:2809
+#: ../wxui/memedit.py:2814
 msgid "Extra"
 msgstr "更多"
 
@@ -1531,8 +1534,8 @@ msgstr "免费中继数据库，提供欧洲中继的最新信息。不需要帐
 msgid "Failed to load radio browser"
 msgstr "无法加载电台浏览器"
 
-#: ../sources/przemienniki_eu.py:57 ../sources/przemienniki_net.py:59
-#: ../sources/mapy73pl.py:61
+#: ../sources/mapy73pl.py:61 ../sources/przemienniki_net.py:59
+#: ../sources/przemienniki_eu.py:57
 msgid "Failed to parse result"
 msgstr "无法解析结果"
 
@@ -1595,7 +1598,7 @@ msgstr ""
 msgid "Finish float value like: 146.52"
 msgstr ""
 
-#: ../wxui/common.py:340
+#: ../wxui/common.py:341
 #, python-format
 msgid "Finished radio job %s"
 msgstr "已完成电台作业 %s"
@@ -1657,11 +1660,11 @@ msgstr ""
 "4 - 电台 > 从电台下载\n"
 "5 - 断开接口电缆！否则将没有右侧音频！\n"
 
-#: ../drivers/mursv1.py:341 ../drivers/baofeng_wp970i.py:327
-#: ../drivers/btech.py:693 ../drivers/gmrsuv1.py:391
-#: ../drivers/tdxone_tdq8a.py:456 ../drivers/uv6r.py:339
-#: ../drivers/uv5x3.py:417 ../drivers/gmrsv2.py:363
-#: ../drivers/baofeng_uv17Pro.py:468 ../drivers/bf_t1.py:482
+#: ../drivers/uv6r.py:339 ../drivers/baofeng_uv17Pro.py:501
+#: ../drivers/gmrsuv1.py:391 ../drivers/tdxone_tdq8a.py:456
+#: ../drivers/mursv1.py:341 ../drivers/uv5x3.py:417
+#: ../drivers/baofeng_wp970i.py:327 ../drivers/btech.py:698
+#: ../drivers/gmrsv2.py:363 ../drivers/bf_t1.py:482
 msgid ""
 "Follow these instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1762,7 +1765,7 @@ msgstr ""
 "5 - 断开接口电缆，否则将没有右侧音频！\n"
 "6 - 重启电台以退出克隆模式\n"
 
-#: ../drivers/btech.py:699 ../drivers/bf_t1.py:488
+#: ../drivers/btech.py:704 ../drivers/bf_t1.py:488
 msgid ""
 "Follow these instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1804,7 +1807,7 @@ msgstr ""
 "3 - 打开电台\n"
 "4 - 单击 \"确定 \"开始\n"
 
-#: ../drivers/vgc.py:598 ../drivers/lt725uv.py:496
+#: ../drivers/lt725uv.py:496 ../drivers/vgc.py:598
 msgid ""
 "Follow this instructions to download your info:\n"
 "1 - Turn off your radio\n"
@@ -1832,11 +1835,11 @@ msgstr ""
 "3 - 打开电台\n"
 "4 - 下载电台数据\n"
 
-#: ../drivers/vgc.py:604 ../drivers/mursv1.py:347
-#: ../drivers/baofeng_wp970i.py:333 ../drivers/gmrsuv1.py:397
-#: ../drivers/lt725uv.py:502 ../drivers/tdxone_tdq8a.py:462
-#: ../drivers/uv6r.py:345 ../drivers/uv5x3.py:423 ../drivers/gmrsv2.py:369
-#: ../drivers/baofeng_uv17Pro.py:474
+#: ../drivers/uv6r.py:345 ../drivers/baofeng_uv17Pro.py:507
+#: ../drivers/lt725uv.py:502 ../drivers/gmrsuv1.py:397
+#: ../drivers/tdxone_tdq8a.py:462 ../drivers/mursv1.py:347
+#: ../drivers/uv5x3.py:423 ../drivers/baofeng_wp970i.py:333
+#: ../drivers/vgc.py:604 ../drivers/gmrsv2.py:369
 msgid ""
 "Follow this instructions to upload your info:\n"
 "1 - Turn off your radio\n"
@@ -1882,17 +1885,17 @@ msgstr "频率 %s 超出支持范围"
 msgid "Frequency granularity in kHz"
 msgstr "频率粒度（kHz）"
 
-#: ../drivers/ga510.py:1072 ../drivers/mml_jc8810.py:1378
-#: ../drivers/tdh8.py:2608 ../drivers/baofeng_uv17Pro.py:1197
+#: ../drivers/ga510.py:1072 ../drivers/baofeng_uv17Pro.py:1244
+#: ../drivers/tdh8.py:2609 ../drivers/mml_jc8810.py:1393
 msgid "Frequency in this range must not be AM mode"
 msgstr "此范围内的频率不能是AM模式"
 
-#: ../drivers/ga510.py:1065 ../drivers/mml_jc8810.py:1375
-#: ../drivers/tdh8.py:2605 ../drivers/baofeng_uv17Pro.py:1193
+#: ../drivers/ga510.py:1065 ../drivers/baofeng_uv17Pro.py:1240
+#: ../drivers/tdh8.py:2606 ../drivers/mml_jc8810.py:1390
 msgid "Frequency in this range requires AM mode"
 msgstr "此范围内的频率需要是AM模式"
 
-#: ../drivers/tdh8.py:2612
+#: ../drivers/tdh8.py:2613
 msgid "Frequency outside TX bands must be duplex=off"
 msgstr "超出发射频段的频率必须是双工=关闭"
 
@@ -1951,7 +1954,7 @@ msgstr "设置后按距离排序"
 msgid "Import"
 msgstr "导入"
 
-#: ../wxui/memedit.py:2408
+#: ../wxui/memedit.py:2413
 #, python-format
 msgid "Import %i memories"
 msgstr ""
@@ -1980,11 +1983,11 @@ msgstr "索引"
 msgid "Info"
 msgstr "信息"
 
-#: ../wxui/memedit.py:1775
+#: ../wxui/memedit.py:1780
 msgid "Information"
 msgstr "信息"
 
-#: ../wxui/memedit.py:2095
+#: ../wxui/memedit.py:2100
 msgid "Insert Row Above"
 msgstr "上方插入一行"
 
@@ -1996,7 +1999,7 @@ msgstr "要安装桌面图标吗？"
 msgid "Interact with driver"
 msgstr "与驱动程序交互"
 
-#: ../wxui/clone.py:817
+#: ../wxui/clone.py:799
 msgid "Internal driver error"
 msgstr "内部驱动程序错误"
 
@@ -2005,8 +2008,8 @@ msgstr "内部驱动程序错误"
 msgid "Invalid %(value)s (use decimal degrees)"
 msgstr "无效的 %(value)s（请使用十进制度数）"
 
-#: ../wxui/query_sources.py:69 ../wxui/query_sources.py:123
-#: ../wxui/memedit.py:1938
+#: ../wxui/memedit.py:1943 ../wxui/query_sources.py:69
+#: ../wxui/query_sources.py:123
 msgid "Invalid Entry"
 msgstr "无效项目"
 
@@ -2014,7 +2017,7 @@ msgstr "无效项目"
 msgid "Invalid ZIP code"
 msgstr "无效的邮政编码"
 
-#: ../wxui/memedit.py:1937 ../wxui/memedit.py:2900
+#: ../wxui/memedit.py:1942 ../wxui/memedit.py:2905
 #, python-format
 msgid "Invalid edit: %s"
 msgstr "编辑无效：%s"
@@ -2041,7 +2044,7 @@ msgstr "问题编号："
 msgid "LIVE"
 msgstr "实时"
 
-#: ../drivers/radtel_rt490.py:1026 ../wxui/main.py:852 ../wxui/main.py:1622
+#: ../wxui/main.py:852 ../wxui/main.py:1622 ../drivers/radtel_rt490.py:1026
 msgid "Language"
 msgstr "更改语言 (Change Language)"
 
@@ -2098,7 +2101,7 @@ msgstr "从 issue 加载模块"
 msgid "Load module from issue..."
 msgstr "从 issue 加载模块..."
 
-#: ../wxui/main.py:1999
+#: ../wxui/main.py:2004
 msgid "Loading a module will not affect open tabs. It is recommended (unless instructed otherwise) to close all tabs before loading a module."
 msgstr "加载模块不会影响打开的标签页。建议（除非另有说明）在加载模块之前关闭所有标签页。"
 
@@ -2131,7 +2134,7 @@ msgstr "Logo 字符串 2（12 个字符）"
 msgid "Longitude"
 msgstr "经度"
 
-#: ../wxui/memedit.py:1950
+#: ../wxui/memedit.py:1955
 #, python-format
 msgid "Manual edit of memory %i"
 msgstr ""
@@ -2144,7 +2147,7 @@ msgstr "存储"
 msgid "Memories are read-only due to unsupported firmware version"
 msgstr "由于不支持的固件版本，存储是只读的"
 
-#: ../wxui/memedit.py:1979
+#: ../wxui/memedit.py:1984
 #, python-format
 msgid "Memory %i is not deletable"
 msgstr "存储 %i 不能删除"
@@ -2167,8 +2170,8 @@ msgstr "存储必须在一个存储区中才能编辑"
 msgid "Memory {num} not in bank {bank}"
 msgstr "存储 {num} 不在存储区 {bank}"
 
-#: ../wxui/query_sources.py:624 ../wxui/query_sources.py:777
-#: ../wxui/memedit.py:628
+#: ../wxui/memedit.py:628 ../wxui/query_sources.py:624
+#: ../wxui/query_sources.py:777
 msgid "Mode"
 msgstr "制式"
 
@@ -2188,11 +2191,11 @@ msgstr "模块"
 msgid "Module Loaded"
 msgstr "模块已加载"
 
-#: ../wxui/main.py:2010
+#: ../wxui/main.py:2015
 msgid "Module loaded successfully"
 msgstr "模块加载成功"
 
-#: ../wxui/clone.py:697
+#: ../wxui/common.py:641
 msgid "More Info"
 msgstr "更多信息"
 
@@ -2201,7 +2204,7 @@ msgstr "更多信息"
 msgid "More than one port found: %s"
 msgstr "找到多个端口：%s"
 
-#: ../wxui/memedit.py:2628
+#: ../wxui/memedit.py:2633
 #, python-format
 msgid "Move %i memories"
 msgstr ""
@@ -2214,7 +2217,7 @@ msgstr "下移"
 msgid "Move Up"
 msgstr "上移"
 
-#: ../wxui/memedit.py:2598
+#: ../wxui/memedit.py:2603
 msgid "Move operations are disabled while the view is sorted"
 msgstr "排序启用时不能移动"
 
@@ -2222,11 +2225,11 @@ msgstr "排序启用时不能移动"
 msgid "New Window"
 msgstr "创建一个新的窗口"
 
-#: ../wxui/main.py:2091
+#: ../wxui/main.py:2096
 msgid "New version available"
 msgstr "有新版本"
 
-#: ../wxui/memedit.py:2279
+#: ../wxui/memedit.py:2284
 msgid "No empty rows below!"
 msgstr "下方已无空行！"
 
@@ -2244,20 +2247,20 @@ msgstr "未找到模块"
 msgid "No modules found in issue %i"
 msgstr "在 issue %i 中未找到模块"
 
-#: ../wxui/memedit.py:2462
+#: ../wxui/memedit.py:2467
 msgid "No more space available; some memories were not applied"
 msgstr "没有更多空间可用；一些存储未应用"
 
-#: ../sources/przemienniki_eu.py:53 ../sources/przemienniki_net.py:55
-#: ../sources/mapy73pl.py:57
+#: ../sources/mapy73pl.py:57 ../sources/przemienniki_net.py:55
+#: ../sources/przemienniki_eu.py:53
 msgid "No results"
 msgstr "无结果"
 
-#: ../sources/repeaterbook.py:329
+#: ../sources/repeaterbook.py:332
 msgid "No results!"
 msgstr "无结果！"
 
-#: ../wxui/query_sources.py:44 ../wxui/memedit.py:1322
+#: ../wxui/memedit.py:1322 ../wxui/query_sources.py:44
 msgid "Number"
 msgstr "编号"
 
@@ -2374,7 +2377,7 @@ msgstr "可选：-122.0000"
 msgid "Optional: County, Hospital, etc."
 msgstr "可选：县，医院，等等."
 
-#: ../wxui/memedit.py:2442
+#: ../wxui/memedit.py:2447
 msgid "Overwrite memories?"
 msgstr "要覆盖存储吗？"
 
@@ -2387,8 +2390,8 @@ msgstr ""
 "P-VFO 频道 100-109 被认为是设置。\n"
 "在这个版本中，仅支持超过 130 个可用的电台设置中的一部分。\n"
 
-#: ../sources/przemienniki_eu.py:48 ../sources/przemienniki_net.py:50
-#: ../sources/mapy73pl.py:52
+#: ../sources/mapy73pl.py:52 ../sources/przemienniki_net.py:50
+#: ../sources/przemienniki_eu.py:48
 msgid "Parsing"
 msgstr "解析"
 
@@ -2396,39 +2399,39 @@ msgstr "解析"
 msgid "Password"
 msgstr "密码"
 
-#: ../wxui/memedit.py:2115
+#: ../wxui/memedit.py:2120
 msgid "Paste"
 msgstr "粘贴"
 
-#: ../wxui/common.py:805
+#: ../wxui/common.py:796
 msgid "Paste external memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2541
+#: ../wxui/memedit.py:2546
 msgid "Paste memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2436
+#: ../wxui/memedit.py:2441
 #, python-format
 msgid "Pasted memories will overwrite %s existing memories"
 msgstr "粘贴的存储将覆盖 %s 个现有存储"
 
-#: ../wxui/memedit.py:2439
+#: ../wxui/memedit.py:2444
 #, python-format
 msgid "Pasted memories will overwrite memories %s"
 msgstr "粘贴的存储将覆盖存储 %s"
 
-#: ../wxui/memedit.py:2433
+#: ../wxui/memedit.py:2438
 #, python-format
 msgid "Pasted memories will overwrite memory %s"
 msgstr "粘贴的存储将覆盖存储 %s"
 
-#: ../wxui/memedit.py:2430
+#: ../wxui/memedit.py:2435
 #, python-format
 msgid "Pasted memory will overwrite memory %s"
 msgstr "粘贴的存储将覆盖存储 %s"
 
-#: ../wxui/main.py:2095
+#: ../wxui/main.py:2100
 msgid "Please be sure to quit CHIRP before installing the new version!"
 msgstr "请确保在安装新版本之前退出 CHIRP！"
 
@@ -2478,11 +2481,11 @@ msgstr ""
 "4 - 然后按下电台上的“A”按钮开始克隆。\n"
 "    (在结束时电台将发出蜂鸣声)\n"
 
-#: ../wxui/main.py:1939
+#: ../wxui/main.py:1944
 msgid "Please note that developer mode is intended for use by developers of the CHIRP project, or under the direction of a developer. It enables behaviors and functions that can damage your computer and your radio if not used with EXTREME care. You have been warned! Proceed anyway?"
 msgstr "请注意，开发者模式是为 CHIRP 项目的开发人员使用，或在开发人员的指导下使用。如果不小心使用，它会启用可能会损坏您的计算机和电台的行为和功能。您已经被警告！是否继续？"
 
-#: ../wxui/common.py:203
+#: ../wxui/common.py:204
 msgid "Please wait"
 msgstr "请等待"
 
@@ -2522,7 +2525,7 @@ msgstr "正在打印"
 msgid "Prolific USB device"
 msgstr "Prolific USB 设备"
 
-#: ../wxui/memedit.py:2088
+#: ../wxui/memedit.py:2093
 msgid "Properties"
 msgstr "属性"
 
@@ -2540,7 +2543,7 @@ msgstr "属性"
 msgid "QTH Locator"
 msgstr ""
 
-#: ../wxui/main.py:2040
+#: ../wxui/main.py:2045
 #, python-format
 msgid "Query %s"
 msgstr "查询 %s"
@@ -2562,8 +2565,8 @@ msgstr "查询 %s"
 msgid "Query syntax help"
 msgstr ""
 
-#: ../sources/przemienniki_eu.py:36 ../sources/przemienniki_net.py:36
-#: ../sources/mapy73pl.py:36
+#: ../sources/mapy73pl.py:36 ../sources/przemienniki_net.py:36
+#: ../sources/przemienniki_eu.py:36
 #, fuzzy
 msgid "Querying"
 msgstr "查询 %s"
@@ -2581,7 +2584,7 @@ msgstr "电台"
 msgid "Radio did not ack block %i"
 msgstr "电台未确认块 %i"
 
-#: ../wxui/clone.py:787 ../wxui/clone.py:887
+#: ../wxui/clone.py:769 ../wxui/clone.py:869
 msgid "Radio information"
 msgstr "电台信息"
 
@@ -2630,11 +2633,11 @@ msgstr "建议使用 55.2"
 msgid "Redo"
 msgstr ""
 
-#: ../wxui/common.py:497
+#: ../wxui/common.py:498
 msgid "Refresh required"
 msgstr "需要刷新"
 
-#: ../wxui/common.py:330
+#: ../wxui/common.py:331
 #, python-format
 msgid "Refreshed memory %s"
 msgstr "刷新了存储 %s"
@@ -2682,11 +2685,11 @@ msgstr "正在报告新 Bug：%r"
 msgid "Reporting enabled"
 msgstr "启用报告功能"
 
-#: ../wxui/main.py:1959
+#: ../wxui/main.py:1964
 msgid "Reporting helps the CHIRP project know which radio models and OS platforms to spend our limited efforts on. We would really appreciate if you left it enabled. Really disable reporting?"
 msgstr "报告有助于 CHIRP 项目了解哪些电台型号和操作系统平台值得我们有限的努力。如果您保持它启用，我们将不胜感激。真的要禁用报告吗？"
 
-#: ../wxui/main.py:1639 ../wxui/main.py:1953
+#: ../wxui/main.py:1639 ../wxui/main.py:1958
 msgid "Restart Required"
 msgstr "需要重新启动"
 
@@ -2704,7 +2707,7 @@ msgstr "启动时恢复标签页"
 msgid "Results from other areas"
 msgstr ""
 
-#: ../wxui/common.py:334
+#: ../wxui/common.py:335
 msgid "Retrieved settings"
 msgstr "已取得设置"
 
@@ -2720,7 +2723,7 @@ msgstr "在关闭前保存？"
 msgid "Save file"
 msgstr "保存文件"
 
-#: ../wxui/common.py:336
+#: ../wxui/common.py:337
 msgid "Saved settings"
 msgstr "已保存设置"
 
@@ -2732,7 +2735,7 @@ msgstr "扫描控制（跳过、包含、优先级等）"
 msgid "Scanlists"
 msgstr "扫描列表"
 
-#: ../drivers/ksun_m6.py:418 ../drivers/uvk5.py:889
+#: ../drivers/uvk5.py:889 ../drivers/ksun_m6.py:418
 msgid "Scrambler"
 msgstr "加密器"
 
@@ -2757,7 +2760,7 @@ msgstr "更改语言 (Change Language)"
 msgid "Select Modes"
 msgstr "选择制式"
 
-#: ../wxui/main.py:2023
+#: ../wxui/main.py:2028
 msgid "Select a bandplan"
 msgstr "选择一个频段计划"
 
@@ -2786,7 +2789,7 @@ msgstr "由于不支持的固件版本，设置是只读的"
 msgid "Shift amount (or transmit frequency) controlled by duplex"
 msgstr "由双工控制的移动量（或发射频率）"
 
-#: ../wxui/memedit.py:2224 ../wxui/developer.py:100
+#: ../wxui/developer.py:100 ../wxui/memedit.py:2229
 msgid "Show Raw Memory"
 msgstr "显示原始存储"
 
@@ -2806,47 +2809,47 @@ msgstr "打开镜像备份所在文件夹"
 msgid "Skip"
 msgstr "跳过"
 
-#: ../wxui/memedit.py:2532
+#: ../wxui/memedit.py:2537
 msgid "Some memories are incompatible with this radio"
 msgstr "某些内容与此电台不兼容"
 
-#: ../wxui/memedit.py:2371
+#: ../wxui/memedit.py:2376
 msgid "Some memories are not deletable"
 msgstr "某些内容不可被删除"
 
-#: ../wxui/memedit.py:2050
+#: ../wxui/memedit.py:2055
 #, python-format
 msgid "Sort %i memories"
 msgstr ""
 
-#: ../wxui/memedit.py:2180
+#: ../wxui/memedit.py:2185
 #, python-format
 msgid "Sort %i memory"
 msgid_plural "Sort %i memories"
 msgstr[0] "将 %i 个存储排序"
 
-#: ../wxui/memedit.py:2184
+#: ../wxui/memedit.py:2189
 #, python-format
 msgid "Sort %i memory ascending"
 msgid_plural "Sort %i memories ascending"
 msgstr[0] "将 %i 个存储升序排列"
 
-#: ../wxui/memedit.py:2206
+#: ../wxui/memedit.py:2211
 #, python-format
 msgid "Sort %i memory descending"
 msgid_plural "Sort %i memories descending"
 msgstr[0] "将 %i 个存储降序排列"
 
-#: ../wxui/memedit.py:2065
+#: ../wxui/memedit.py:2070
 msgid "Sort by column:"
 msgstr "排序列："
 
-#: ../wxui/memedit.py:2064
+#: ../wxui/memedit.py:2069
 msgid "Sort memories"
 msgstr "排序存储"
 
-#: ../sources/przemienniki_eu.py:60 ../sources/przemienniki_net.py:62
-#: ../sources/mapy73pl.py:64
+#: ../sources/mapy73pl.py:64 ../sources/przemienniki_net.py:62
+#: ../sources/przemienniki_eu.py:60
 msgid "Sorting"
 msgstr "排序"
 
@@ -2858,7 +2861,7 @@ msgstr "州"
 msgid "State/Province"
 msgstr "州/省"
 
-#: ../wxui/main.py:2011
+#: ../wxui/main.py:2016
 msgid "Success"
 msgstr "成功"
 
@@ -2940,7 +2943,7 @@ msgstr ""
 msgid "The recommended procedure for importing memories is to open the source file and copy/paste memories from it into your target image. If you continue with this import function, CHIRP will replace all memories in your currently-open file with those in %(file)s. Would you like to open this file to copy/paste memories across, or proceed with the import?"
 msgstr "导入存储的推荐方法是打开源文件，然后将存储从源文件复制/粘贴到目标镜像中。如果继续使用此导入功能，CHIRP 将使用 %(file)s 中的存储替换当前打开文件中的所有存储。您想要打开此文件以复制/粘贴记忆，还是继续导入？"
 
-#: ../wxui/memedit.py:2141
+#: ../wxui/memedit.py:2146
 msgid "This Memory"
 msgstr "该内容"
 
@@ -3003,11 +3006,11 @@ msgstr ""
 msgid "This is the ticket number for an already-created issue on the chirpmyradio.com website"
 msgstr "这是 chirpmyradio.com 网站上已创建问题的票号"
 
-#: ../wxui/memedit.py:2145
+#: ../wxui/memedit.py:2150
 msgid "This memory and shift all up"
 msgstr "此存储并上移所有"
 
-#: ../wxui/memedit.py:2143
+#: ../wxui/memedit.py:2148
 msgid "This memory and shift block up"
 msgstr "此存储并上移区块"
 
@@ -3097,7 +3100,7 @@ msgstr "USB 端口查找器"
 msgid "Unable to determine port for your cable. Check your drivers and connections."
 msgstr "无法确定您的电缆端口。检查您的驱动程序和连接。"
 
-#: ../wxui/memedit.py:1858
+#: ../wxui/memedit.py:1863
 msgid "Unable to edit memory before radio is loaded"
 msgstr "无法在加载电台之前编辑存储器"
 
@@ -3106,16 +3109,16 @@ msgstr "无法在加载电台之前编辑存储器"
 msgid "Unable to find stock config %r"
 msgstr "无法找到预设配置 %r"
 
-#: ../wxui/memedit.py:2388
+#: ../wxui/memedit.py:2393
 msgid "Unable to import while the view is sorted"
 msgstr "无法在视图排序时导入"
 
-#: ../wxui/common.py:236
+#: ../wxui/common.py:237
 msgid "Unable to open the clipboard"
 msgstr "无法打开剪贴板"
 
-#: ../sources/przemienniki_eu.py:46 ../sources/przemienniki_net.py:48
-#: ../sources/mapy73pl.py:50
+#: ../sources/mapy73pl.py:50 ../sources/przemienniki_net.py:48
+#: ../sources/przemienniki_eu.py:46
 msgid "Unable to query"
 msgstr "无法查询"
 
@@ -3123,7 +3126,7 @@ msgstr "无法查询"
 msgid "Unable to read last block. This often happens when the selected model is US but the radio is a non-US one (or widebanded). Please choose the correct model and try again."
 msgstr "无法读取最后一个块。这通常发生在所选模型为美国，但电台是非美国的（或扩频的）情况下。请选择正确的模型并重试。"
 
-#: ../wxui/common.py:702
+#: ../wxui/common.py:693
 #, python-format
 msgid "Unable to reveal %s on this system"
 msgstr "无法在此系统上显示 %s"
@@ -3163,7 +3166,7 @@ msgstr "更新现有 Bug"
 msgid "Updating bug %s"
 msgstr "正在更新 Bug %s"
 
-#: ../wxui/clone.py:902
+#: ../wxui/clone.py:884
 msgid "Upload instructions"
 msgstr "上传说明"
 
@@ -3179,7 +3182,7 @@ msgstr "上传到电台"
 msgid "Upload to radio..."
 msgstr "上传到电台……"
 
-#: ../wxui/common.py:332
+#: ../wxui/common.py:333
 #, python-format
 msgid "Uploaded memory %s"
 msgstr ""
@@ -3205,12 +3208,12 @@ msgstr "用户名"
 msgid "Value does not fit in %i bits"
 msgstr "数值无法用 %i 位表示"
 
-#: ../wxui/common.py:534
+#: ../wxui/common.py:535
 #, python-format
 msgid "Value must be at least %.4f"
 msgstr "数值必须至少为 %.4f"
 
-#: ../wxui/common.py:538
+#: ../wxui/common.py:539
 #, python-format
 msgid "Value must be at most %.4f"
 msgstr "数值必须至多为 %.4f"
@@ -3228,7 +3231,7 @@ msgstr "数值必须为零或更大"
 msgid "Value to search memory field for"
 msgstr ""
 
-#: ../wxui/memedit.py:2800
+#: ../wxui/memedit.py:2805
 msgid "Values"
 msgstr "数值"
 
@@ -3240,15 +3243,15 @@ msgstr "厂商"
 msgid "View"
 msgstr "查看"
 
-#: ../wxui/common.py:482
+#: ../wxui/common.py:483
 msgid "WARNING!"
 msgstr "警告！"
 
-#: ../wxui/bugreport.py:218 ../wxui/memedit.py:1944 ../wxui/main.py:2003
+#: ../wxui/main.py:2008 ../wxui/bugreport.py:218 ../wxui/memedit.py:1949
 msgid "Warning"
 msgstr "警告"
 
-#: ../wxui/memedit.py:1943
+#: ../wxui/memedit.py:1948
 #, python-format
 msgid "Warning: %s"
 msgstr "警告：%s"
@@ -3293,11 +3296,11 @@ msgstr "字节"
 msgid "bytes each"
 msgstr "字节每个"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "disabled"
 msgstr "已禁用"
 
-#: ../wxui/main.py:1936
+#: ../wxui/main.py:1941
 msgid "enabled"
 msgstr "已启用"
 

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1889,11 +1889,10 @@ class ChirpMain(wx.Frame):
                      border=10,
                      flag=wx.ALIGN_CENTER)
 
-        license_link = wx.adv.HyperlinkCtrl(
-            d, label=_('Click here for full license text'),
-            url=('https://www.chirpmyradio.com/projects/chirp/repository/'
-                 'github/revisions/master/entry/COPYING'))
-        vbox.Add(license_link, border=10, flag=wx.ALL | wx.ALIGN_CENTER)
+        documentation_link = wx.adv.HyperlinkCtrl(
+            d, label=_('Click here for online documentation'),
+            url=('https://chirpmyradio.com/projects/chirp/wiki/Documentation'))
+        vbox.Add(documentation_link, border=10, flag=wx.ALL | wx.ALIGN_CENTER)
 
         licheader = """
 This program is free software: you can redistribute it and/or modify
@@ -1910,6 +1909,12 @@ GNU General Public License for more details."""
             d, value=licheader.strip(),
             style=wx.TE_WORDWRAP | wx.TE_MULTILINE | wx.TE_READONLY)
         vbox.Add(lic, border=10, flag=wx.ALL | wx.EXPAND, proportion=1)
+
+        license_link = wx.adv.HyperlinkCtrl(
+            d, label=_('Click here for full license text'),
+            url=('https://www.chirpmyradio.com/projects/chirp/repository/'
+                 'github/revisions/master/entry/COPYING'))
+        vbox.Add(license_link, border=10, flag=wx.ALL | wx.ALIGN_CENTER)
 
         license_approved = CONF.get_bool('agreed_to_license', 'state')
 


### PR DESCRIPTION
This PR adds a clickable text linked to https://chirpmyradio.com/projects/chirp/wiki/Documentation and moves the exsting link to the full license text to be between the text box and the Close/Agree buttons:

![Schermata_20250508_202847](https://github.com/user-attachments/assets/427092f2-2e50-4240-bf13-1d6d437fc99a)

The idea is that the documentation is closer to the top because might it be read more than once, while the license is probably read once (or never...) and the windows seems to be more balanced.
Putting both links above seems more confusing:

![Schermata_20250508_202419](https://github.com/user-attachments/assets/2e06f601-2f24-4c32-b85e-99cd9c75a602)
