### PR TITLE
baofeng_uv17Pro: add boot screen image upload for BF5RM / AR-5RM

### DIFF
--- a/chirp/drivers/baofeng_uv17Pro.py
+++ b/chirp/drivers/baofeng_uv17Pro.py
@@ -15,16 +15,25 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import logging
+import os
+import time
 
 from chirp.drivers import baofeng_common as bfc
 from chirp import chirp_common, directory, memmap, bandplan_na
 from chirp import bitwise
 from chirp.settings import RadioSetting, \
     RadioSettingValueBoolean, RadioSettingValueList, \
-    RadioSettingValueString, \
+    RadioSettingValueString, RadioSettingValueFile, \
     RadioSettings, RadioSettingGroup
 import struct
-from chirp import errors
+from chirp import checksum, errors
+
+try:
+    from PIL import Image as _PILImage
+    _PIL_AVAILABLE = True
+except ImportError:
+    _PILImage = None
+    _PIL_AVAILABLE = False
 
 LOG = logging.getLogger(__name__)
 
@@ -217,6 +226,329 @@ def _upload(radio):
             radio.status_fn(status)
     return data
 
+
+# Boot screen upload — BF5RM / AR-5RM family (160×128 color display)
+
+_BS_FRAME_HDR = 0xA5
+_BS_CMD_SHAKE = 0x02
+_BS_CMD_SETADDR = 0x03
+_BS_CMD_ERASE = 0x04
+_BS_CMD_WRITE = 0x57
+_BS_CMD_OVER = 0x06
+_BS_FLASH_ADDR = 0x0C0000
+_BS_ERASE_ID = 17668    # 0x4504
+_BS_WIDTH = 160
+_BS_HEIGHT = 128
+_BS_CHUNK = 1024
+
+
+def _bs_packet(cmd, pkg_id, payload):
+    """Build a framed boot-screen protocol packet."""
+    n = len(payload)
+    frame = bytearray(6 + n + 2)
+    frame[0] = _BS_FRAME_HDR
+    frame[1] = cmd
+    frame[2] = (pkg_id >> 8) & 0xFF
+    frame[3] = pkg_id & 0xFF
+    frame[4] = (n >> 8) & 0xFF
+    frame[5] = n & 0xFF
+    frame[6:6 + n] = payload
+    crc = checksum.crc16_xmodem(bytes(frame[1:6 + n]))
+    frame[6 + n] = (crc >> 8) & 0xFF
+    frame[6 + n + 1] = crc & 0xFF
+    return bytes(frame)
+
+
+def _bs_recv(pipe, timeout=5.0):
+    """Read one framed response; returns (cmd_byte, payload) or raises."""
+    deadline = time.time() + timeout
+    # Scan byte-by-byte for the frame header, then read exact field lengths.
+    pipe.timeout = 0.05
+    while time.time() < deadline:
+        b = pipe.read(1)
+        if not b or b[0] != _BS_FRAME_HDR:
+            continue
+        # Header found — read cmd(1) + pkg_id(2) + payload_len(2)
+        pipe.timeout = max(0.1, deadline - time.time())
+        hdr = pipe.read(5)
+        if len(hdr) < 5:
+            continue
+        n = (hdr[3] << 8) | hdr[4]
+        # Read payload (n bytes) + CRC (2 bytes)
+        body = pipe.read(n + 2)
+        if len(body) < n + 2:
+            continue
+        frame = bytes([_BS_FRAME_HDR]) + hdr + body
+        crc_rx = (body[n] << 8) | body[n + 1]
+        if crc_rx != checksum.crc16_xmodem(bytes(frame[1:6 + n])):
+            pipe.timeout = 0.05
+            continue
+        return hdr[0], bytes(body[:n])
+    raise errors.RadioError("Boot screen upload timed out waiting for radio")
+
+
+def _bs_expect(pipe, expected_cmd, label, timeout=5.0):
+    cmd, payload = _bs_recv(pipe, timeout=timeout)
+    if cmd != expected_cmd or not payload or payload[0] != 0x59:
+        raise errors.RadioError(
+            "Boot screen %s failed (cmd=0x%02x payload=%r)" %
+            (label, cmd, payload))
+
+
+def _bs_read_bmp(path):
+    """
+    Read any 24-bit BMP and return a list-of-rows of (r,g,b) tuples,
+    plus (width, height).  No external dependencies.
+    """
+    with open(path, 'rb') as f:
+        raw = f.read()
+    if raw[:2] != b'BM':
+        raise errors.RadioError("Boot screen: not a valid BMP file")
+    px_off = struct.unpack_from('<I', raw, 10)[0]
+    width = struct.unpack_from('<i', raw, 18)[0]
+    height = struct.unpack_from('<i', raw, 22)[0]
+    bpp = struct.unpack_from('<H', raw, 28)[0]
+    if bpp != 24:
+        raise errors.RadioError(
+            "Boot screen: unsupported format — BMP must be 24-bit RGB "
+            "(got %d-bit). Re-save as a 24-bit BMP." % bpp)
+    flip = height > 0
+    height = abs(height)
+    row_sz = (width * 3 + 3) & ~3
+    rows = []
+    for y in range(height):
+        row = []
+        off = px_off + y * row_sz
+        for x in range(width):
+            b = raw[off + x * 3]
+            g = raw[off + x * 3 + 1]
+            r = raw[off + x * 3 + 2]
+            row.append((r, g, b))
+        rows.append(row)
+    if flip:
+        rows.reverse()
+    return rows, width, height
+
+
+def _bs_scale_nn(rows, src_w, src_h, dst_w, dst_h):
+    """Nearest-neighbour scale a rows grid to (dst_w, dst_h)."""
+    out = []
+    for y in range(dst_h):
+        sy = y * src_h // dst_h
+        row = []
+        for x in range(dst_w):
+            sx = x * src_w // dst_w
+            row.append(rows[sy][sx])
+        out.append(row)
+    return out
+
+
+def _bs_rows_to_rgb565(rows):
+    """Convert a rows grid of (r,g,b) tuples to RGB565 LE bytes."""
+    buf = bytearray()
+    for row in rows:
+        for r, g, b in row:
+            px = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3)
+            buf.append(px & 0xFF)
+            buf.append((px >> 8) & 0xFF)
+    return bytes(buf)
+
+
+def _bs_image_to_rgb565(img_path):
+    """
+    Convert any image to RGB565 LE bytes sized for the radio boot screen
+    (_BS_WIDTH × _BS_HEIGHT).  Auto-scales if the source is a different size.
+    Reads 24-bit BMP natively; all other formats require Pillow.
+    Output is padded to a whole number of _BS_CHUNK-byte blocks.
+    """
+    ext = os.path.splitext(img_path)[1].lower()
+
+    if ext == '.bmp':
+        rows, w, h = _bs_read_bmp(img_path)
+        if w != _BS_WIDTH or h != _BS_HEIGHT:
+            LOG.info("Boot screen: scaling BMP from %dx%d to %dx%d",
+                     w, h, _BS_WIDTH, _BS_HEIGHT)
+            rows = _bs_scale_nn(rows, w, h, _BS_WIDTH, _BS_HEIGHT)
+        data = _bs_rows_to_rgb565(rows)
+    else:
+        if not _PIL_AVAILABLE:
+            raise errors.RadioError(
+                "Boot screen: unsupported format — only 24-bit BMP files "
+                "are supported. Convert the image to a 24-bit BMP and "
+                "try again.")
+        img = _PILImage.open(img_path).convert('RGB')
+        if img.width != _BS_WIDTH or img.height != _BS_HEIGHT:
+            LOG.info("Boot screen: scaling image from %dx%d to %dx%d",
+                     img.width, img.height, _BS_WIDTH, _BS_HEIGHT)
+            img = img.resize((_BS_WIDTH, _BS_HEIGHT), _PILImage.LANCZOS)
+        pixels = img.load()
+        # Pack each pixel as RGB565 little-endian:
+        # bits 15-11 = R (5 bits), 10-5 = G (6 bits), 4-0 = B (5 bits)
+        buf = bytearray(_BS_WIDTH * _BS_HEIGHT * 2)
+        for y in range(_BS_HEIGHT):
+            for x in range(_BS_WIDTH):
+                r, g, b = pixels[x, y]
+                px = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3)
+                i = (y * _BS_WIDTH + x) * 2
+                buf[i] = px & 0xFF        # low byte first (little-endian)
+                buf[i + 1] = (px >> 8) & 0xFF
+        data = bytes(buf)
+
+    rem = len(data) % _BS_CHUNK
+    if rem:
+        data += b'\xFF' * (_BS_CHUNK - rem)
+    return data
+
+
+def _bs_raw_handshake(pipe):
+    """
+    Send PROGRAMBFNORMALU, wait for 0x06, reply with 0x44.
+    Drains any bytes the radio sends after 0x44.
+    Returns True on success, False on timeout.
+    """
+    pipe.reset_input_buffer()
+    pipe.write(b"PROGRAMBFNORMALU")
+    pipe.timeout = 0.1
+    deadline = time.time() + 2.0
+    while time.time() < deadline:
+        b = pipe.read(1)
+        if b and b[0] == 0x06:
+            pipe.write(b'\x44')
+            # Drain any bytes the radio sends in response to 0x44
+            # (some firmware variants may echo model bytes here)
+            pipe.timeout = 0.05
+            drain_end = time.time() + 0.5
+            drain = bytearray()
+            while time.time() < drain_end:
+                rx = pipe.read(64)
+                if rx:
+                    drain.extend(rx)
+                    drain_end = time.time() + 0.05
+            if drain:
+                LOG.debug("Boot screen: radio replied to 0x44: %s",
+                          drain.hex())
+            return True
+    return False
+
+
+def _upload_boot_screen(radio, img_data):
+    """
+    Upload pre-converted RGB565 image data to the radio using the dedicated
+    picture protocol.  Called from BF5RM.sync_out() before the normal channel
+    upload.  Uses the already-open radio.pipe serial port.
+    """
+    total = len(img_data) // _BS_CHUNK
+    pipe = radio.pipe
+    pipe.dtr = True
+    pipe.rts = True
+
+    status = chirp_common.Status()
+    status.max = total + 5   # handshake + erase + setaddr + chunks + over
+    status.cur = 0
+    status.msg = "Boot screen: connecting..."
+    radio.status_fn(status)
+
+    # 1. Raw handshake: "PROGRAMBFNORMALU" → 0x06 → 0x44 ('D')
+    for attempt in range(5):
+        if _bs_raw_handshake(pipe):
+            break
+        LOG.debug("Boot screen raw handshake retry %d", attempt + 1)
+        time.sleep(0.5)
+    else:
+        raise errors.RadioError(
+            "Boot screen: radio not responding — check cable and port")
+
+    status.cur = 1
+    status.msg = "Boot screen: handshake OK"
+    radio.status_fn(status)
+
+    # 2. PROGRAM framed handshake — retry up to 5 times.
+    # The radio may need up to ~5 seconds to enter picture mode after 0x44.
+    handshake_pkt = _bs_packet(_BS_CMD_SHAKE, 0, b"PROGRAM")
+    pipe.reset_input_buffer()
+    hs_ok = False
+    for hs_attempt in range(5):
+        pipe.write(handshake_pkt)
+        try:
+            _bs_expect(pipe, _BS_CMD_SHAKE, "HANDSHAKE", timeout=1.5)
+            hs_ok = True
+            break
+        except errors.RadioError:
+            LOG.debug("Boot screen HANDSHAKE no response (attempt %d/5)",
+                      hs_attempt + 1)
+            pipe.reset_input_buffer()
+    if not hs_ok:
+        # Last resort: redo the raw handshake entirely and retry once more
+        LOG.debug("Boot screen: retrying full handshake sequence")
+        if _bs_raw_handshake(pipe):
+            pipe.reset_input_buffer()
+            for hs_attempt in range(5):
+                pipe.write(handshake_pkt)
+                try:
+                    _bs_expect(pipe, _BS_CMD_SHAKE, "HANDSHAKE", timeout=1.5)
+                    hs_ok = True
+                    break
+                except errors.RadioError:
+                    LOG.debug("Boot screen HANDSHAKE retry2 attempt %d/5",
+                              hs_attempt + 1)
+                    pipe.reset_input_buffer()
+    if not hs_ok:
+        raise errors.RadioError(
+            "Boot screen upload timed out waiting for radio")
+    status.cur = 2
+    radio.status_fn(status)
+
+    # 3. Erase flash at boot-screen address
+    status.msg = "Boot screen: erasing flash..."
+    radio.status_fn(status)
+    ep = bytearray(6)
+    ep[0] = _BS_FLASH_ADDR & 0xFF
+    ep[1] = (_BS_FLASH_ADDR >> 8) & 0xFF
+    ep[2] = (_BS_FLASH_ADDR >> 16) & 0xFF
+    ep[3] = (_BS_FLASH_ADDR >> 24) & 0xFF
+    ep[4] = 0    # 1 block, MSB
+    ep[5] = 1    # 1 block, LSB
+    pipe.write(_bs_packet(_BS_CMD_ERASE, _BS_ERASE_ID, bytes(ep)))
+    _bs_expect(pipe, _BS_CMD_ERASE, "ERASE", timeout=15.0)
+    status.cur = 3
+    radio.status_fn(status)
+
+    # 4. Set flash write address
+    ap = bytearray(4)
+    ap[0] = _BS_FLASH_ADDR & 0xFF
+    ap[1] = (_BS_FLASH_ADDR >> 8) & 0xFF
+    ap[2] = (_BS_FLASH_ADDR >> 16) & 0xFF
+    ap[3] = (_BS_FLASH_ADDR >> 24) & 0xFF
+    pipe.write(_bs_packet(_BS_CMD_SETADDR, 0, bytes(ap)))
+    _bs_expect(pipe, _BS_CMD_SETADDR, "SET_ADDRESS", timeout=3.0)
+    status.cur = 4
+    radio.status_fn(status)
+
+    # 5. Write image in 1024-byte chunks
+    for pkg_id in range(total):
+        chunk = img_data[pkg_id * _BS_CHUNK:(pkg_id + 1) * _BS_CHUNK]
+        pipe.write(_bs_packet(_BS_CMD_WRITE, pkg_id, chunk))
+        _bs_expect(pipe, _BS_CMD_WRITE, "WRITE chunk %d" % pkg_id, timeout=5.0)
+        status.cur = 5 + pkg_id
+        pct = (pkg_id + 1) * 100 // total
+        status.msg = "Boot screen: writing %d%%" % pct
+        radio.status_fn(status)
+
+    # 6. Signal done
+    pipe.write(_bs_packet(_BS_CMD_OVER, 0, b"Over"))
+    time.sleep(0.5)   # let radio finish before the next serial session
+
+    # Drain any trailing bytes
+    pipe.timeout = 0.1
+    pipe.read(256)
+
+    status.cur = status.max
+    status.msg = "Boot screen uploaded successfully"
+    radio.status_fn(status)
+    LOG.info("Boot screen upload complete (%d bytes)", len(img_data))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 
 @directory.register
 class UV17Pro(bfc.BaofengCommonHT):
