### PR TITLE
Fixes #12005 TD-H8 SHORT_KEY_TOP not saving

### DIFF
--- a/chirp/drivers/tdh8.py
+++ b/chirp/drivers/tdh8.py
@@ -1541,8 +1541,9 @@ class TDH8(chirp_common.CloneModeRadio):
 
         if self.MODEL in H8_LIST:
             rs = RadioSetting("stopkey1", "SHORT_KEY_TOP",
-                              RadioSettingValueList(SHORT_KEY_LIST,
-                                                    current_index=0))
+                              RadioSettingValueList(
+                                  SHORT_KEY_LIST,
+                                  current_index=_press.stopkey1))
             basic.append(rs)
 
             rs = RadioSetting("ltopkey2", "LONG_KEY_TOP",


### PR DESCRIPTION
Fixes #12005 **TD-H8** SHORT_KEY_TOP not saving.

A long-standing bug where the short key press setting of the top button on the TD-H8 was being saved to the radio, but not read and displayed properly by the **TD-H8** **CHIRP next** driver to reflect what the radio was actually set to. An easy one-line code fix.