### PR TITLE
chirpc: Fix exit code on successful --download-mmap and --upload-mmap

### DIFF
--- a/chirp/cli/main.py
+++ b/chirp/cli/main.py
@@ -379,9 +379,11 @@ def main(args=None):
         try:
             radio.sync_in()
             radio.save_mmap(options.mmap)
+            LOG.info("Download successful: %s", options.mmap)
+            sys.exit(0)
         except Exception as e:
             LOG.exception(e)
-        sys.exit(1)
+            sys.exit(1)
 
     if options.upload_mmap:
         if not issubclass(rclass, chirp_common.CloneModeRadio):
@@ -394,9 +396,10 @@ def main(args=None):
             radio.load_mmap(options.mmap)
             radio.sync_out()
             print("Upload successful")
+            sys.exit(0)
         except Exception as e:
             LOG.exception(e)
-        sys.exit(1)
+            sys.exit(1)
 
     if options.mmap and isinstance(radio, chirp_common.CloneModeRadio):
         radio.save_mmap(options.mmap)


### PR DESCRIPTION
## Summary

`sys.exit(1)` was called unconditionally after the try/except block in both the `--download-mmap` and `--upload-mmap` paths, returning failure even when the operation succeeded. Any script checking the exit code would treat a successful clone as an error.

Fix: move `sys.exit(1)` inside the `except` block and add `sys.exit(0)` on success.

## Steps to reproduce

```bash
python -m chirp.cli.main --radio Yaesu_FT-65R \
  --serial /dev/ttyUSB0 --mmap ft65.img --download-mmap
echo $?   # prints 1 even on success
```

## Test plan

- [ ] Successful `--download-mmap` exits with code 0
- [ ] Successful `--upload-mmap` exits with code 0
- [ ] Failed download/upload (e.g. wrong port) still exits with code 1