### PR TITLE
Ipython support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ chirp/locale/.files
 # nix
 .direnv
 result/
+# for nvim editor
+.nvim.lua

--- a/chirp/wxui/main.py
+++ b/chirp/wxui/main.py
@@ -1809,14 +1809,27 @@ class ChirpMain(wx.Frame):
 
     def _menu_interact_driver(self, event):
         LOG.warning('Going to interact with radio at the console')
+
         radio = self.current_editorset.current_editor.radio
-        import code
         locals = {'main': self,
                   'radio': radio}
+
         if self.current_editorset.radio != radio:
             locals['parent_radio'] = self.current_editorset.radio
-        code.interact(banner='Locals are: %s' % (', '.join(locals.keys())),
-                      local=locals)
+
+        banner = 'Locals are: %s' % (', '.join(locals.keys()))
+
+        # Use ipython if it's installed which gives tab complete and some other
+        # nice features over the built in REPL.
+        try:
+            from IPython.terminal.embed import InteractiveShellEmbed
+
+            shell = InteractiveShellEmbed()
+            shell(header=banner, local_ns=locals)
+
+        except ModuleNotFoundError:
+            import code
+            code.interact(banner=banner, local=locals)
 
     @common.error_proof()
     def load_module(self, filename):


### PR DESCRIPTION
Adds support for using ipython interactive console instead of the default, if ipython is installed. This is really useful for things like tab completion, which makes debugging drivers easier.