### PR TITLE
Improved autocomplete for memory structure objects

### DIFF
--- a/chirp/bitwise.py
+++ b/chirp/bitwise.py
@@ -836,12 +836,13 @@ class structDataElement(DataElement):
             self._generators[key] = value
             self._keys.append(key)
 
+    def __dir__(self):
+        return list(super().__dir__()) + list(self._generators.keys())
+
     def __getattr__(self, name):
         try:
             return self._generators[name]
         except KeyError:
-            LOG.error('Request for struct element %s not in %s' % (
-                name, self._generators.keys()))
             raise AttributeError("No attribute %s in struct %s" % (
                 name, self._name))
 


### PR DESCRIPTION
IPython auto complete works really well for most of the radio driver objects. One that stands out as a bit of a pain is the `structDataElement` object. Which spits log messages all over the repl prompt when you try and tab complete on the struct fields.

The `structDataElement` objects implement `__getattr__` which pulls up the generator keys to full object attributes. The problem is that `dir()` then tries to use `__getattr__` to determine the attributes on the object.

`structDataElement.__getattr__` contained a logger call, which meant that every failed call created a log entry. Which means that if `dir()` is called or the IPython completion, then you get log spamming. So I've removed the logger call in this low level magic method, which fixes the log spamming issue.

This resolves the issue, but only lists the standard python object attributes, none of the struct fields are available. Looking at the `dir()` docs, the recommendation is to implement `__dir__` alongside `__getattr__` so that all attributes can be found.

With both of these changes, the memory structure objects can be tab completed in IPython as expected, and the builtin `dir()` lists all of the attributes that can be accessed.