### PR TITLE
Add Baofeng BF-5RH as alias of UV-5RH

### DIFF
--- a/chirp/share/model_alias_map.yaml
+++ b/chirp/share/model_alias_map.yaml
@@ -143,6 +143,8 @@ Baofeng/Pofung:
   model: UV-5RG, RK, RQ, RS, RT, RU
 - alt: Baofeng 5RM
   model: UV-5RH Pro Max
+- alt: Baofeng UV-5RH
+  model: BF-5RH
 - alt: BF-F8HP
   model: UV-5RHP
 - alt: Radioddity UV-5RX3


### PR DESCRIPTION
## Summary

The Baofeng BF-5RH is the same radio as the Baofeng UV-5RH, but it does not appear in the CHIRP model list. Expose it as an alias of the existing UV-5RH driver.