### PR TITLE
radtel_rt900: Expose LearnFHSS per-channel setting

### DIFF
--- a/chirp/drivers/radtel_rt900.py
+++ b/chirp/drivers/radtel_rt900.py
@@ -71,8 +71,8 @@ struct {
      bcl:1,           //     BCL
      scan:1,          //     Scan  0 = Skip, 1 = Scan
      am_modulation:1, //     Per chan AM modulation
-     learning:1;      //     Learning
-  lbcd code[3];       // 0-2 Code
+     learning:1;      //     FHSS Learning
+  ul24 code;          // 0-2 FHSS Code (little-endian, 0-0x7FFFFF)
   u8 unknown6;        // 3
   char name[12];      // 4-F 12-character Alpha Tag
 } memory[%d];
@@ -1247,6 +1247,25 @@ class RT900BT(chirp_common.CloneModeRadio):
         rset = RadioSetting("learning", "LearnFHSS", rs)
         mem.extra.append(rset)
 
+        # FHSS Code (24-bit little-endian, range 0x000000-0x7FFFFF).
+        # Displayed and accepted as a 6-digit uppercase hex string to
+        # match the OEM CPS convention.
+        def validate_fhss_code(value):
+            try:
+                v = int(str(value).strip(), 16)
+            except ValueError:
+                raise InvalidValueError(
+                    "FHSS Code must be a hex value (e.g. 1A2B3C)")
+            if not (0 <= v <= 0x7FFFFF):
+                raise InvalidValueError(
+                    "FHSS Code must be between 000000 and 7FFFFF")
+            return value
+
+        rs = RadioSettingValueString(0, 6, "%06X" % int(_mem.code))
+        rs.set_validate_callback(validate_fhss_code)
+        rset = RadioSetting("fhss_code", "FHSS Code (hex)", rs)
+        mem.extra.append(rset)
+
         # PTT-ID
         rs = RadioSettingValueList(PTTID_LIST, current_index=_mem.pttid)
         rset = RadioSetting("pttid", "PTT ID", rs)
@@ -1328,7 +1347,10 @@ class RT900BT(chirp_common.CloneModeRadio):
                 _mem.narrow = 0b1
 
         for setting in mem.extra:
-            setattr(_mem, setting.get_name(), setting.value)
+            if setting.get_name() == 'fhss_code':
+                _mem.code = int(str(setting.value).strip(), 16)
+            else:
+                setattr(_mem, setting.get_name(), setting.value)
 
     def validate_memory(self, mem):
         msgs = []

--- a/chirp/drivers/radtel_rt900.py
+++ b/chirp/drivers/radtel_rt900.py
@@ -1261,7 +1261,8 @@ class RT900BT(chirp_common.CloneModeRadio):
                     "FHSS Code must be between 000000 and 7FFFFF")
             return value
 
-        rs = RadioSettingValueString(0, 6, "%06X" % (int(_mem.code) & 0x7FFFFF))
+        rs = RadioSettingValueString(
+            0, 6, "%06X" % (int(_mem.code) & 0x7FFFFF))
         rs.set_validate_callback(validate_fhss_code)
         rset = RadioSetting("fhss_code", "FHSS Code (hex)", rs)
         mem.extra.append(rset)

--- a/chirp/drivers/radtel_rt900.py
+++ b/chirp/drivers/radtel_rt900.py
@@ -1261,7 +1261,7 @@ class RT900BT(chirp_common.CloneModeRadio):
                     "FHSS Code must be between 000000 and 7FFFFF")
             return value
 
-        rs = RadioSettingValueString(0, 6, "%06X" % int(_mem.code))
+        rs = RadioSettingValueString(0, 6, "%06X" % (int(_mem.code) & 0x7FFFFF))
         rs.set_validate_callback(validate_fhss_code)
         rset = RadioSetting("fhss_code", "FHSS Code (hex)", rs)
         mem.extra.append(rset)

--- a/chirp/drivers/radtel_rt900.py
+++ b/chirp/drivers/radtel_rt900.py
@@ -1240,6 +1240,13 @@ class RT900BT(chirp_common.CloneModeRadio):
         rset = RadioSetting("bcl", "BCL", rs)
         mem.extra.append(rset)
 
