### PR TITLE
Added chirp-wrapper.sh into flathub directory

### DIFF
--- a/flathub/chirp-wrapper.sh
+++ b/flathub/chirp-wrapper.sh
@@ -1,0 +1,2 @@
+#!/bin/env sh
+chirp --no-install-desktop-app


### PR DESCRIPTION
This is the entry point for the CHIRP flatpak and Flathub said that it must be upstreamed.

This is a continuation of #1546.