### PR TITLE
ft4: Format nonmatching ID messages for better readability

### DIFF
--- a/chirp/drivers/ft4.py
+++ b/chirp/drivers/ft4.py
@@ -345,13 +345,15 @@ def startcomms(radio, direction):
     if id_response != radio.id_str:
         substr0 = radio.id_str[:radio.id_str.find(b'\x00')]
         if id_response[:id_response.find(b'\x00')] != substr0:
-            msg = "ID mismatch. Expected" + util.hexprint(radio.id_str)
-            msg += ", Received:" + util.hexprint(id_response_mod)
+            msg = "ID mismatch.\nExpected:\n{}Received:\n{}".format(
+                util.hexprint(radio.id_str), util.hexprint(id_response_mod)
+                )
             LOG.warning(msg)
             raise errors.RadioError("Incorrect ID read from radio.")
         else:
-            msg = "ID suspect. Expected" + util.hexprint(radio.id_str)
-            msg += ", Received:" + util.hexprint(id_response_mod)
+            msg = "ID suspect.\nExpected:\n{}Received:\n{}".format(
+                util.hexprint(radio.id_str), util.hexprint(id_response_mod)
+                )
             LOG.warning(msg)
     return progressbar
 


### PR DESCRIPTION
Before
<img width="563" height="70" alt="Before" src="https://github.com/user-attachments/assets/fd969418-d70e-4331-bc29-86e117e10e06" />

After
<img width="325" height="116" alt="After" src="https://github.com/user-attachments/assets/5faa3d45-a397-4dd7-9b46-07a03334c39b" />
