### PR TITLE
Fixes for recent BLE Serial Connection additions for uploading to Baofeng to UV-5R Mini series radios over BLE

### DIFF
--- a/chirp/drivers/baofeng_uv17Pro.py
+++ b/chirp/drivers/baofeng_uv17Pro.py
@@ -2435,7 +2435,7 @@ class UV5RMini(UV17Pro):
                 data = radio_mem[data_addr:data_addr + byte_count]
 
                 if byte_count < _blocksize:  # does block need padding?
-                    radio.pipe.log('Padding partial block with \xff '
+                    radio.pipe.log('Padding partial block with \\xff '
                                    'by 0x%02x bytes' %
                                    (_blocksize - len(data)))
                     # pad partial block with \xff

--- a/chirp/platform.py
+++ b/chirp/platform.py
@@ -253,10 +253,10 @@ class Win32Platform(Platform):
 
         try:
             # ble-serial names its device BLE, so find it
-            ble_device = devices.get('BLE')
+            ble_device = devices['BLE']
         except KeyError:
             LOG.debug('No BLE device found')
-            sys.exit(1)
+            return False
 
         # The pair device appears to always be \Device\com0com14 if
         # the BLE device is \Device\com0com24


### PR DESCRIPTION
This PR contains two commits to fix problems in recent additions for allowing uploads over BLE serial connections for the Baofeng UV-5R Mini series of radios:

0) platform: Fixes #12498. Unhandeled exception NoneType when no BLE port is present in is_ble_serial() detection. ONLY occures on **Windows** platform.

    Fixed by refactoring **dict** _index_ lookup and returning **False** when no BLE port is found. This problem was persistently happening   on systems where no BLE port existed.

1) baofeng_uv17Pro: Fix escape character in .pipe.log() message for UV-5R Mini

    radio.pipe.log messages were not displaying hex literal strings properly. Fixed by adding escape character to message string.

CHIRP Issues tracker as reported:
    https://chirpmyradio.com/issues/12498
    https://chirpmyradio.com/issues/12500 (duplicate issue)
