### PR TITLE
Enable offset for Icom 7100; fixes #11033

### DIFF
--- a/chirp/drivers/icomciv.py
+++ b/chirp/drivers/icomciv.py
@@ -1018,7 +1018,7 @@ class Icom7100Radio(IcomCIVRadio):
         self._rf.has_dtcs_polarity = False
         self._rf.has_dtcs = False
         self._rf.has_ctone = True
-        self._rf.has_offset = False
+        self._rf.has_offset = True
         self._rf.has_name = True
         self._rf.has_tuning_step = False
         self._rf.valid_modes = [


### PR DESCRIPTION
Hello, this fixes a long-standing bug where new UHF repeaters added to an Icom 7100 are given an offset of 600kHz.

https://www.chirpmyradio.com/issues/11033
https://www.reddit.com/r/amateurradio/comments/bsqg88/icom_7100_problem_incorrect_offset_in_uhf_when/
https://www.reddit.com/r/amateurradio/comments/7gxh5b/what_memory_manager_like_chirp_works_with_icom/

The reason an offset of 600kHz was being set seems to be an omission, here:

```
    def _set_memory_defaults(self, mem, *only):
        [...]
        defaults = self.bandplan.get_defaults_for_frequency(mem.freq)
        features = self._features
        [...]
        if want_duplex is not None and want_duplex in features.valid_duplexes:
            if 'duplex' in only:
                mem.duplex = want_duplex
        if want_offset is not None and features.has_offset:
            if 'offset' in only:
                mem.offset = want_offset
```

Because we don't `has_offset`, the offset from `get_defaults_for_frequency` is never assigned.

The truth is, the Icom 7100 fully supports offsets and when `has_offset` is set to True in the driver, it works great, and I can kerchunk freshly programmed UHF repeaters to my heart's content. It works fine with non-standard offsets like 1.0MHz as well. I think fully exposing the offset functionality in this radio is the true fix for this bug.