@@ -1729,6 +2061,71 @@ class BF5RM(UV17Pro):
     _has_workmode_support = True
     MODES = UV17Pro.MODES + ['AM']
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._boot_image_path = ""
+        self._boot_image_data = None  # RGB565 bytes; set by set_settings()
+
+    def get_settings(self):
+        settings = super().get_settings()
+
+        boot = RadioSettingGroup("boot_screen", "Boot Screen")
+
+        if _PIL_AVAILABLE:
+            wildcard = ("Image files (*.bmp;*.png;*.jpg;*.jpeg)"
+                        "|*.bmp;*.png;*.jpg;*.jpeg"
+                        "|BMP files (*.bmp)|*.bmp"
+                        "|All files (*.*)|*.*")
+            label = ("Boot screen image — auto-scaled to 160\u00d7128"
+                     " on upload (.bmp, .png, .jpg)")
+        else:
+            wildcard = "BMP files (*.bmp)|*.bmp|All files (*.*)|*.*"
+            label = ("Boot screen image — auto-scaled to 160\u00d7128"
+                     " on upload (.bmp only)")
+
+        val = RadioSettingValueFile(
+            current=self._boot_image_path,
+            wildcard=wildcard)
+        rs = RadioSetting("boot_screen_image", label, val)
+
+        def _apply_boot_image(setting, obj):
+            path = str(setting.value).strip()
+            self._boot_image_path = path
+            if path:
+                if not os.path.isfile(path):
+                    raise errors.RadioError(
+                        "Boot screen image not found: %s" % path)
+                # Convert here so bad files are caught before upload starts
+                self._boot_image_data = _bs_image_to_rgb565(path)
+            else:
+                self._boot_image_data = None
+
+        rs.set_apply_callback(_apply_boot_image, None)
+        boot.append(rs)
+        settings.append(boot)
+        return settings
+
+    def sync_out(self):
+        if self._boot_image_data:
+            try:
+                _upload_boot_screen(self, self._boot_image_data)
+                # Brief pause before the normal programming session starts
+                time.sleep(1.5)
+            except errors.RadioError:
+                raise
+            except Exception as e:
+                raise errors.RadioError(
+                    "Boot screen upload failed: %s" % e)
+            finally:
+                # Always drain the serial buffer so stale bytes don't corrupt
+                # the channel-programming session that follows.
+                try:
+                    self.pipe.timeout = 0.1
+                    self.pipe.reset_input_buffer()
+                except Exception:
+                    pass
+        super().sync_out()
+
 
 @directory.register
 class MaxTalkerP15(BF5RM):
