### PR TITLE
Bug 12454 - Fix 935/XS20 new channel creation

### DIFF
--- a/chirp/drivers/kg935g.py
+++ b/chirp/drivers/kg935g.py
@@ -1660,16 +1660,16 @@ class KG935GRadio(chirp_common.CloneModeRadio,
         _nam = self._memobj.names[number]
 
         if mem.empty:
-            _mem.set_raw("\x00" * (_mem.size() // 8))
+            _mem.fill_raw(b'\x00')
             self._memobj.valid[number] = 0
-            self._memobj.names[number].set_raw("\x00" * (_nam.size() // 8))
+            self._memobj.names[number].fill_raw(b'\x00')
             return
 
         # If it's a NEW channel, wipe it to all 0s first
         # This prevents "ghost" data from previous radio use or factory junk
         if was_empty:
-            _mem.set_raw("\x00" * (_mem.size() // 8))
-            _nam.set_raw("\x00" * (_nam.size() // 8))
+            _mem.fill_raw(b'\x00')
+            _nam.fill_raw(b'\x00')
 
         _mem.rxfreq = int(mem.freq / 10)
         if mem.duplex == "off":

--- a/chirp/drivers/kg935g.py
+++ b/chirp/drivers/kg935g.py
@@ -1694,7 +1694,7 @@ class KG935GRadio(chirp_common.CloneModeRadio,
         if mem.power is not None:
             _mem.power = self._set_power(mem)
         else:
-            _mem.power = True
+            _mem.power = 0  # default to Low power if not set
 
         for setting in mem.extra:
             setattr(_mem, setting.get_name(), setting.value)
@@ -2513,8 +2513,8 @@ class KGXS20G(KG935GRadio):
     _model = b"KG-UV8D-A"
     _record_start = 0x79
     config_map = config_map_x20h
-    POWER_LEVELS = [chirp_common.PowerLevel("L", watts=0.5),
-                    chirp_common.PowerLevel("H", watts=5.5)]
+    POWER_LEVELS = [chirp_common.PowerLevel("L", watts=5.0),
+                    chirp_common.PowerLevel("H", watts=20.0)]
     HAS_SCRAMBLER = False
     HAS_FAVORITE = False
 

--- a/chirp/drivers/kg935g.py
+++ b/chirp/drivers/kg935g.py
@@ -1653,6 +1653,9 @@ class KG935GRadio(chirp_common.CloneModeRadio,
     def set_memory(self, mem):
         number = mem.number
 
+        # Determine if we are moving from Empty -> Not Empty
+        was_empty = (self._memobj.valid[number] != MEM_VALID)
+
         _mem = self._memobj.memory[number]
         _nam = self._memobj.names[number]
 
@@ -1661,6 +1664,12 @@ class KG935GRadio(chirp_common.CloneModeRadio,
             self._memobj.valid[number] = 0
             self._memobj.names[number].set_raw("\x00" * (_nam.size() // 8))
             return
+
+        # If it's a NEW channel, wipe it to all 0s first
+        # This prevents "ghost" data from previous radio use or factory junk
+        if was_empty:
+            _mem.set_raw("\x00" * (_mem.size() // 8))
+            _nam.set_raw("\x00" * (_nam.size() // 8))
 
         _mem.rxfreq = int(mem.freq / 10)
         if mem.duplex == "off":


### PR DESCRIPTION
Fixes #12454
Clear factory bits on channel creation to prevent incorrect values. Fix power level wattage settings for XS20 series

# CHIRP PR Guidelines

The following must be true before PRs can be merged:

1. All tests must be passing. The "PR Checks" job is speculative and failure doesn't always indicate a critial problem, but generally it needs to pass as well.
1. Commits should be rebased (or simply rebase-able in the web UI) on current master. Do not put merge commits in a PR.
1. Commits in a single PR should be related. Squash intermediate commits into logical units (i.e. "fix tests" commits need not survive on their own). Keep cleanup commits separate from functional changes.
1. Major new features or bug fixes should reference a [CHIRP issue](https://chirpmyradio.com/projects/chirp/issues) _in the commit message_. Do this with the pattern `Fixes #1234` or `Related to #1234` so that the ticket system links the commit to the issue.
1. Please write a reasonable commit message, especially if making some change that isn't totally obvious (such as adding a new model, adding a feature, etc). The first line of every commit is emailed to the users' list after each build. It should be short, but meaningful for regular users (examples: "thd74: Fixed tone decoding" or "uv5r: Added settings support"). There should be a blank line after the first, followed by additional text so that it gets formatted properly for the mailing list.
1. New drivers should be accompanied by a test image in `tests/images` (except for thin aliases where the driver is sufficiently tested already). All new drivers must use `MemoryMapBytes`.
1. All files must be GPLv3 licensed or contain no license verbiage. No additional restrictions can be placed on the usage (i.e. such as noncommercial).
1. Do not add new py2-compatibility code (No new uses of `six`, `future`, etc).
