### PR TITLE
 baofeng_uv17Pro: Fixes #12251. Allow UV-5R Mini, Mini 5 and UV-5G Mini to upload to radio over a BLE serial connection

### DIFF
--- a/chirp/drivers/baofeng_uv17Pro.py
+++ b/chirp/drivers/baofeng_uv17Pro.py
@@ -19,6 +19,7 @@ import logging
 from chirp.drivers import baofeng_common as bfc
 from chirp import chirp_common, directory, memmap, bandplan_na
 from chirp import bitwise
+from chirp import platform
 from chirp.settings import RadioSetting, \
     RadioSettingValueBoolean, RadioSettingValueList, \
     RadioSettingValueString, \
@@ -158,7 +159,7 @@ def _download(radio):
                           radio.BLOCK_SIZE):
             frame = radio._make_read_frame(addr, radio.BLOCK_SIZE)
 
-            radio.pipe.log('Sending request for %04x' % addr)
+            radio.pipe.log('Sending request for 0x%04x' % addr)
             bfc._rawsend(radio, frame)
 
             d = bfc._rawrecv(radio, radio.BLOCK_SIZE + 4)
@@ -173,7 +174,6 @@ def _download(radio):
 
             # UI Update
             status.cur = len(data) // radio.BLOCK_SIZE
-            status.msg = "Cloning from radio..."
             radio.status_fn(status)
     return data
 
@@ -494,7 +494,7 @@ class UV17Pro(bfc.BaofengCommonHT):
 
     def _make_frame(self, cmd, addr, length, data=""):
         """Pack the info in the header format"""
-        frame = cmd + struct.pack(">i", addr)[2:] + struct.pack("b", length)
+        frame = cmd + struct.pack(">i", addr)[2:] + struct.pack("B", length)
         # add the data if set
         if len(data) != 0:
             frame += data
@@ -2358,7 +2358,10 @@ class UV5RMini(UV17Pro):
 
     MEM_TOTAL = 0x8240
 
+    _is_on_ble = False
+
     _has_support_for_banknames = False
+    _has_bt = True  # allow BT setting
 
     _idents = [MSTRING_UV17PROGPS]
     _mem_size = MEM_TOTAL
@@ -2384,6 +2387,81 @@ class UV5RMini(UV17Pro):
                    _uhf_range,
                    _uhf_rx2_range]
     MODES = UV17Pro.MODES + ['AM']
