### PR TITLE
Fix typos

### DIFF
--- a/chirp/drivers/icf520.py
+++ b/chirp/drivers/icf520.py
@@ -337,8 +337,8 @@ TONES = [
 
 DUPLEX = ["", "+", "-", "split", "off"]
 
-# Valid values for programable keys.
-# Hex numbers are used for unkown functions.
+# Valid values for programmable keys.
+# Hex numbers are used for unknown functions.
 KEY_FUNC = [
     "Null",
     "CH Up",
@@ -493,7 +493,7 @@ AUDIO_FILTER_VALUES = [
     ]
 
 # Valid values for Mic Gain.
-# Hex numbers are used for unkown functions.
+# Hex numbers are used for unknown functions.
 MIC_GAIN_FUNC = [
     "0x00",
     "1 Min",
@@ -544,7 +544,7 @@ SCRAMBLER_GCODE_VALUES = [
     ]
 
 # Valid values for Scrambler Synchronous Capture.
-# Hex numbers are used for unkown functions.
+# Hex numbers are used for unknown functions.
 SYN_CAPTURE_FUNC = [
     "Standard",
     "0x01",
@@ -797,7 +797,7 @@ class ICF621_2Radio(icf.IcomCloneModeRadio):
         memory.extra = RadioSettingGroup('extra', 'Extra')
 
         # Mask (Don't display) channel on radio.
-        # This is refered as Inhibit in the CS-F500 software.
+        # This is referred as Inhibit in the CS-F500 software.
         _disp_inhibit = RadioSetting(
             "disp_inhibit", "Mask",
             RadioSettingValueList(

--- a/chirp/drivers/retevis_ra25.py
+++ b/chirp/drivers/retevis_ra25.py
@@ -597,7 +597,7 @@ class RA25UVRadio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
         mem.extra.append(rs)
 
         rstype = RadioSettingValueBoolean(_mem.nc)
-        rs = RadioSetting("nc", "Noise Cancelation", rstype)
+        rs = RadioSetting("nc", "Noise Cancellation", rstype)
         mem.extra.append(rs)
 
         tid_options = ['Off', 'Begin', 'End', "Both"]

--- a/chirp/drivers/tdh8.py
+++ b/chirp/drivers/tdh8.py
@@ -1507,7 +1507,7 @@ class TDH8(chirp_common.CloneModeRadio):
                 if _settings.brightness not in range(0, 5):
                     LOG.warning(
                         "brightness out of range 1 to 5. Actual value: %X. "
-                        "Screen may not be visable",
+                        "Screen may not be visible",
                         _settings.brightness)
 
                 rs = RadioSetting("brightness", "Brightness",

--- a/chirp/drivers/tk280.py
+++ b/chirp/drivers/tk280.py
@@ -68,7 +68,7 @@ def choose_step(step_map, freq, default=5.0):
         step = chirp_common.required_step(freq, step_map.keys())
     except errors.InvalidDataError:
         step = default
-        LOG.warning('Frequency %s requires step not in availble map, '
+        LOG.warning('Frequency %s requires step not in available map, '
                     'using %s kHz by default',
                     chirp_common.format_freq(freq), step)
     return step_map[step]


### PR DESCRIPTION
This PR fixes some small spelling mistakes:
* one in the GUI for Retevis RA25 (the title of the columns "Noise Cancellation")
*  2 in log messages
* and the others in comments.

Local tox tests are passing (11229 passed, 2684 skipped, 233 xfailed, 474 xpassed, 285014 warnings).