@@ -1760,6 +2157,8 @@ class BaofengUV5RMPlus(BF5RM):
     _has_pilot_tone = True
     _has_send_id_delay = True
     _has_scramble = True
+    _has_gps = True
+    _has_voxsw = True
 
 
 @directory.register

--- a/chirp/settings.py
+++ b/chirp/settings.py
@@ -338,6 +338,25 @@ class RadioSettingValueString(RadioSettingValue):
         return self._current[i]
 
 
+class RadioSettingValueFile(RadioSettingValueString):
+    """A file-path setting — renders as a text field with a Browse button."""
+
+    def __init__(self, current="",
+                 wildcard="All files (*.*)|*.*"):
+        super().__init__(0, 512, current, autopad=False)
+        self._wildcard = wildcard
+
+    @property
+    def wildcard(self):
+        return self._wildcard
+
+    def set_value(self, value):
+        value = value.strip()
+        if len(value) > 512:
+            raise InvalidValueError("Path too long (max 512 chars)")
+        RadioSettingValue.set_value(self, value)
+
+
 class RadioSettingValueMap(RadioSettingValueList):
 
     """Map User Options to Radio Memory Values

--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -451,6 +451,8 @@ class ChirpSettingGrid(wx.Panel):
                     editor = self._get_editor_choice(element, value)
                 elif isinstance(value, settings.RadioSettingValueBoolean):
                     editor = self._get_editor_bool(element, value)
+                elif isinstance(value, settings.RadioSettingValueFile):
+                    editor = self._get_editor_file(element, value)
                 elif isinstance(value, settings.RadioSettingValueString):
                     editor = self._get_editor_str(element, value)
                 else:
@@ -577,6 +579,16 @@ class ChirpSettingGrid(wx.Panel):
                                         bool(value))
         prop.SetAttribute(wx.propgrid.PG_BOOL_USE_CHECKBOX, True)
         return prop
+
+    def _get_editor_file(self, setting, value):
+        e = wx.propgrid.FileProperty(setting.get_shortname(),
+                                     setting.get_name())
+        e.SetAttribute(wx.propgrid.PG_FILE_WILDCARD, value.wildcard)
+        e.SetAttribute(wx.propgrid.PG_FILE_SHOW_FULL_PATH, True)
+        current = str(value).strip()
+        if current:
+            e.SetValue(current)
+        return e
 
     def _get_editor_str(self, setting, value):
         class ChirpStrProperty(wx.propgrid.StringProperty):

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ pywin32; platform_system=="Windows"
 suds
 yattag
 lark
+Pillow


### PR DESCRIPTION
Continuation of #1559 (accidentally closed).

## What this does

Adds a **Boot Screen** settings group to the `BF5RM` driver (Baofeng 5RM / AR-5RM) so users can upload a custom 160×128 boot image directly from CHIRP without needing a separate tool.

A single **Upload to Radio** click uploads the boot image first, then proceeds with normal channel programming.

## Protocol

- 115200 baud 8N1, DTR+RTS asserted
- Raw handshake: `PROGRAMBFNORMALU` → `0x06` → `0x44`
- Framed packets: `[0xA5][cmd][id_hi][id_lo][len_hi][len_lo][payload…][crc_hi][crc_lo]`  
  CRC-16/CCITT (poly 0x1021) over bytes 1…(5+len)
- Sequence: `HANDSHAKE(0x02)` → `ERASE(0x04)` → `SET_ADDRESS(0x03)` → `WRITE(0x57)`×40 → `OVER(0x06)`
- Flash base `0x0C0000`, erase package ID 17668, 40 × 1024-byte chunks
- HANDSHAKE is retried up to 5× to allow for firmware startup time after mode switch

## Image handling

- **BMP**: parsed natively, no extra dependencies
- **PNG / JPEG**: auto-scaled via Pillow; PIL added to `requirements.txt`
- Nearest-neighbour scaling to 160×128, RGB565 little-endian encoding

## UI changes

- Adds `RadioSettingValueFile` to `chirp/settings.py` — a `RadioSettingValueString` subclass that carries a wildcard filter string
- `ChirpSettingGrid._add_items()` in `chirp/wxui/common.py` detects `RadioSettingValueFile` and renders a `wx.propgrid.FileProperty` (native Browse button) instead of a plain text field

## Test plan

- [ ] Upload boot screen image (BMP, PNG, JPEG) on AR-5RM / Baofeng 5RM
- [ ] Verify normal channel upload still works after boot screen upload
- [ ] Verify graceful error if image file is missing or path is blank
- [ ] Verify other BF5RM subclasses (MaxTalker P15, K5-Plus) unaffected
- [ ] Verify no regression in settings grid for other radios using `RadioSettingValueString`