### PR TITLE
Fix download dialog OK still active after upload

### DIFF
--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1718,14 +1718,15 @@ class ChirpMain(wx.Frame):
         else:
             d = clone.ChirpUploadDialog(radio, self)
 
-        d.Centre()
-        r = d.ShowModal()
-        if r != wx.ID_OK:
-            LOG.info('Removing un-uploaded backup %s', fn)
-            try:
-                os.remove(fn)
-            except Exception:
-                pass
+        with d:
+            d.Centre()
+            r = d.ShowModal()
+            if r != wx.ID_OK:
+                LOG.info('Removing un-uploaded backup %s', fn)
+                try:
+                    os.remove(fn)
+                except Exception:
+                    pass
 
     @common.error_proof()
     def _menu_reload_driver(self, event, andfile=False):


### PR DESCRIPTION
This is a very obscure bug that I still don't understand. Possibly an
issue in wx. If you upload followed by a download, the download
dialog's OK button does not get disabled on click, allowing a double-
spawn of the clone thread. This seems to be some sort of reentrancy
problem with the upload dialog not having been garbage collected yet
and us disabling the wrong (hidden) OK button. By using the dialog
as a context manager (like we do for download) we destroy it
after use and the problem does not manifest.

Fixes #12107
