### PR TITLE
Fix RB query for non-NA countries when translated

### DIFF
--- a/chirp/sources/repeaterbook.py
+++ b/chirp/sources/repeaterbook.py
@@ -83,6 +83,9 @@ class RepeaterBook(base.NetworkResultRadio):
 
     @staticmethod
     def get_resource_name(service, country, state):
+        if country not in STATES:
+            # Hack around the translated "All" string in the UI
+            state = 'all'
         return 'rb%s-%s-%s.json' % (service,
                                     country.lower().replace(' ', '_'),
                                     state.lower().replace(' ', '_'))


### PR DESCRIPTION
If you are using a non-english locale and selected a non-NA country,
you'll get a 404 when querying.
