### PR TITLE
fix default for BLOCK_SIZE for non-8900D models -

### DIFF
--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -662,7 +662,7 @@ class BTechMobileCommon(chirp_common.CloneModeRadio,
     """BTECH's UV-5001 and alike radios"""
     VENDOR = "BTECH"
     MODEL = ""
-    _block_size = 0x20  # Bug 11851 BLOCKSIZE fix for KT-8900D
+    _block_size = BLOCK_SIZE  # Bug 11851 should default to BLOCK_SIZE
     IDENT = ""
     BANDS = 2
     COLOR_LCD = False


### PR DESCRIPTION
btech: Fix block size for non-8900D models

Fixes: #11851

In my latest fix for Bug #11851 it looks like I may have caused issue with Non-8900D Models.  
I can not prove it because I don't have other models but closer code review and checking serial strings simulation it looks like I accidently changed the other models to default to 0x20 when the original was 0x40

The correct fix is to set the other models like

`  _block_size = BLOCK_SIZE `

This way it uses the original value from the file.    (0x40) 

This was my first contribution to the project and I screwed it up.  Sorry.
But this change needs made or the other models may have issues.  I guess alternately we could role back my initial change. 

Sorry for the confusion on this but I am confident it is correct now. 

Followed the PR guided.  All tox test passed.   
I did not make a new bug for this as I was not sure how you guys are doing these type of changes in this project.  