+
+    BLE_UP_BLOCK_SIZE = 0x80  # uploading to radio over BLE uses 0x80 blocksize
+
+    def sync_in(self):
+        self._is_on_ble = platform.get_platform().is_ble_serial(self.pipe)
+        LOG.debug('Detected BLE: %s' % self._is_on_ble)
+        return super().sync_in()
+
+    def sync_out(self):
+        self._is_on_ble = platform.get_platform().is_ble_serial(self.pipe)
+        LOG.debug('Detected BLE: %s' % self._is_on_ble)
+        return super().sync_out()
+
+    def _upload(radio):
+        """Upload to UV5R Mini (over BLE or USB/Serial)"""
+        # Put radio in program mode and identify it and
+        # determine if on BLE or USB/Serial connection
+        _do_ident(radio)
+
+        if radio._is_on_ble:  # BLE upload needs a diff blocksize
+            _blocksize = radio.BLE_UP_BLOCK_SIZE
+        else:
+            _blocksize = radio.BLOCK_SIZE
+
+        data = b""
+
+        # UI progress
+        status = chirp_common.Status()
+        status.cur = 0
+        status.max = radio.MEM_TOTAL // _blocksize
+        status.msg = "Cloning to radio on %s/Serial..." % \
+            ('BLE' if radio._is_on_ble else 'USB')
+        radio.status_fn(status)
+
+        data_addr = 0x00
+        radio_mem = radio.get_mmap()
+        radio.pipe.log('Uploading to radio using block size of 0x%04x'
+                       % _blocksize)
+        for i in range(len(radio.MEM_SIZES)):
+            MEM_SIZE = radio.MEM_SIZES[i]
+            MEM_START = radio.MEM_STARTS[i]
+            for addr in range(MEM_START, MEM_START + MEM_SIZE,
+                              _blocksize):
+                # calc min byte count to keep from reading too many bytes
+                byte_count = min(_blocksize, (MEM_START + MEM_SIZE) - addr)
+                data = radio_mem[data_addr:data_addr + byte_count]
+
+                if byte_count < _blocksize:  # does block need padding?
+                    radio.pipe.log('Padding partial block with \xff '
+                                   'by 0x%02x bytes' %
+                                   (_blocksize - len(data)))
+                    # pad partial block with \xff
+                    data += (b'\xff' * (_blocksize - len(data)))
+
+                if radio._uses_encr:
+                    data = _crypt(radio._encrsym, data)
+
+                data_addr += byte_count  # advance read pointer
+
+                frame = radio._make_frame(b"W", addr, _blocksize, data)
+                radio.pipe.log('Sending address %04x' % addr)
+                bfc._rawsend(radio, frame)
+
+                ack = bfc._rawrecv(radio, 1)
+                if ack != b"\x06":
+                    msg = "Bad ack writing block %04x" % addr
+                    raise errors.RadioError(msg)
+
+                # UI Update
+                status.cur = data_addr // _blocksize
+                radio.status_fn(status)
+
+        return data
+
+    upload_function = _upload
 
     _end_fmt = """
     // #seekto 0x8220;

--- a/chirp/platform.py
+++ b/chirp/platform.py
@@ -182,6 +182,9 @@ class UnixPlatform(Platform):
 
         return ver
 
+    def is_ble_serial(self, serial):
+        return serial.port.startswith('/tmp/ttyBLE')
+
 
 class Win32Platform(Platform):
     """A platform module suitable for Windows systems"""
@@ -229,6 +232,48 @@ class Win32Platform(Platform):
 
         return vers.get(pform,
                         "Win32 (Unknown %i.%i:%i)" % (pform, sub, build))
+
+    def is_ble_serial(self, serial):
+        import winreg
+
+        max_ports = 255
+        key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE,
+                             r'HARDWARE\DEVICEMAP\SERIALCOMM')
+        devices = {}
+        for i in range(max_ports):
+            try:
+                # device is something like \Device\com0com24
+                # name is something like COM12
+                device, name, _ = winreg.EnumValue(key, i)
+                devices[name] = device
+            except EnvironmentError:
+                break
+
+        LOG.debug('All device/name pairs: %s' % devices)
+
+        try:
+            # ble-serial names its device BLE, so find it
+            ble_device = devices.get('BLE')
+        except KeyError:
+            LOG.debug('No BLE device found')
+            sys.exit(1)
+
+        # The pair device appears to always be \Device\com0com14 if
+        # the BLE device is \Device\com0com24
+        pair_device = list(ble_device)
+        # Change 2 to 1 to get the first device of the pair
+        pair_device[-2] = '1'
+        pair_device = ''.join(pair_device)
+        LOG.debug('Found BLE device %s, guessing pair is %s' % (
+            device, pair_device))
+        try:
+            pair_name = dict(((v, k) for k, v in devices.items()))[pair_device]
+        except KeyError:
+            LOG.debug('Pair device not found!')
+        else:
+            LOG.info('BLE pair device is %s' % pair_name)
+
+        return serial.port == pair_name
 
 
 def _get_platform(basepath):

--- a/tests/test_clone.py
+++ b/tests/test_clone.py
@@ -16,6 +16,10 @@ class SerialException(Exception):
 
 
 class SerialNone(serialtrace.SerialTrace):
+    def __init__(self, *a, **k):
+        super().__init__(*a, **k)
+        self.port = '/dev/ttyUSB0'
+
     def flush(self):
         pass
 


### PR DESCRIPTION
baofeng_uv17Pro: Fixes #12251. Allow UV-5R Mini, Mini 5 and UV-5G Mini to upload to radio over a BLE serial connection

This PR has two commits that address  the long-standing issue where a Bluetooth Low Energy (BLE) serial connection could not be used to upload to a Baofeng UV-5R Mini, UV-5G Mini or the newer Mini 5 radios.

These two commits are a substantial refactor of a previous PR ([1463](https://github.com/kk7ds/chirp/pull/1463)) submitted by @Marcotic some months ago.

I'd like to give full credit here to him for discovering a solution to the problem and figuring out the logic to implement it. That PR seems to have gone stale and has not seen any activity for months now. Hence the reason for the refactoring and the submission of a new one.

The following will help describe the fix:

0) The radio firmware supports downloading and uploading  from/to the radio over a BLE connection
1) The BLE connection supports a block size of **0x40** for **downloads**
2) The BLE connection supports a block size of **0x80** for **uploads**
3) The upload blocks must be an even multiple of the size of the memory region being written to during a BLE  upload
4) Partial blocks (blocks not a full 0x80 bytes long) must be padded to a full BLE upload block size with \xff bytes
5) if a partial block is padded with any values that are not equal to \xff it will corrupt the radio memory
6) When a partial block has been padded an entry is added to the serial trace log file.

7) A serial connection over BLE has substantially more latency than a USB serial connection. During the **ident** process that latency is used during the "magic sending" exchange to measure that latency and use that OR  the port name to determine if the connection is over USB or BLE.

During testing it was discovered that the USB Serial connection cannot use a block size of 0x80 for uploads. When that was tried it would corrupt the radio memory and only 2 out or each 4 memories would be displayed.

A helper method has also been added to chirp_common to help determine of the current serial connection is over a BLE serial connection and can be used by other drivers that need to determine if they are operating over a BLE connection.

8) A new setting for Enabling/Disabling Bluetooth as also been added.

This has been tested on Windows, Linux and MacOS and is working as it should for both connections over USB Serial and BLE Serial.

See CHIRP Issues tracker: https://chirpmyradio.com/issues/12251
