### PR TITLE
fix: test runner shebang

### DIFF
--- a/tools/fast-driver.py
+++ b/tools/fast-driver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env Python3
+#!/usr/bin/env python3
 
 import glob
 import os


### PR DESCRIPTION
Fix the shebang for fast-driver script.

The only reason this currently works with a broken shebang is because it's called with `python tools/fast-driver.py` in `tox.ini`. Whereas if you just do `./fast-driver.py ...` it fails saying it can't find `Python3` (should be python3).