### PR TITLE
chirpc: Set builtins._ before importing drivers

### DIFF
--- a/chirp/cli/main.py
+++ b/chirp/cli/main.py
@@ -24,6 +24,8 @@ import logging
 from chirp import logger
 from chirp import chirp_common, errors, directory, util
 
+sys.modules['builtins']._ = lambda x: x  # type: ignore[attr-defined]
+
 directory.import_drivers()
 
 LOG = logging.getLogger("chirpc")


### PR DESCRIPTION
## Summary

Several drivers (e.g. `ft4.py`) call `_()` for gettext translations at module level. The CLI never initialised `builtins._`, so importing these drivers via `directory.import_drivers()` raised `NameError` and made chirpc unusable with any ft4-family radio (FT-4X, FT-65R, etc.).

Fix: set `builtins._ = lambda x: x` before the driver import.

## Steps to reproduce

```bash
python -m chirp.cli.main --radio Yaesu_FT-65R \
  --serial /dev/ttyUSB0 --mmap ft65.img --download-mmap
# NameError: name '_' is not defined
```

## Test plan

- [ ] Run `python -m chirp.cli.main --radio Yaesu_FT-65R --serial <port> --mmap out.img --download-mmap` with radio in clone mode — should complete without NameError
- [ ] Verify other ft4-family models (FT-4X, FT-65E) import cleanly