### PR TITLE
feat: add nixos support with nix devshell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ ignored/
 patch_queue/
 archived_builds/
 .tox/
+.venv/
 **.mo
 **.pot
 locale/.files
@@ -34,3 +35,6 @@ chirpwx.spec
 chirp/locale/.files
 # for pycharm IDE
 .idea
+# nix
+.direnv
+result/

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "Nix development environment";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      pythonPackages = pkgs.python3Packages;
+    in {
+      devShells = {
+        default = pkgs.mkShell {
+          name = "impurePythonEnv";
+          venvDir = "./.venv";
+
+          # Packages required to build the venv
+          buildInputs = [
+            # The interpreter to use
+            pythonPackages.python
+            # automatically create the venv
+            pythonPackages.venvShellHook
+            # get nix to install wxpython as whl doesn't work on NixOS
+            pythonPackages.wxpython
+
+            pkgs.gsettings-desktop-schemas
+            pkgs.glib
+            pkgs.gtk3
+          ];
+
+          # Runtime packages
+          packages = [
+            # Python dev tools
+            pythonPackages.ipython
+            pythonPackages.ipdb
+            pkgs.ruff
+            pkgs.pyright
+
+            # radio driver development dev tools
+            pkgs.biodiff # binary diff
+          ];
+          env = {
+            # Make breakpoint() use ipdb instead of the builtin pdb
+            PYTHONBREAKPOINT = "ipdb.set_trace";
+
+          };
+          postVenvCreation = ''
+            unset SOURCE_DATE_EPOCH
+            # Install chirp as an editable package
+            pip install -e .
+          '';
+
+          # Now we can execute any commands within the virtual environment.
+          # This is optional and can be left out to run pip manually.
+          postShellHook = ''
+            # allow pip to install wheels
+            unset SOURCE_DATE_EPOCH
+            export XDG_DATA_DIRS=$GSETTINGS_SCHEMAS_PATH
+          '';
+        };
+      };
+
+      formatter = nixpkgs.legacyPackages.${system}.alejandra;
+    });
+}


### PR DESCRIPTION
Add a nix devshell flake to the repo to make it easier for anyone using NixOS or nix in general.

[[[https://nixos.org/]]] is a Linux distribution that enables declarative configuration of everything right down to the partition structure (using disko). Problem is that you can't just create a Python virtual environment and install what you like, if a python package is linked against a dynamic library then you have to use the NixOS packaged version instead.

The generally accepted way of developing Python on NixOS is to use DevShells. These create a sub shell that contains the required the dependencies.

To add support we just need to add a flake.nix file in the project root. This doesn't effect anyone who doesn't use nix or NixOS, but does make it a lot easier for those who do.

Related to #12131