### PR TITLE
Always show character requirements in setting string tooltip

### DIFF
--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -304,6 +304,10 @@ class RadioSettingValueString(RadioSettingValue):
     def maxlength(self):
         return self._maxlength
 
+    @property
+    def minlength(self):
+        return self._minlength
+
     def set_charset(self, charset):
         """Sets the set of allowed characters"""
         self._charset = charset
@@ -608,6 +612,8 @@ class RadioSetting(RadioSettingGroup):
         self._warning_text = None
         self._safe_value = None
         self._volatile = False
+        if self.__doc__ == self.get_name():
+            self.__doc__ = None
 
     @property
     def volatile(self):

--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -403,12 +403,16 @@ class ChirpSettingGrid(wx.Panel):
         tip = None
         if prop:
             setting = self.get_setting_by_name(prop.GetName())
-            tip = setting.__doc__ or None
-            if tip and tip == setting.get_name():
-                # This is the default, which makes no sense, but it's been
-                # that way for ages, so just avoid exposing it here if it's
-                # set to the default.
-                tip = None
+            if isinstance(setting.value, settings.RadioSettingValueString):
+                tip = setting.__doc__ or ''
+                if setting.value.maxlength == setting.value._minlength:
+                    extra = '%i characters' % setting.value.maxlength
+                else:
+                    extra = '%i-%i characters' % (setting.value.minlength,
+                                                  setting.value.maxlength)
+                tip = (tip + ' (%s)' % extra).strip()
+            else:
+                tip = setting.__doc__ or None
 
         event.GetEventObject().SetToolTip(tip)
 


### PR DESCRIPTION
This helps people know how long of a string is required for a
RadioSettingValueString.