+        # LearnFHSS (per-channel learn / FHSS flag). The OEM CPS labels
+        # this column "LearnFHSS"; the open-source firmware reads the
+        # same bit as chFlag3.b0 / fhssFlag (Core/Radio.c).
+        rs = RadioSettingValueBoolean(_mem.learning)
+        rset = RadioSetting("learning", "LearnFHSS", rs)
+        mem.extra.append(rset)
+
         # PTT-ID
         rs = RadioSettingValueList(PTTID_LIST, current_index=_mem.pttid)
         rset = RadioSetting("pttid", "PTT ID", rs)


### PR DESCRIPTION
## Summary

Expose the per-channel `LearnFHSS` flag as a `RadioSetting` in the RT-900 driver's `mem.extra` group. The bit was already modeled in `MEM_FORMAT` as `learning:1` (byte F bit 0) but was never wired to a UI setting, so users could not toggle it from CHIRP.

One-line change in `get_memory`; round-trip is handled by the existing `mem.extra` setattr loop in `set_memory`.

## Where this comes from

While investigating the RT-900 series driver against the vendor open-source firmware release [`Radtel_RT900+open+source+20250305+.zip`](https://www.radtels.com/pages/software-download) (labeled "Radtel RT-900（无BT）Open Source 250305" — **non-BT**, 2025-03-05 snapshot), I noticed:

1. `chirp/drivers/radtel_rt900.py` defines a `learning:1` bitfield at byte F bit 0 of the channel struct, but no code in the driver reads or writes `_mem.learning` anywhere outside the struct declaration.
2. The vendor firmware source reads the same bit as `chFlag3.Bit.b0` / `fhssFlag` in `work/source/Core/Radio.c`:
   ```c
   fhssFlag = channelInfo.chFlag3.Byte & 0x01;
   ```
3. The OEM Radtel CPS exposes this bit to users as a per-channel column labeled **`LearnFHSS`** — i.e. the OEM combines both the firmware name ("FHSS") and CHIRP's working name ("Learn"). This confirmed the feature is real and user-facing but simply missing from CHIRP's UI.

## Verification

Tested against a real physical **RT-900 BT** on macOS:

1. Downloaded a baseline image from the radio with CHIRP.
2. Configured a test channel (ch. 34) in the OEM Radtel CPS with only `LearnFHSS` toggled (all other fields unchanged from a previous known-reference write).
3. Wrote the config back to the radio via OEM CPS.
4. Re-downloaded with CHIRP.
5. Hex-diffed the two CHIRP images. The only relevant change on channel 34 was byte F: `0x68 → 0x69` — a clean single-bit flip at bit 0, exactly where CHIRP models `learning:1`. No other bytes in the channel struct moved.

This establishes that CHIRP's bit location is correct and that the OEM feature maps 1:1 to the field CHIRP already has.

The same verification round incidentally confirmed CHIRP's modeling of byte F bits `narrow`, `encrypt`, `bcl`, `scan`, and `am_modulation` against the OEM CPS output (they all matched byte-for-byte on the same test channel).

## Test plan

- [x] `tools/cpep8.py chirp/drivers/radtel_rt900.py` — clean
- [x] `mypy --config-file .mypy.ini chirp/drivers/radtel_rt900.py` — clean
- [x] `pytest tests/test_drivers.py -k "Radtel_RT-9 or Radioddity_GS-10B"` — **213 passed** across all six variants that inherit from `RT900BT` (RT-900, RT-900_BT, RT-910, RT-910_BT, RT-920, Radioddity GS-10B), including `test_memory_extra_flat`, `test_memory_extra_frozen`, and `test_copy` which exercise the new setting's round-trip.
- [x] Empirical round-trip of the new setting verified against a physical RT-900 BT (see "Verification" above).

## Scope note

This PR intentionally does **not** touch `MEM_FORMAT`, does not rename the `learning` field, and does not change any other setting, label, or default. Keeping it to a minimal, strictly-tested change so the diff is easy to review. A follow-up investigation into scramble (which the OEM CPS itself cannot currently persist on this radio) and into exposing other hidden struct fields will come as separate PRs.