### PR TITLE
tdh8 - Fixes 12466: TD-H3, H8 Gen 2 and H8 Gen 3 Adds VFO A&B Offset Direction. Also fixes VFO A&B BCL setting persistence

### DIFF
--- a/chirp/drivers/tdh8.py
+++ b/chirp/drivers/tdh8.py
@@ -106,8 +106,10 @@ struct {
 } settings;
 
 //#seekto 0x0CB8;
-lbcd offseta[4];
-lbcd offsetb[4];
+struct{
+    lbcd a[4];
+    lbcd b[4];
+}vfo_offset;
 
 #seekto 0x0CD8;
 struct{
@@ -148,7 +150,7 @@ struct {
      lowpower:2,
      wide:1,
      unused8:1,
-     offset:2;
+     dira:2;
   u8 unused10;
 } vfoa;
 
@@ -171,7 +173,7 @@ struct {
      lowpowerb:2,
      wideb:1,
      unused8:1,
-     offsetb:2;
+     dirb:2;
   u8 unused10;
 } vfob;
 
@@ -365,8 +367,10 @@ struct {
 } settings;
 
 //#seekto 0x0CB8;
-lbcd offseta[4];
-lbcd offsetb[4];
+struct{
+  lbcd a[4];
+  lbcd b[4];
+}vfo_offset;
 
 #seekto 0x0CD8;
 struct{
@@ -472,7 +476,7 @@ struct {
      lowpower:2,
      wide:1,
      unused8:1,
-     offset:2;
+     dira:2;
   u8 unused10;
 } vfoa;
 
@@ -495,7 +499,7 @@ struct {
      lowpowerb:2,
      wideb:1,
      unused8:1,
-     offsetb:2;
+     dirb:2;
   u8 unused10;
 } vfob;
 
@@ -589,8 +593,10 @@ struct {
 } settings;
 
 //#seekto 0x0CB8;
-lbcd offseta[4];
-lbcd offsetb[4];
+struct {
+lbcd a[4];
+lbcd b[4];
+}vfo_offset;
 
 #seekto 0x0CD8;
 struct{
@@ -638,7 +644,7 @@ struct {
      lowpower:2,
      wide:1,
      unused8:1,
-     offset:2;
+     dira:2;
   u8 unused9;
 } vfoa;
 
@@ -661,7 +667,7 @@ struct {
      lowpowerb:2,
      wideb:1,
      unused8:1,
-     offsetb:2;
+     dirb:2;
   u8 unused9;
 } vfob;
 
@@ -704,7 +710,9 @@ VFOA_NAME = ["rxfreqa",
              "bcl",
              "lowpower",
              "wide",
-             "offset"]
+             "a",
+             "dira",
+             ]
 
 VFOB_NAME = ["rxfreqb",
              "txfreq",
@@ -715,7 +723,9 @@ VFOB_NAME = ["rxfreqb",
              "bclb",
              "lowpowerb",
              "wideb",
-             "offsetb"]
+             "b",
+             "dirb",
+             ]
 
 TOT_LIST = ["Off", "30S", "60S", "90S", "120S", "150S", "180S", "210S"]
 ALARM_LIST = ["On site", "Alarm"]
@@ -1757,27 +1767,70 @@ class TDH8(chirp_common.CloneModeRadio):
             # If the offset is 12.345
             # Then the data obtained is [0x45, 0x23, 0x01, 0x00]
             offsets = {}
+            dirs = {}
+
+            def _calc_txfreq(rxfreq, offset, dir):
+                # calc tx freq
+                txfreq = 0
+                match dir:
+                    case 0:  # off
+                        txfreq = rxfreq
+                    case 1:  # minus
+                        txfreq = \
+                            (int(rxfreq) /
+                                100000 - int(offset) / 100000) * 100000
+                    case 2:  # plus
+                        txfreq = \
+                            (int(rxfreq) /
+                                100000 + int(offset) / 100000) * 100000
+                return int(txfreq)
+
+            def _apply_offset_dir(setting, i, obj1, obj2):
+                value = getattr(obj1, setting.get_name())
+                value.set_value(setting.value)
+                # calc tx freq and store
+                obj1.txfreq = _calc_txfreq(
+                    getattr(obj1, "rxfreq%s" % i),
+                    obj2,
+                    getattr(obj1, "dir%s" % i)
+                )
+
             for i in ('a', 'b'):
-                value = getattr(self._memobj, 'offset%s' % i)
+                value = getattr(self._memobj.vfo_offset, '%s' % i)
                 if value.get_raw() == b'\xff\xff\xff\xff':
                     offset = 0
                 else:
                     offset = int(value) / 100000
 
                 def _apply(setting):
-                    value = getattr(self._memobj, setting.get_name())
+                    value = getattr(self._memobj.vfo_offset,
+                                    setting.get_name())
                     if float(setting.value) == 0:
                         value.fill_raw(b'\xff')
                     else:
                         value.set_value(int(setting.value * 100000))
 
-                rs = RadioSetting("offset%s" % i,
+                rs = RadioSetting("%s" % i,
                                   "%s Offset Frequency" % i.upper(),
                                   RadioSettingValueFloat(
                                       0.00000, 59.99750, offset, 0.00001, 5))
                 rs.set_apply_callback(_apply)
                 offsets[i] = rs
+                _obj1 = self._memobj.vfoa if i == \
+                    'a' else self._memobj.vfob
+                _obj2 = self._memobj.vfo_offset.a if i == 'a' \
+                    else self._memobj.vfo_offset.b
+                _obj3 = self._memobj.vfoa.dira if i == 'a' \
+                    else self._memobj.vfob.dirb
+                rs = RadioSetting("dir%s" % i,
+                                  "%s Offset Direction" % i.upper(),
+                                  RadioSettingValueList(A_OFFSET,
+                                                        current_index=_obj3))
+                rs.set_apply_callback(_apply_offset_dir, i, _obj1, _obj2)
+                dirs[i] = rs
+
             abblock.append(offsets['a'])
+            abblock.append(dirs['a'])
 
             try:
                 self._tx_power[_vfoa.lowpower]
@@ -1821,6 +1874,7 @@ class TDH8(chirp_common.CloneModeRadio):
             abblock.append(rs)
 
             abblock.append(offsets['b'])
+            abblock.append(dirs['b'])
 
             try:
                 self._tx_power[_vfob.lowpowerb]
@@ -2214,7 +2268,7 @@ class TDH8(chirp_common.CloneModeRadio):
                         _settings.brightness = 4 - int(element.value)
                     elif "sync" == name:
                         _settings.sync = not int(element.value)
-                    # Channel A
+                    # Channel A RX freq
                     elif "rxfreqa" == setting and element.value.get_mutable():
                         val = int(str(element.value).replace(
                             '.', '').ljust(8, '0'))

--- a/chirp/drivers/tdh8.py
+++ b/chirp/drivers/tdh8.py
@@ -761,14 +761,9 @@ PTTID_VALUES = ["Off", "BOT", "EOT", "BOTH"]
 BCLOCK_VALUES = ["Off", "On"]
 FREQHOP_VALUES = ["Off", "On"]
 
-# AB CHANNEL
-A_OFFSET = ["Off", "-", "+"]
-A_BAND = ["Wide", "Narrow"]
-A_WORKMODE = ["VFO", "VFO+CH", "CH Mode"]
-
-B_OFFSET = ["Off", "-", "+"]
-B_BAND = ["Wide", "Narrow"]
-B_WORKMODE = ["VFO", "VFO+CH", "CH Mode"]
+# AB VFO CHANNEL
+OFFSET_DIR = ["Off", "-", "+"]
+VFO_WORKMODE = ["VFO", "VFO+CH", "CH Mode"]
 
 # FM
 FM_WORKMODE = ["VFO", "CH"]
@@ -1824,7 +1819,7 @@ class TDH8(chirp_common.CloneModeRadio):
                     else self._memobj.vfob.dirb
                 rs = RadioSetting("dir%s" % i,
                                   "%s Offset Direction" % i.upper(),
-                                  RadioSettingValueList(A_OFFSET,
+                                  RadioSettingValueList(OFFSET_DIR,
                                                         current_index=_obj3))
                 rs.set_apply_callback(_apply_offset_dir, i, _obj1, _obj2)
                 dirs[i] = rs
@@ -1845,11 +1840,11 @@ class TDH8(chirp_common.CloneModeRadio):
 
             rs = RadioSetting("wide", "A Band",
                               RadioSettingValueList(
-                                  A_BAND, current_index=_vfoa.wide))
+                                  BANDWIDTH_LIST, current_index=_vfoa.wide))
             abblock.append(rs)
 
             rs = RadioSetting("bcl", "A Busy Lock",
-                              RadioSettingValueBoolean(_settings.ablock))
+                              RadioSettingValueBoolean(_vfoa.bcl))
             abblock.append(rs)
 
             rs = RadioSetting("specialqta", "A Special QT/DQT",
@@ -1859,7 +1854,7 @@ class TDH8(chirp_common.CloneModeRadio):
             rs = RadioSetting(
                 "aworkmode", "A Work Mode",
                 RadioSettingValueList(
-                    A_WORKMODE, current_index=_settings.aworkmode))
+                    VFO_WORKMODE, current_index=_settings.aworkmode))
             abblock.append(rs)
 
             # B channel
