### PR TITLE
Correct P15UV model alias to UV-13Pro

### DIFF
--- a/chirp/share/model_alias_map.yaml
+++ b/chirp/share/model_alias_map.yaml
@@ -23,7 +23,7 @@ Baofeng/Pofung:
   model: Baofeng BF-1903
 - alt: Baofeng BF-888
   model: Baofeng BF-777S
-- alt: UV-17Pro
+- alt: UV-13Pro
   model: P15UV
 - alt: UV-5R
   model: 997-S (Foscam Digital Technologies)


### PR DESCRIPTION
As reported (and seems correct).

Fixes #11980
