### PR TITLE
Add helper method is_split() to chirp_common

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -2137,3 +2137,19 @@ def in_range(freq, ranges):
         if lo <= freq <= hi:
             return True
     return False
+
+
+def is_split(rf, freq1, freq2):
+    """Check if two freqs are in the same radio band
+    Returns False if the two freqs are in the same band (not split)
+    or True if they are in separate bands (split)"""
+
+    # determine if the two freqs are in the same band
+    for low, high in rf.valid_bands:
+        if freq1 >= low and freq1 <= high and \
+                freq2 >= low and freq2 <= high:
+            # if the two freqs are on the same Band this is not a split
+            return False
+
+    # if you get here is because the freq pairs are split
+    return True

--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -2139,13 +2139,13 @@ def in_range(freq, ranges):
     return False
 
 
-def is_split(rf, freq1, freq2):
-    """Check if two freqs are in the same radio band
+def is_split(bands, freq1, freq2):
+    """Check if two freqs are in the same band from a list of bands
     Returns False if the two freqs are in the same band (not split)
     or True if they are in separate bands (split)"""
 
     # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
+    for low, high in bands:
         if freq1 >= low and freq1 <= high and \
                 freq2 >= low and freq2 <= high:
             # if the two freqs are on the same Band this is not a split

--- a/chirp/drivers/baofeng_common.py
+++ b/chirp/drivers/baofeng_common.py
@@ -434,21 +434,6 @@ def _upload(radio):
             radio.status_fn(status)
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 def bcd_decode_freq(bytes):
     real_freq = 0
     for byte in bytes:
@@ -567,8 +552,8 @@ class BaofengCommonHT(chirp_common.CloneModeRadio,
             # TX freq set
             offset = (int(_mem.txfreq) * 10) - mem.freq
             if offset != 0:
-                if _split(self.get_features(), mem.freq, int(
-                          _mem.txfreq) * 10):
+                if chirp_common.is_split(self.get_features().valid_bands,
+                                         mem.freq, int(_mem.txfreq) * 10):
                     mem.duplex = "split"
                     mem.offset = int(_mem.txfreq) * 10
                 elif offset < 0:

--- a/chirp/drivers/baofeng_uv17Pro.py
+++ b/chirp/drivers/baofeng_uv17Pro.py
@@ -1308,8 +1308,8 @@ class UV17Pro(bfc.BaofengCommonHT):
         else:
             offset = (int(_mem.txfreq) * 10) - freq
             if offset != 0:
-                if bfc._split(self.get_features(), freq, int(
-                          _mem.txfreq) * 10):
+                if chirp_common.is_split(self.get_features().valid_bands,
+                                         freq, int(_mem.txfreq) * 10):
                     duplex = "split"
                     offset = int(_mem.txfreq) * 10
                 elif offset < 0:

--- a/chirp/drivers/btech.py
+++ b/chirp/drivers/btech.py
@@ -642,21 +642,6 @@ def _decode_ranges(low, high):
     return (ilow, ihigh)
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 class BTechMobileCommon(chirp_common.CloneModeRadio,
                         chirp_common.ExperimentalRadio):
     """BTECH's UV-5001 and alike radios"""