@@ -1889,11 +1884,11 @@ class TDH8(chirp_common.CloneModeRadio):
 
             rs = RadioSetting("wideb", "B Band",
                               RadioSettingValueList(
-                                  B_BAND, current_index=_vfob.wideb))
+                                  BANDWIDTH_LIST, current_index=_vfob.wideb))
             abblock.append(rs)
 
             rs = RadioSetting("bclb", "B Busy Lock",
-                              RadioSettingValueBoolean(_settings.bblock))
+                              RadioSettingValueBoolean(_vfob.bclb))
             abblock.append(rs)
 
             rs = RadioSetting("specialqtb", "B Special QT/DQT",
@@ -1903,7 +1898,7 @@ class TDH8(chirp_common.CloneModeRadio):
             rs = RadioSetting(
                 "bworkmode", "B Work Mode",
                 RadioSettingValueList(
-                    B_WORKMODE, current_index=_settings.bworkmode))
+                    VFO_WORKMODE, current_index=_settings.bworkmode))
             abblock.append(rs)
 
         group.append(fmmode)


### PR DESCRIPTION
tdh8 - Fixes 12466: TD-H3, H8 Gen 2 and H8 Gen 3 Adds VFO A&B Offset Direction. Also fixes VFO A&B BCL setting persistence.

This fixes two **long-standing** bugs in the TD-H3, TD-H8 Gen 2 and TD-H8 Gen 3 drivers:

0) VFO A and B Offsets and TX Frequencies were completely broken. The radio firmware expects a VFO A or B to have a TX Frequency in a certain memory location. The driver did not have a setting for the Offset direction value (+, - or Off). The direction is need to calculate the TX Frequency from the RX Frequency, the Offset value and the Offset Direction. The first commit address this problem. The driver was never even calculating or storing a TX Frequency at all. This fix required refactoring some of the memory variable names to eliminate duplicates names.

1) The VFO A and B settings had a setting for BCL (Busy Lock) that did not work properly as the setting was getting the value from the wrong place in memory. Naturally, this was causing the BCL value to appear to not persist between radio downloads/uploads as  the value was being written to the correct place, but being read from the wrong place. This bug was found in testing the bug reported in Issue 12466 by the reporting user.

2) Removed some duplicate redundant settings value lists and refactored the settings code to clean it up some.

User testing and results here:

https://chirpmyradio.com/issues/12466

It's **way-about-time** for this driver to get a total rewrite as it is very hard to maintain in its current state!