### PR TITLE
Updated flatpak XML metadata to point to CHIRP repo

### DIFF
--- a/flathub/com.chirpmyradio.chirp.metainfo.xml
+++ b/flathub/com.chirpmyradio.chirp.metainfo.xml
@@ -4,7 +4,7 @@
   <name>CHIRP</name>
   <summary>A free, open-source tool for programming your radio.</summary>
 
-  <metadata_license>GPL-3.0-only</metadata_license>
+  <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-only</project_license>
 
   <description>

--- a/flathub/com.chirpmyradio.chirp.metainfo.xml
+++ b/flathub/com.chirpmyradio.chirp.metainfo.xml
@@ -19,10 +19,10 @@
   <launchable type="desktop-id">com.chirpmyradio.chirp.desktop</launchable>
   <screenshots>
     <screenshot type="default">
-      <image>https://raw.githubusercontent.com/PolyCatDev/flathub/refs/heads/com.chirpmyradio.chirp/screenshots/main.png</image>
+      <image>https://raw.githubusercontent.com/kk7ds/chirp/refs/heads/master/flathub/screenshots/main.png</image>
     </screenshot>
     <screenshot>
-      <image>https://raw.githubusercontent.com/PolyCatDev/flathub/refs/heads/com.chirpmyradio.chirp/screenshots/example.png</image>
+      <image>https://raw.githubusercontent.com/kk7ds/chirp/refs/heads/master/flathub/screenshots/example.png</image>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
I made the screenshot links from the flatpak XML metadata point to the chirp github repo and not my own.

I also changed the license of the XML metadata file to what flathub mandates.

This is a continuation of #1544.