### PR TITLE
tools/check_commit: enforce whole-word six/future detection

### DIFF
--- a/tools/check_commit.sh
+++ b/tools/check_commit.sh
@@ -18,11 +18,11 @@ echo
 
 git diff ${BASE}.. -- '*.py' | grep '^+' > added_lines
 
-if grep -E '(from|import).*six' added_lines; then
-    fail No new uses of future
+if grep -E '(from|import).*\<six\>' added_lines; then
+    fail No new uses of six
 fi
 
-if grep -E '\wsix\w' added_lines; then
+if grep -E '\<six\>' added_lines; then
     fail No new uses of six
 fi
 
@@ -30,7 +30,7 @@ if grep -E '(from|import).*builtins' added_lines; then
     fail No new uses of future
 fi
 
-if grep -E '\wfuture\w' added_lines; then
+if grep -E '\<future\>' added_lines; then
     fail No new uses of future
 fi
 


### PR DESCRIPTION
Fix word-boundary matching in check_commit six/future checks.

Now we match `six` word but not eg. `sixth` etc.