### PR TITLE
at779UV: Fix setting empty memories

### DIFF
--- a/chirp/drivers/retevis_ra25.py
+++ b/chirp/drivers/retevis_ra25.py
@@ -630,7 +630,6 @@ class RA25UVRadio(chirp_common.CloneModeRadio, chirp_common.ExperimentalRadio):
                 _mem.txpower = 2
                 _mem.freq = mem.freq // 10
                 _mem.tx_off = 0 if self.is_tx_allowed(mem.freq) else 1
-                return
 
             _mem.name = mem.name.ljust(8)[:8]
             # scan when set(1) skip when off(0)


### PR DESCRIPTION
This driver had an errant 'return' in the new-memory initialization
code that meant initial values were lost.

Fixes #12166
