### PR TITLE
Bug #11851 - btech: Fix download for QYT KT-8900D radios

### DIFF
--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -419,11 +419,11 @@ def _recv(radio, addr):
     # Get the full 69 bytes at a time to reduce load
     # 1 byte ACK + 4 bytes header + 64 bytes of data (BLOCK_SIZE)
 
-    # get the whole block
-    block = _rawrecv(radio, BLOCK_SIZE + 5)
+    # get the whole block Bug #11851 BLOCKSIZE fix for KT-8900D
+    block = _rawrecv(radio, radio._block_size + 5)
 
-    # basic check
-    if len(block) < (BLOCK_SIZE + 5):
+    # basic check Bug #11851 BLOCKSIZE fix for KT-8900D
+    if len(block) < (radio._block_size + 5):
         raise errors.RadioError("Short read of the block 0x%04x" % addr)
 
     # checking for the ack
@@ -432,7 +432,7 @@ def _recv(radio, addr):
 
     # header validation
     c, a, l = struct.unpack(">BHB", block[1:5])
-    if a != addr or l != BLOCK_SIZE or c != ord("X"):
+    if a != addr or l != radio._block_size or c != ord("X"):
         LOG.debug("Invalid header for block 0x%04x" % addr)
         LOG.debug("CMD: %s  ADDR: %04x  SIZE: %02x" % (c, a, l))
         raise errors.RadioError("Invalid header for block 0x%04x:" % addr)
@@ -542,16 +542,16 @@ def _download(radio):
     # put radio in program mode and identify it
     _do_ident(radio, status)
 
-    # reset the progress bar in the UI
-    status.max = MEM_SIZE // BLOCK_SIZE
+    # reset the progress bar in the UI Bug #11851 BLOCKSIZE fix for KT-8900D
+    status.max = MEM_SIZE // radio._block_size
     status.msg = "Cloning from radio..."
     status.cur = 0
     radio.status_fn(status)
 
     data = b""
-    for addr in range(0, MEM_SIZE, BLOCK_SIZE):
+    for addr in range(0, MEM_SIZE, radio._block_size):
         # sending the read request
-        _send(radio, _make_frame("S", addr, BLOCK_SIZE))
+        _send(radio, _make_frame("S", addr, radio._block_size))
 
         # read
         d = _recv(radio, addr)
@@ -662,6 +662,7 @@ class BTechMobileCommon(chirp_common.CloneModeRadio,
     """BTECH's UV-5001 and alike radios"""
     VENDOR = "BTECH"
     MODEL = ""
+    _block_size = 0x20  # Bug 11851 BLOCKSIZE fix for KT-8900D
     IDENT = ""
     BANDS = 2
     COLOR_LCD = False
@@ -4091,6 +4092,7 @@ class KT8900D(BTechColor):
     """QYT KT8900D"""
     VENDOR = "QYT"
     MODEL = "KT8900D"
+    _block_size = 0x10   # Bug 11851 BLOCKSIZE fix for KT-8900D
     BANDS = 2
     LIST_TMR = LIST_TMR15
     _vhf_range = (136000000, 175000000)


### PR DESCRIPTION
btech: Fix download for QYT KT-8900D radios
This fix will change the BLOCK_SIZE to 0x10 for the KT8900D model but leave it as 0x40 for all other models. 

# CHIRP PR Guidelines

The following must be true before PRs can be merged:

1. All tests must be passing. The "PR Checks" job is speculative and failure doesn't always indicate a critial problem, but generally it needs to pass as well.
1. Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
1. Commits in a single PR should be related. Squash intermediate commits into logical units (i.e. "fix tests" commits need not survive on their own). Keep cleanup commits separate from functional changes.
1. Major new features or bug fixes should reference a [CHIRP issue](https://chirpmyradio.com/projects/chirp/issues) _in the commit message_. Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
1. Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc). The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support").
1. New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already). All new drivers must use `MemoryMapBytes`.
1. All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).
1. Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
