### PR TITLE
Fixes #11996 FM VFO/CH inverted and related inverted setting label for FM receive interruption for TD-H8 and TD-H3 radios

### DIFF
--- a/chirp/drivers/tdh8.py
+++ b/chirp/drivers/tdh8.py
@@ -1912,7 +1912,7 @@ class TDH8(chirp_common.CloneModeRadio):
                               current_index=_settings.fmroad))
         fmmode.append(rs)
 
-        rs = RadioSetting("fmrec", "Forbid Receive",
+        rs = RadioSetting("fmrec", "Allow Receive",
                           RadioSettingValueBoolean(_settings.fmrec))
         fmmode.append(rs)
 

--- a/chirp/drivers/tdh8.py
+++ b/chirp/drivers/tdh8.py
@@ -779,7 +779,7 @@ B_BAND = ["Wide", "Narrow"]
 B_WORKMODE = ["VFO", "VFO+CH", "CH Mode"]
 
 # FM
-FM_WORKMODE = ["CH", "VFO"]
+FM_WORKMODE = ["VFO", "CH"]
 FM_CHANNEL = ['%s' % x for x in range(0, 26)]
 
 # DTMF


### PR DESCRIPTION
VFO and CH FM work-mode setting literals were reversed in the original driver code. This was fixed by reversing the setting list values to match what the radio actually does with this setting value.

The setting text for FM "Forbid Receive" also had reversed sense. This has been changed to "Allow Receive" to follow what the radio actually does on this setting value.

This bug fix is relevant to both TD-H8 and TD-H3 radios.
