### PR TITLE
generic_csv: Accept power labels and fall back gracefully (#11959)

### DIFF
--- a/chirp/drivers/generic_csv.py
+++ b/chirp/drivers/generic_csv.py
@@ -23,6 +23,31 @@ from chirp import chirp_common, errors, directory
 LOG = logging.getLogger(__name__)
 DEFAULT_POWER_LEVEL = chirp_common.AutoNamedPowerLevel(50)
 
+# Handheld-typical wattages applied when a CSV's Power column contains a
+# label (e.g. "Low"/"High") instead of a numeric value. Without the source
+# radio's power table we can't know exact watts, so these are best-effort
+# defaults matching common HT (handheld transceiver) ranges.
+POWER_LABEL_DEFAULTS = {
+    'low':    ('Low', 1.0),
+    'high':   ('High', 5.0),
+    'med':    ('Med', 2.5),
+    'medium': ('Med', 2.5),
+    'mid':    ('Mid', 2.5),
+}
+
+
+def _interpret_power_label(value):
+    """If @value is a known power label (case-insensitive), return a
+    PowerLevel with HT-typical wattage. Otherwise return None."""
+    if not value:
+        return None
+    key = value.strip().lower()
+    spec = POWER_LABEL_DEFAULTS.get(key)
+    if spec is None:
+        return None
+    name, watts = spec
+    return chirp_common.PowerLevel(name, watts=watts)
+
 
 class OmittedHeaderError(Exception):
     """Internal exception to signal that a column has been omitted"""
@@ -188,6 +213,27 @@ class CSVRadio(chirp_common.FileBackedRadio):
             except OmittedHeaderError:
                 pass
             except Exception as e:
+                if attr == "power":
+                    # CHIRP exports PowerLevel labels (e.g. "Low"/"High")
+                    # that parse_power() can't decode without radio context.
+                    # Map common labels to HT-typical wattages; otherwise
+                    # fall back to the default rather than dropping the row.
+                    labelled = _interpret_power_label(val)
+                    if labelled is not None:
+                        if hasattr(mem, attr):
+                            setattr(mem, attr, labelled)
+                        LOG.info(
+                            "Power label %r mapped to %s (~%.1fW); "
+                            "actual radio wattage may differ",
+                            val, labelled,
+                            chirp_common.dBm_to_watts(float(labelled)))
+                        continue
+                    LOG.warning(
+                        "Power %r is not a wattage (e.g. '5W', '50') and "
+                        "not a recognized label (Low/Med/High); applying "
+                        "default (shown as %r in the Power column)",
+                        val, str(DEFAULT_POWER_LEVEL))
+                    continue
                 raise Exception("[%s] %s" % (attr, e))
 
         if not mem.power:

--- a/tests/unit/test_csv.py
+++ b/tests/unit/test_csv.py
@@ -159,9 +159,44 @@ class TestCSV(unittest.TestCase):
             f.write('0,146.520,L1\n')
             f.write('1,146.520,5W\n')
         csv = generic_csv.CSVRadio(self.testfn)
+        # Unparseable power labels fall back to the default power level
+        # rather than dropping the row entirely (issue 11959).
+        mem0 = csv.get_memory(0)
+        self.assertEqual(0, mem0.number)
+        self.assertEqual(146520000, mem0.freq)
+        self.assertEqual(generic_csv.DEFAULT_POWER_LEVEL, mem0.power)
         mem = csv.get_memory(1)
         self.assertEqual(1, mem.number)
         self.assertEqual(146520000, mem.freq)
+
+    def test_round_trip_label_power(self):
+        # CSVs exported from radios with "Low"/"High" PowerLevel labels
+        # must re-import without rejecting every row (issue 11959), and
+        # known labels should round-trip to a PowerLevel with HT-typical
+        # wattage rather than the generic default.
+        with open(self.testfn, 'w', encoding='utf-8') as f:
+            f.write('Location,Frequency,Power\n')
+            f.write('0,146.520,Low\n')
+            f.write('1,146.520,HIGH\n')
+            f.write('2,146.520,medium\n')
+        csv = generic_csv.CSVRadio(self.testfn)
+        self.assertEqual('Low', str(csv.get_memory(0).power))
+        self.assertEqual('High', str(csv.get_memory(1).power))
+        self.assertEqual('Med', str(csv.get_memory(2).power))
+        # Sanity-check the implied wattage (handheld-typical defaults).
+        self.assertLess(float(csv.get_memory(0).power),
+                        float(csv.get_memory(1).power))
+
+    def test_unrecognized_power_falls_back_to_default(self):
+        # An unparseable, unrecognized power value should not drop the row;
+        # the default power level is applied with a clear warning.
+        with open(self.testfn, 'w', encoding='utf-8') as f:
+            f.write('Location,Frequency,Power\n')
+            f.write('0,146.520,Bogus\n')
+        csv = generic_csv.CSVRadio(self.testfn)
+        self.assertEqual(146520000, csv.get_memory(0).freq)
+        self.assertEqual(generic_csv.DEFAULT_POWER_LEVEL,
+                         csv.get_memory(0).power)
 
     def test_foreign_power(self):
         csv = generic_csv.CSVRadio(None)


### PR DESCRIPTION
## Summary

- Fixes the CSV import failure described in [issue 11959](https://chirpmyradio.com/issues/11959): a CSV exported from a radio whose `PowerLevel` objects use labels like `Low`/`High` (rather than wattages) cannot be re-imported. `parse_power()` raises `ValueError` on each row, every row is dropped, and the importer surfaces the result as `InvalidDataError("No channels found")` — the file is rejected outright.
- In `chirp/drivers/generic_csv.py`, `_parse_csv_data_line` now special-cases the `Power` column: case-insensitive labels `low`/`med`/`medium`/`mid`/`high` are mapped to `PowerLevel` objects with handheld-typical wattages (1W / 2.5W / 5W). This is best-effort — without the source radio's power table we can't know exact watts — but it preserves the label and avoids dropping the row.
- Unknown values still fall back to `DEFAULT_POWER_LEVEL` (50W), but the warning is now self-explanatory: it names the expected formats *and* the literal text the user will see in the GUI's Power column, instead of a terse "using default" message.

## Before / After

### Error message

**Before** — terse `Invalid power specification: ''` with no guidance on what was expected or what CHIRP did:

![Before error](https://raw.githubusercontent.com/JWhiteUX/chirp/pr-images/assets/before-error.png)

**After** — names the accepted formats *and* the literal value the user will see in the GUI's Power column:

![After error](https://raw.githubusercontent.com/JWhiteUX/chirp/pr-images/assets/after-error.png)

### Import outcome

**Before** — every row rejected, import fails with `No channels found`:

![Before result](https://raw.githubusercontent.com/JWhiteUX/chirp/pr-images/assets/before-result.png)

**After** — rows import successfully with HT-typical wattage applied for known labels (`Low` here on a UV-5R):

![After result](https://raw.githubusercontent.com/JWhiteUX/chirp/pr-images/assets/after-result.png)

## Test plan

- [x] `pytest tests/unit/test_csv.py` — 23/23 pass.
- [x] Updated `test_parse_unknown_power` to assert non-numeric labels no longer drop the row (default applied).
- [x] New `test_round_trip_label_power` covers `Low` / `HIGH` / `medium` (case-insensitive) round-tripping to `Low` / `High` / `Med` PowerLevels.
- [x] New `test_unrecognized_power_falls_back_to_default` covers the truly bogus value path.
- [x] Manual: opened a UV-5R `.img`, exported to CSV, re-imported — rows now load with `Low (1W)` / `High (5W)` instead of being rejected (see screenshots above).

## Notes / out of scope

A fuller fix would round-trip the *exact* radio-specific wattage by embedding the source radio's `valid_power_levels` in the CSV (or matching labels against the destination driver's power table on import). That requires a CSV format change and is left for a follow-up. The mapping in this PR handles the common HT case and unblocks the reported bug.