### PR TITLE
h777v4: Fix detected models

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -1508,6 +1508,10 @@ class DetectableInterface:
         return extra + list(detected)
 
     @classmethod
+    def is_detected(cls):
+        return getattr(cls, '_DETECTED_BY', None) is not None
+
+    @classmethod
     def detect_model(cls, detected_cls):
         detected_attr = class_detected_models_attribute(cls)
         if getattr(cls, detected_attr, None) is None:

--- a/chirp/drivers/retevis_h777v4.py
+++ b/chirp/drivers/retevis_h777v4.py
@@ -185,7 +185,11 @@ def _write_block(radio, block_addr, block_size):
 def do_download(radio):
     LOG.debug("download")
 
-    h777._h777_enter_single_programming_mode(radio)
+    if not radio.is_detected() and not radio.detected_models():
+        # If we are a detect-ee or detect-or, don't re-initialize programming
+        # mode. But if we're one of the other subclasses of this work that
+        # would not have run through detection, we need to do so.
+        h777._h777_enter_single_programming_mode(radio)
 
     data = b""
 


### PR DESCRIPTION
A recent change to h777v4 re-added the enter-programming-mode step
to do_download() which is correct for non-detected subclasses but
not for those that did detect_from_serial() first.

Make the driver do this only if we're not a detect-or or detect-ee.