@@ -858,8 +843,8 @@ class BTechMobileCommon(chirp_common.CloneModeRadio,
             # TX freq set
             offset = (int(_mem.txfreq) * 10) - mem.freq
             if offset != 0:
-                if _split(self.get_features(), mem.freq, int(
-                          _mem.txfreq) * 10):
+                if chirp_common.is_split(self.get_features().valid_bands,
+                                         mem.freq, int(_mem.txfreq) * 10):
                     mem.duplex = "split"
                     mem.offset = int(_mem.txfreq) * 10
                 elif offset < 0:

--- a/chirp/drivers/iradio_uv_5118.py
+++ b/chirp/drivers/iradio_uv_5118.py
@@ -302,21 +302,6 @@ def do_upload(radio):
     _exit_programming_mode(radio)
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 class IradioUV5118(chirp_common.CloneModeRadio):
     """IRADIO UV5118"""
     VENDOR = "Iradio"
@@ -469,8 +454,8 @@ class IradioUV5118(chirp_common.CloneModeRadio):
         # TX freq set
         offset = (int(_mem.txfreq) * 10) - mem.freq
         if offset != 0:
-            if _split(self.get_features(), mem.freq, int(
-                      _mem.txfreq) * 10):
+            if chirp_common.is_split(self.get_features().valid_bands,
+                                     mem.freq, int(_mem.txfreq) * 10):
                 mem.duplex = "split"
                 mem.offset = int(_mem.txfreq) * 10
             elif offset < 0:

--- a/chirp/drivers/iradio_uv_5118plus.py
+++ b/chirp/drivers/iradio_uv_5118plus.py
@@ -336,21 +336,6 @@ def do_upload(radio):
     _exit_programming_mode(radio)
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 class IradioUV5118plus(chirp_common.CloneModeRadio):
     """IRADIO UV5118plus"""
     VENDOR = "Iradio"
@@ -507,8 +492,8 @@ class IradioUV5118plus(chirp_common.CloneModeRadio):
         # TX freq set
         offset = (int(_mem.txfreq) * 10) - mem.freq
         if offset != 0:
-            if _split(self.get_features(), mem.freq, int(
-                      _mem.txfreq) * 10):
+            if chirp_common.is_split(self.get_features().valid_bands,
+                                     mem.freq, int(_mem.txfreq) * 10):
                 mem.duplex = "split"
                 mem.offset = int(_mem.txfreq) * 10
             elif offset < 0:

--- a/chirp/drivers/lt725uv.py
+++ b/chirp/drivers/lt725uv.py
@@ -406,21 +406,6 @@ def model_match(cls, data):
         return False
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # Determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # If the two freqs are on the same Band this is not a split
-            return False
-
-    # If you get here is because the freq pairs are split
-    return True
-
-
 @directory.register
 class LT725UV(chirp_common.CloneModeRadio):
     """LUITON LT-725UV Radio"""
@@ -607,7 +592,8 @@ class LT725UV(chirp_common.CloneModeRadio):
         elif int(_mem.rxfreq) == int(_mem.txfreq):
             mem.duplex = ""
             mem.offset = 0
-        elif _split(self.get_features(), mem.freq, int(_mem.txfreq) * 10):
+        elif chirp_common.is_split(self.get_features().valid_bands,
+                                   mem.freq, int(_mem.txfreq) * 10):
             mem.duplex = "split"
             mem.offset = int(_mem.txfreq) * 10
         else:

--- a/chirp/drivers/mml_jc8810.py
+++ b/chirp/drivers/mml_jc8810.py
@@ -405,21 +405,6 @@ def do_upload(radio):
     _exit_programming_mode(radio)
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 class JC8810base(chirp_common.CloneModeRadio):
     """MML JC-8810"""
     VENDOR = "MML"
@@ -539,8 +524,8 @@ class JC8810base(chirp_common.CloneModeRadio):
             # TX freq set
             offset = (int(_mem.txfreq) * 10) - mem.freq
             if offset != 0:
-                if _split(self.get_features(), mem.freq, int(
-                          _mem.txfreq) * 10):
+                if chirp_common.is_split(self.get_features().valid_bands,
+                                         mem.freq, int(_mem.txfreq) * 10):
                     mem.duplex = "split"
                     mem.offset = int(_mem.txfreq) * 10
                 elif offset < 0:

--- a/chirp/drivers/retevis_ra86.py
+++ b/chirp/drivers/retevis_ra86.py
@@ -238,21 +238,6 @@ def do_upload(radio):
     _exit_programming_mode(radio)
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 @directory.register
 class RA86Radio(chirp_common.CloneModeRadio):
     """RETEVIS RA86"""
@@ -409,8 +394,8 @@ class RA86Radio(chirp_common.CloneModeRadio):
             # TX freq set
             offset = (int(_mem.txfreq)) - mem.freq
             if offset != 0:
-                if _split(self.get_features(), mem.freq, int(
-                          _mem.txfreq)):
+                if chirp_common.is_split(self.get_features().valid_bands,
+                                         mem.freq, int(_mem.txfreq)):
                     mem.duplex = "split"
                     mem.offset = int(_mem.txfreq)
                 elif offset < 0:

--- a/chirp/drivers/retevis_rb15.py
+++ b/chirp/drivers/retevis_rb15.py
@@ -280,21 +280,6 @@ def do_upload(radio):
     _rb15_exit_programming_mode(radio)
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 class RB15RadioBase(chirp_common.CloneModeRadio):
     """RETEVIS RB15 BASE"""
     VENDOR = "Retevis"
@@ -490,8 +475,8 @@ class RB15RadioBase(chirp_common.CloneModeRadio):
             # TX freq set
             offset = (int(_mem.txfreq) * 10) - mem.freq
             if offset != 0:
-                if _split(self.get_features(), mem.freq, int(
-                          _mem.txfreq) * 10):
+                if chirp_common.is_split(self.get_features().valid_bands,
+                                         mem.freq, int(_mem.txfreq) * 10):
                     mem.duplex = "split"
                     mem.offset = int(_mem.txfreq) * 10
                 elif offset < 0:

--- a/chirp/drivers/retevis_rt23.py
+++ b/chirp/drivers/retevis_rt23.py
@@ -338,21 +338,6 @@ def model_match(cls, data):
         return False
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 @directory.register
 class RT23Radio(chirp_common.CloneModeRadio):
     """RETEVIS RT23"""
@@ -499,8 +484,8 @@ class RT23Radio(chirp_common.CloneModeRadio):
             # TX freq set
             offset = (int(_mem.txfreq) * 10) - mem.freq
             if offset != 0:
-                if _split(self.get_features(), mem.freq, int(
-                          _mem.txfreq) * 10):
+                if chirp_common.is_split(self.get_features().valid_bands,
+                                         mem.freq, int(_mem.txfreq) * 10):
                     mem.duplex = "split"
                     mem.offset = int(_mem.txfreq) * 10
                 elif offset < 0:

--- a/chirp/drivers/retevis_rt87.py
+++ b/chirp/drivers/retevis_rt87.py
@@ -317,21 +317,6 @@ def _upload(radio):
     radio.pipe.write(b"E")
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 class Rt87BaseRadio(chirp_common.CloneModeRadio):
     VENDOR = "Retevis"
     MODEL = "RT87 Base"
@@ -491,8 +476,8 @@ class Rt87BaseRadio(chirp_common.CloneModeRadio):
             # TX freq set
             offset = (int(_mem.tx_freq) * 10) - mem.freq
             if offset != 0:
-                if _split(self.get_features(), mem.freq, int(
-                          _mem.tx_freq) * 10):
+                if chirp_common.is_split(self.get_features().valid_bands,
+                                         mem.freq, int(_mem.tx_freq) * 10):
                     mem.duplex = "split"
                     mem.offset = int(_mem.tx_freq) * 10
                 elif offset < 0:

--- a/chirp/drivers/tdxone_tdq8a.py
+++ b/chirp/drivers/tdxone_tdq8a.py
@@ -406,21 +406,6 @@ def model_match(cls, data):
         return False
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 @directory.register
 class TDXoneTDQ8A(chirp_common.CloneModeRadio,
                   chirp_common.ExperimentalRadio):
@@ -562,8 +547,8 @@ class TDXoneTDQ8A(chirp_common.CloneModeRadio,
             # TX freq set
             offset = (int(_mem.txfreq) * 10) - mem.freq
             if offset != 0:
-                if _split(self.get_features(), mem.freq, int(
-                          _mem.txfreq) * 10):
+                if chirp_common.is_split(self.get_features().valid_bands,
+                                         mem.freq, int(_mem.txfreq) * 10):
                     mem.duplex = "split"
                     mem.offset = int(_mem.txfreq) * 10
                 elif offset < 0:

--- a/chirp/drivers/vgc.py
+++ b/chirp/drivers/vgc.py
@@ -555,21 +555,6 @@ def model_match(cls, data):
     return False
 
 
-def _split(rf, f1, f2):
-    """Returns False if the two freqs are in the same band (no split)
-    or True otherwise"""
-
-    # determine if the two freqs are in the same band
-    for low, high in rf.valid_bands:
-        if f1 >= low and f1 <= high and \
-                f2 >= low and f2 <= high:
-            # if the two freqs are on the same Band this is not a split
-            return False
-
-    # if you get here is because the freq pairs are split
-    return True
-
-
 class VGCStyleRadio(chirp_common.CloneModeRadio,
                     chirp_common.ExperimentalRadio):
     """BTECH's UV-50X3"""
@@ -764,8 +749,8 @@ class VGCStyleRadio(chirp_common.CloneModeRadio,
             # TX feq set
             offset = (int(_mem.txfreq) * 10) - mem.freq
             if offset != 0:
-                if _split(self.get_features(), mem.freq, int(
-                          _mem.txfreq) * 10):
+                if chirp_common.is_split(self.get_features().valid_bands,
+                                         mem.freq, int(_mem.txfreq) * 10):
                     mem.duplex = "split"
                     mem.offset = int(_mem.txfreq) * 10
                 elif offset < 0:


### PR DESCRIPTION
Add helper method is_split() to chirp_common

A local _split() method is defined in at least 12 driver modules and is **not** easily _reusable_ in other driver modules.

This change will make way for an easily _reusage_ equivalent of all those local _split() method implementations.

This change does not address any outstanding issue, but came about during a PR code review of a new driver (PR #1391) that uses a local _split() method yet again. This is an opportunity to finally make it reusable.

The future intent is the refactor the existing driver modules that have local defs of their own _split() method and replace those with a call to the one contained in this change.