### PR TITLE
bulk_rename: Add Bulk Rename dialog for templated channel renaming

### DIFF
--- a/chirp/wxui/bulk_rename.py
+++ b/chirp/wxui/bulk_rename.py
@@ -1,0 +1,496 @@
+# Copyright 2026 Tony Gies <tgies@tgies.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import logging
+import re
+
+import wx
+
+LOG = logging.getLogger(__name__)
+
+# Token buttons: (label, tooltip).
+_DISPLAY_TOKENS = [
+    ('{num}', 'Channel number'),
+    ('{seq}', 'Sequential counter (1, 2, 3...)'),
+    ('{freq}', 'Frequency in MHz (e.g. 462.5625)'),
+    ('{freq_khz}', 'Frequency in kHz (e.g. 462562)'),
+    ('{name}', 'Current channel name'),
+    ('{mode}', 'Modulation (FM, NFM, AM)'),
+    ('{duplex}', 'Duplex direction (+, -, off)'),
+]
+
+_SYNTAX_HELP = (
+    'Format specs\n'
+    '{freq:.1f} - 1 decimal (462.6)\n'
+    '{seq:03d} - zero-padded (001)\n'
+    '\n'
+    'Counter options\n'
+    '{seq+10} - start at 10\n'
+    '{seq+10/2} - start 10, step 2\n'
+    '\n'
+    'Arithmetic (+ - * % //)\n'
+    '{freq_khz%1000} - last 3 digits\n'
+    '{freq_khz%1000:03d} - zero-padded\n'
+    '\n'
+    'Conditionals\n'
+    '{duplex?+=RPTR|SPLX}\n'
+    '  if + then RPTR, else SPLX\n'
+    '{mode?FM=F|NFM=N|?}\n'
+    '  map values, ? is fallback\n'
+    '{duplex?!+=NOT PLUS|PLUS}\n'
+    '  ! negates the match'
+)
+
+
+class CaseInsensitiveDict(dict):
+    """Dict subclass that normalizes key lookups to lowercase."""
+
+    def __init__(self, data):
+        super().__init__({k.lower(): v for k, v in data.items()})
+
+    def __getitem__(self, key):
+        return super().__getitem__(key.lower())
+
+    def __contains__(self, key):
+        return super().__contains__(key.lower())
+
+
+# Regex to match {seq}, {seq+N}, {seq+N/S}, {SEQ+N:fmt}, etc.
+# Groups: 1=sign(+/-), 2=start, 3=step, 4=format_spec
+_SEQ_RE = re.compile(
+    r'\{[Ss][Ee][Qq]'       # opening {seq (case-insensitive)
+    r'(?:([+-])(\d+))?'     # optional +N or -N
+    r'(?:/(\d+))?'          # optional /step
+    r'(:[^}]+)?'            # optional :format_spec
+    r'\}',                  # closing }
+)
+
+
+def _extract_seq_params(m):
+    """Extract (start, step) from a _SEQ_RE match."""
+    sign = m.group(1)
+    start_str = m.group(2)
+    step_str = m.group(3)
+    start = 1
+    if start_str is not None:
+        start = int(start_str)
+        if sign == '-':
+            start = -start
+    step = int(step_str) if step_str else 1
+    return start, step
+
+
+def parse_seq_token(template):
+    """Parse {seq} extended syntax out of a template string.
+
+    Returns (normalized_template, start, step) where all {seq...}
+    tokens have been replaced with plain {seq} or {seq:fmt}.
+    Start and step are extracted from the first match.
+    Raises ValueError if multiple seq tokens have conflicting
+    start/step values.
+    """
+    matches = list(_SEQ_RE.finditer(template))
+    if not matches:
+        return template, 1, 1
+
+    # Extract and validate start/step across all matches
+    start, step = _extract_seq_params(matches[0])
+    for m in matches[1:]:
+        s, st = _extract_seq_params(m)
+        if s != start or st != step:
+            raise ValueError(
+                'conflicting {seq} modifiers: '
+                '%s vs %s' % (matches[0].group(),
+                              m.group()))
+
+    # Replace all matches, preserving each one's format spec
+    def _replace(m):
+        fmt = m.group(4) or ''
+        return '{seq%s}' % fmt
+
+    normalized = _SEQ_RE.sub(_replace, template)
+    return normalized, start, step
+
+
+# Memory attributes to skip
+_SKIP_ATTRS = frozenset((
+    'empty', 'immutable', 'extra', 'vfo', 'extd_number',
+))
+
+# Attributes needing conversion from raw storage
+_CONVERSIONS = {
+    'freq': lambda v: v / 1_000_000,
+    'offset': lambda v: v / 1_000_000,
+    'power': lambda v: str(v) if v else '',
+}
+
+
+def build_format_dict(mem, seq_value):
+    """Build the format dict from a Memory object.
+
+    Dynamically exposes all Memory attributes plus extras.
+    Frequency and offset are converted from Hz to MHz.
+    """
+    d = {}
+
+    # Pull all public attributes from Memory
+    for attr in dir(mem):
+        if attr.startswith('_') or attr in _SKIP_ATTRS:
+            continue
+        val = getattr(mem, attr, None)
+        if callable(val):
+            continue
+        if attr in _CONVERSIONS:
+            val = _CONVERSIONS[attr](val)
+        d[attr] = val
+
+    # Aliases and derived tokens
+    d['num'] = mem.number
+    d['freq_khz'] = mem.freq // 1000
+    d['seq'] = seq_value
+
+    # Flatten mem.extra settings into the dict
+    if mem.extra:
+        for setting in mem.extra:
+            name = setting.get_name()
+            if name not in d:
+                d[name] = str(setting.value)
+
+    return CaseInsensitiveDict(d)
+
+
+# Regex to match {field+N}, {field//N}, {field%N}, etc.
+# Groups: 1=field, 2=operator, 3=operand, 4=format_spec
+_ARITH_RE = re.compile(
+    r'\{(\w+)(//|[+\-*%])(\d+)(:[^}]+)?\}'
+)
+
+_ARITH_OPS = {
+    '+': lambda a, b: a + b,
+    '-': lambda a, b: a - b,
+    '*': lambda a, b: a * b,
+    '%': lambda a, b: a % b,
+    '//': lambda a, b: a // b,
+}
+
+
+def resolve_arithmetic(template, fmt_dict):
+    """Resolve {field<op>N} arithmetic expressions.
+
+    Supported operators: + - * % //
+    Result is injected into fmt_dict under a synthetic key.
+    """
+    counter = [0]
+
+    def _resolve(m):
+        field = m.group(1).lower()
+        op = m.group(2)
+        operand = int(m.group(3))
+        fmt = m.group(4) or ''
+
+        if field not in fmt_dict:
+            raise KeyError(field)
+        val = fmt_dict[field]
+        if not isinstance(val, (int, float)):
+            raise ValueError(
+                'cannot do arithmetic on %s' % field)
+        if operand == 0 and op in ('%', '//'):
+            raise ValueError('division by zero')
+
+        result = _ARITH_OPS[op](val, operand)
+        if isinstance(result, float) and result == int(result):
+            result = int(result)
+
+        key = '_arith_%i' % counter[0]
+        counter[0] += 1
+        fmt_dict[key] = result
+        return '{%s%s}' % (key, fmt)
+
+    return _ARITH_RE.sub(_resolve, template)
+
+
+# Regex to match {field?val=repl|val2=repl2|fallback}
+# The expression part allows nested {token} references
+# inside replacement values.
+_COND_RE = re.compile(
+    r'\{(\w+)\?((?:[^{}]|\{[^}]*\})+)\}'
+)
+
+
+def resolve_conditionals(template, fmt_dict):
+    """Resolve {field?value=replacement|...} conditional tokens.
+
+    Syntax:
+        {field?val=repl|val2=repl2|fallback}
+
+    Entries with = are match cases (if field equals val, emit
+    repl). The last entry without = is the default. If no match
+    and no default, the original field value passes through.
+    Field lookup is case-insensitive.
+    """
+    def _resolve(m):
+        field = m.group(1).lower()
+        expr = m.group(2)
+        if field not in fmt_dict:
+            raise KeyError(field)
+        field_val = str(fmt_dict[field])
+        entries = expr.split('|')
+        fallback = None
+        for entry in entries:
+            if '=' in entry:
+                negate = entry.startswith('!')
+                if negate:
+                    entry = entry[1:]
+                match_val, repl = entry.split('=', 1)
+                matched = (match_val == field_val)
+                if negate:
+                    matched = not matched
+                if matched:
+                    return repl
+            else:
+                fallback = entry
+        if fallback is not None:
+            return fallback
+        return field_val
+
+    return _COND_RE.sub(_resolve, template)
+
+
+class TemplateResult:
+    """Result of applying a template: either a name or an error."""
+
+    def __init__(self, value, error=None):
+        self.value = value
+        self.error = error
+
+    @property
+    def ok(self):
+        return self.error is None
+
+
+def apply_template(template, mem, row_index):
+    """Apply a name template to a Memory object.
+
+    Args:
+        template: Format string with {token} placeholders.
+        mem: chirp_common.Memory object.
+        row_index: Zero-based index of this memory in the selection
+                   (used for {seq} counter).
+
+    Returns:
+        TemplateResult with .value (formatted string) and
+        .error (None on success, error message on failure).
+    """
+    try:
+        normalized, start, step = parse_seq_token(template)
+        seq_value = start + (row_index * step)
+        fmt_dict = build_format_dict(mem, seq_value)
+        normalized = resolve_arithmetic(
+            normalized, fmt_dict)
+        normalized = resolve_conditionals(
+            normalized, fmt_dict)
+        return TemplateResult(
+            normalized.format_map(fmt_dict))
+    except KeyError as e:
+        return TemplateResult(
+            '', 'unknown: %s' % str(e).strip("'"))
+    except (ValueError, IndexError) as e:
+        return TemplateResult('', str(e))
+
+
+class BulkRenameDialog(wx.Dialog):
+    """Dialog for renaming multiple channels using a template."""
+
+    def __init__(self, parent, radio, memories):
+        super().__init__(parent, title=_('Bulk Rename Channels'),
+                         style=wx.DEFAULT_DIALOG_STYLE
+                         | wx.RESIZE_BORDER)
+        self._radio = radio
+        self._memories = memories
+        self._features = radio.get_features()
+
+        self._build_ui()
+        self._update_preview()
+
+        self.SetSize(wx.Size(680, 520))
+        self.CenterOnParent()
+
+    def _build_ui(self):
+        hbox = wx.BoxSizer(wx.HORIZONTAL)
+
+        # Left column: controls
+        left = wx.BoxSizer(wx.VERTICAL)
+
+        # Template input
+        lbl = wx.StaticText(self, label=_('Template:'))
+        left.Add(lbl, 0, wx.ALL, 5)
+
+        self._template = wx.TextCtrl(self)
+        self._template.Bind(wx.EVT_TEXT,
+                            self._on_template_changed)
+        left.Add(self._template, 0,
+                 wx.EXPAND | wx.LEFT | wx.RIGHT, 5)
+
+        # Token buttons
+        token_lbl = wx.StaticText(
+            self, label=_('Common tokens:'))
+        left.Add(token_lbl, 0, wx.ALL, 5)
+
+        token_sizer = wx.WrapSizer()
+        for token, tip in _DISPLAY_TOKENS:
+            btn = wx.Button(self, label=token,
+                            style=wx.BU_EXACTFIT)
+            btn.SetToolTip(_(tip))
+            btn.Bind(
+                wx.EVT_BUTTON,
+                lambda e, t=token:
+                    self._insert_token(t))
+            token_sizer.Add(btn, 0, wx.ALL, 2)
+
+        # "More..." button with popup of all tokens
+        more_btn = wx.Button(self, label=_('More...'),
+                             style=wx.BU_EXACTFIT)
+        more_btn.Bind(wx.EVT_BUTTON,
+                      self._on_more_tokens)
+        token_sizer.Add(more_btn, 0, wx.ALL, 2)
+
+        left.Add(token_sizer, 0,
+                 wx.EXPAND | wx.LEFT | wx.RIGHT, 5)
+
+        # Preview list
+        preview_lbl = wx.StaticText(
+            self, label=_('Preview:'))
+        left.Add(preview_lbl, 0, wx.ALL, 5)
+
+        self._preview = wx.ListCtrl(
+            self, style=wx.LC_REPORT)
+        self._preview.AppendColumn(_('Ch'), width=50)
+        self._preview.AppendColumn(
+            _('Current Name'), width=120)
+        self._preview.AppendColumn(
+            _('New Name'), width=200)
+        left.Add(self._preview, 1,
+                 wx.EXPAND | wx.LEFT | wx.RIGHT, 5)
+
+        # Radio constraints info
+        info = _('Max name length: %i') % (
+            self._features.valid_name_length)
+        info_lbl = wx.StaticText(self, label=info)
+        info_lbl.SetFont(
+            info_lbl.GetFont().MakeSmaller())
+        left.Add(info_lbl, 0, wx.ALL, 5)
+
+        # Buttons
+        btn_sizer = self.CreateStdDialogButtonSizer(
+            wx.OK | wx.CANCEL)
+        self._ok_btn = self.FindWindowById(wx.ID_OK)
+        self._ok_btn.SetLabel(_('Apply'))
+        self._ok_btn.Enable(False)
+        left.Add(btn_sizer, 0,
+                 wx.EXPAND | wx.ALL, 5)
+
+        hbox.Add(left, 1, wx.EXPAND)
+
+        # Right column: syntax help
+        right = wx.BoxSizer(wx.VERTICAL)
+        help_lbl = wx.StaticText(
+            self, label=_('Syntax Reference'))
+        help_lbl.SetFont(
+            help_lbl.GetFont().MakeBold())
+        right.Add(help_lbl, 0, wx.ALL, 5)
+
+        help_text = wx.StaticText(
+            self, label=_(_SYNTAX_HELP))
+        right.Add(help_text, 0, wx.ALL, 5)
+
+        hbox.Add(right, 0, wx.EXPAND | wx.RIGHT, 5)
+
+        self.SetSizer(hbox)
+
+    def _insert_token(self, token):
+        """Insert a token string at the cursor position."""
+        pos = self._template.GetInsertionPoint()
+        self._template.Replace(pos, pos, token)
+        self._template.SetInsertionPoint(
+            pos + len(token))
+        self._template.SetFocus()
+
+    def _on_more_tokens(self, event):
+        """Show popup menu with all available tokens."""
+        # Build token list from first memory
+        fmt_dict = build_format_dict(
+            self._memories[0], 1)
+        common = {t for t, _ in _DISPLAY_TOKENS}
+        menu = wx.Menu()
+        for key in sorted(fmt_dict.keys()):
+            if key.startswith('_'):
+                continue
+            label = '{%s}' % key
+            if label in common:
+                continue
+            item = menu.Append(wx.ID_ANY, label)
+            self.Bind(
+                wx.EVT_MENU,
+                lambda e, t=label:
+                    self._insert_token(t),
+                item)
+        btn = event.GetEventObject()
+        btn.PopupMenu(menu)
+        menu.Destroy()
+
+    def _on_template_changed(self, event):
+        self._update_preview()
+
+    def _update_preview(self):
+        """Re-render the preview list from the template."""
+        self._preview.DeleteAllItems()
+        template = self._template.GetValue()
+        has_error = False
+
+        if not template:
+            self._ok_btn.Enable(False)
+            return
+
+        for i, mem in enumerate(self._memories):
+            r = apply_template(template, mem, i)
+            if r.ok:
+                new_name = self._radio.filter_name(
+                    r.value)
+            else:
+                has_error = True
+                new_name = r.error
+
+            idx = self._preview.InsertItem(
+                self._preview.GetItemCount(),
+                str(mem.number))
+            self._preview.SetItem(idx, 1, mem.name)
+            self._preview.SetItem(idx, 2, new_name)
+
+            if not r.ok:
+                self._preview.SetItemTextColour(
+                    idx, wx.Colour(200, 0, 0))
+
+        self._ok_btn.Enable(not has_error)
+
+    @property
+    def new_names(self):
+        """Return list of (memory, new_name) tuples."""
+        template = self._template.GetValue()
+        result = []
+        for i, mem in enumerate(self._memories):
+            r = apply_template(template, mem, i)
+            name = self._radio.filter_name(r.value)
+            result.append((mem, name))
+        return result

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -1309,6 +1309,10 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
         goto = common.EditorMenuItem(cls, '_goto', _('Goto...'))
         goto.SetAccel(wx.AcceleratorEntry(wx.MOD_CONTROL, ord('G')))
 
+        bulk_rename = common.EditorMenuItem(
+            cls, '_bulk_rename_from_menu',
+            _('Bulk Rename...'))
+
         expand_extra = common.EditorMenuItemToggle(
             cls, '_set_expand_extra', ('expand_extra', 'state'),
             _('Show extra fields'))
@@ -1328,6 +1332,7 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
                 goto,
                 move_up,
                 move_dn,
+                bulk_rename,
                 ],
             common.EditorMenuItem.MENU_VIEW: [
                 expand_extra,
@@ -2310,6 +2315,19 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
             menu.Append(diff_across_item)
             menu.Enable(diff_across_item.GetId(), len(selected_rows) == 1)
 
+        rename_item = wx.MenuItem(
+            menu, wx.NewId(), _('Bulk Rename...'))
+        self.Bind(
+            wx.EVT_MENU,
+            functools.partial(self._bulk_rename,
+                              selected_rows),
+            rename_item)
+        menu.Append(rename_item)
+        rename_item.Enable(
+            self.editable and not self.busy
+            and used_selected >= 2
+            and self._features.has_name)
+
         self.PopupMenu(menu)
         menu.Destroy()
 
@@ -2330,6 +2348,60 @@ class ChirpMemEdit(common.ChirpEditor, common.ChirpSyncEditor):
                 self.set_memory(memory)
 
         wx.PostEvent(self, common.EditorChanged(self.GetId()))
+
+    @common.error_proof()
+    def _bulk_rename(self, rows, event):
+        from chirp.wxui.bulk_rename import BulkRenameDialog
+
+        if (not self._features.has_name
+                or self.busy or not self.editable):
+            return
+
+        # Filter to visible rows in case hide-empty or
+        # search filter is active
+        rows = [r for r in rows
+                if self._grid.IsRowShown(r)]
+        memories = [
+            self.synchronous_get_memory(self.row2mem(row))
+            for row in rows]
+        memories = [m for m in memories
+                    if not m.empty
+                    and 'name' not in m.immutable]
+
+        if len(memories) < 2:
+            wx.MessageBox(
+                _('Select at least two non-empty '
+                  'memories to rename.'),
+                _('Bulk Rename'),
+                wx.OK | wx.ICON_INFORMATION)
+            return
+
+        with BulkRenameDialog(self, self._radio,
+                              memories) as d:
+            if d.ShowModal() != wx.ID_OK:
+                return
+            new_names = d.new_names
+
+        with self.undo_context(
+                _('Rename %i memories') % len(new_names)):
+            for mem, name in new_names:
+                mem = mem.dupe()
+                mem.name = name
+                self.set_memory(mem)
+
+        wx.PostEvent(self, common.EditorChanged(
+            self.GetId()))
+
+    def _bulk_rename_from_menu(self, event):
+        selected_rows = self.get_selected_rows_safe()
+        if not selected_rows:
+            wx.MessageBox(
+                _('Select at least two non-empty '
+                  'memories to rename.'),
+                _('Bulk Rename'),
+                wx.OK | wx.ICON_INFORMATION)
+            return
+        self._bulk_rename(selected_rows, event)
 
     @common.error_proof()
     @undoable('Insert row')

--- a/tests/unit/test_bulk_rename.py
+++ b/tests/unit/test_bulk_rename.py
@@ -1,0 +1,580 @@
+# Copyright 2026 Tony Gies <tgies@tgies.net>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from tests.unit import base
+from chirp import chirp_common
+from chirp import settings
+from chirp.wxui.bulk_rename import (CaseInsensitiveDict, parse_seq_token,
+                                    build_format_dict, apply_template,
+                                    resolve_arithmetic,
+                                    resolve_conditionals)
+
+
+class TestCaseInsensitiveDict(base.BaseTest):
+    def test_lowercase_lookup(self):
+        d = CaseInsensitiveDict({'freq': 462.5625, 'name': 'TEST'})
+        self.assertEqual(462.5625, d['freq'])
+
+    def test_uppercase_lookup(self):
+        d = CaseInsensitiveDict({'freq': 462.5625})
+        self.assertEqual(462.5625, d['FREQ'])
+
+    def test_mixed_case_lookup(self):
+        d = CaseInsensitiveDict({'freq': 462.5625})
+        self.assertEqual(462.5625, d['Freq'])
+
+    def test_missing_key_raises(self):
+        d = CaseInsensitiveDict({'freq': 462.5625})
+        with self.assertRaises(KeyError):
+            d['nonexistent']
+
+    def test_contains(self):
+        d = CaseInsensitiveDict({'freq': 462.5625})
+        self.assertIn('FREQ', d)
+        self.assertIn('freq', d)
+        self.assertNotIn('missing', d)
+
+
+class TestParseSeqToken(base.BaseTest):
+    def test_no_seq(self):
+        template, start, step = parse_seq_token('CH {num}')
+        self.assertEqual('CH {num}', template)
+        self.assertEqual(1, start)
+        self.assertEqual(1, step)
+
+    def test_plain_seq(self):
+        template, start, step = parse_seq_token('{seq}')
+        self.assertEqual('{seq}', template)
+        self.assertEqual(1, start)
+        self.assertEqual(1, step)
+
+    def test_seq_positive_offset(self):
+        template, start, step = parse_seq_token('{seq+10}')
+        self.assertEqual('{seq}', template)
+        self.assertEqual(10, start)
+        self.assertEqual(1, step)
+
+    def test_seq_negative_offset(self):
+        template, start, step = parse_seq_token('{seq-5}')
+        self.assertEqual('{seq}', template)
+        self.assertEqual(-5, start)
+        self.assertEqual(1, step)
+
+    def test_seq_offset_and_step(self):
+        template, start, step = parse_seq_token('{seq+10/2}')
+        self.assertEqual('{seq}', template)
+        self.assertEqual(10, start)
+        self.assertEqual(2, step)
+
+    def test_seq_with_format_spec(self):
+        template, start, step = parse_seq_token('{seq+10:03d}')
+        self.assertEqual('{seq:03d}', template)
+        self.assertEqual(10, start)
+        self.assertEqual(1, step)
+
+    def test_seq_full_syntax(self):
+        template, start, step = parse_seq_token('{seq+10/2:03d}')
+        self.assertEqual('{seq:03d}', template)
+        self.assertEqual(10, start)
+        self.assertEqual(2, step)
+
+    def test_seq_preserves_surrounding_text(self):
+        template, start, step = parse_seq_token('CH {seq+5} x')
+        self.assertEqual('CH {seq} x', template)
+        self.assertEqual(5, start)
+        self.assertEqual(1, step)
+
+    def test_seq_case_insensitive(self):
+        template, start, step = parse_seq_token('{SEQ+10}')
+        self.assertEqual('{seq}', template)
+        self.assertEqual(10, start)
+        self.assertEqual(1, step)
+
+    def test_seq_step_without_offset(self):
+        template, start, step = parse_seq_token('{seq/2}')
+        self.assertEqual('{seq}', template)
+        self.assertEqual(1, start)
+        self.assertEqual(2, step)
+
+    def test_repeated_seq_tokens(self):
+        template, start, step = parse_seq_token(
+            '{seq+10}-{seq+10}')
+        self.assertEqual('{seq}-{seq}', template)
+        self.assertEqual(10, start)
+        self.assertEqual(1, step)
+
+    def test_conflicting_seq_modifiers_raises(self):
+        with self.assertRaises(ValueError):
+            parse_seq_token('{seq+10}-{seq+20}')
+
+
+class TestBuildFormatDict(base.BaseTest):
+    def _make_memory(self, **kwargs):
+        mem = chirp_common.Memory()
+        mem.freq = 462562500
+        mem.number = 5
+        mem.name = 'GMRS 5'
+        mem.offset = 5000000
+        mem.duplex = '+'
+        mem.tmode = 'TSQL'
+        mem.rtone = 141.3
+        mem.ctone = 141.3
+        mem.dtcs = 23
+        mem.mode = 'FM'
+        mem.tuning_step = 12.5
+        mem.skip = ''
+        mem.comment = 'test'
+        for k, v in kwargs.items():
+            setattr(mem, k, v)
+        return mem
+
+    def test_freq_converted_to_mhz(self):
+        mem = self._make_memory(freq=462562500)
+        d = build_format_dict(mem, 1)
+        self.assertAlmostEqual(462.5625, d['freq'], places=4)
+
+    def test_offset_converted_to_mhz(self):
+        mem = self._make_memory(offset=5000000)
+        d = build_format_dict(mem, 1)
+        self.assertAlmostEqual(5.0, d['offset'], places=4)
+
+    def test_num_alias(self):
+        mem = self._make_memory(number=42)
+        d = build_format_dict(mem, 1)
+        self.assertEqual(42, d['num'])
+        self.assertEqual(42, d['number'])
+
+    def test_seq_injected(self):
+        mem = self._make_memory()
+        d = build_format_dict(mem, 7)
+        self.assertEqual(7, d['seq'])
+
+    def test_power_none_becomes_empty_string(self):
+        mem = self._make_memory(power=None)
+        d = build_format_dict(mem, 1)
+        self.assertEqual('', d['power'])
+
+    def test_extra_settings_exposed(self):
+        mem = self._make_memory()
+        rs = settings.RadioSetting(
+            'scramble', 'Scramble',
+            settings.RadioSettingValueList(
+                ['Off', 'SCR1', 'SCR2'],
+                current_index=1))
+        mem.extra = settings.RadioSettingGroup(
+            'extra', 'Extra')
+        mem.extra.append(rs)
+        d = build_format_dict(mem, 1)
+        self.assertEqual('SCR1', d['scramble'])
+
+    def test_cross_mode_exposed(self):
+        mem = self._make_memory()
+        d = build_format_dict(mem, 1)
+        self.assertEqual('Tone->Tone', d['cross_mode'])
+
+    def test_power_stringified(self):
+        pl = chirp_common.PowerLevel('High', watts=5)
+        mem = self._make_memory(power=pl)
+        d = build_format_dict(mem, 1)
+        self.assertEqual('High', d['power'])
+
+    def test_case_insensitive(self):
+        mem = self._make_memory()
+        d = build_format_dict(mem, 1)
+        self.assertEqual(d['freq'], d['FREQ'])
+        self.assertEqual(d['name'], d['Name'])
+
+    def test_tmode_exposed(self):
+        mem = self._make_memory(tmode='TSQL')
+        d = build_format_dict(mem, 1)
+        self.assertEqual('TSQL', d['tmode'])
+
+    def test_all_memory_fields_present(self):
+        mem = self._make_memory()
+        d = build_format_dict(mem, 1)
+        for field in ('number', 'name', 'freq', 'offset', 'duplex',
+                      'tmode', 'rtone', 'ctone', 'dtcs', 'mode',
+                      'tuning_step', 'skip', 'comment', 'cross_mode',
+                      'dtcs_polarity', 'rx_dtcs'):
+            self.assertIn(field, d, 'Missing token: %s' % field)
+
+
+class TestApplyTemplate(base.BaseTest):
+    def _make_memory(self, **kwargs):
+        mem = chirp_common.Memory()
+        mem.freq = 462562500
+        mem.number = 5
+        mem.name = 'GMRS 5'
+        mem.offset = 5000000
+        mem.duplex = '+'
+        mem.tmode = ''
+        mem.rtone = 88.5
+        mem.ctone = 88.5
+        mem.dtcs = 23
+        mem.mode = 'FM'
+        mem.tuning_step = 12.5
+        mem.skip = ''
+        mem.comment = ''
+        for k, v in kwargs.items():
+            setattr(mem, k, v)
+        return mem
+
+    def test_literal_only(self):
+        mem = self._make_memory()
+        result = apply_template('HELLO', mem, 0)
+        self.assertTrue(result.ok)
+        self.assertEqual('HELLO', result.value)
+
+    def test_freq_format(self):
+        mem = self._make_memory(freq=462562500)
+        result = apply_template('{freq:.1f}', mem, 0)
+        self.assertEqual('462.6', result.value)
+
+    def test_freq_full_precision(self):
+        mem = self._make_memory(freq=462562500)
+        result = apply_template('{freq:.4f}', mem, 0)
+        self.assertEqual('462.5625', result.value)
+
+    def test_num_token(self):
+        mem = self._make_memory(number=5)
+        result = apply_template('CH {num}', mem, 0)
+        self.assertEqual('CH 5', result.value)
+
+    def test_seq_default(self):
+        mem = self._make_memory()
+        result = apply_template('CH {seq}', mem, 0)
+        self.assertEqual('CH 1', result.value)
+
+    def test_seq_second_row(self):
+        mem = self._make_memory()
+        result = apply_template('CH {seq}', mem, 2)
+        self.assertEqual('CH 3', result.value)
+
+    def test_seq_with_offset(self):
+        mem = self._make_memory()
+        result = apply_template('CH {seq+10}', mem, 0)
+        self.assertEqual('CH 10', result.value)
+
+    def test_seq_with_offset_and_step(self):
+        mem = self._make_memory()
+        result = apply_template('CH {seq+10/2}', mem, 2)
+        self.assertEqual('CH 14', result.value)
+
+    def test_seq_zero_padded(self):
+        mem = self._make_memory()
+        result = apply_template('G{seq:02d}', mem, 0)
+        self.assertEqual('G01', result.value)
+
+    def test_seq_offset_zero_padded(self):
+        mem = self._make_memory()
+        result = apply_template('G{seq+10:03d}', mem, 0)
+        self.assertEqual('G010', result.value)
+
+    def test_multiple_tokens(self):
+        mem = self._make_memory(freq=462562500, mode='FM')
+        result = apply_template('{freq:.1f} {mode}', mem, 0)
+        self.assertEqual('462.6 FM', result.value)
+
+    def test_case_insensitive_tokens(self):
+        mem = self._make_memory(freq=462562500)
+        result = apply_template('{FREQ:.1f}', mem, 0)
+        self.assertEqual('462.6', result.value)
+
+    def test_empty_template(self):
+        mem = self._make_memory()
+        result = apply_template('', mem, 0)
+        self.assertEqual('', result.value)
+
+    def test_unknown_token_returns_error(self):
+        mem = self._make_memory()
+        result = apply_template('{bogus}', mem, 0)
+        self.assertIn('bogus', result.error)
+        self.assertFalse(result.ok)
+
+    def test_bad_format_spec_returns_error(self):
+        mem = self._make_memory()
+        result = apply_template('{freq:zz}', mem, 0)
+        self.assertFalse(result.ok)
+
+    def test_existing_name_token(self):
+        mem = self._make_memory(name='OLD')
+        result = apply_template('{name} {seq}', mem, 0)
+        self.assertEqual('OLD 1', result.value)
+
+    def test_bracket_in_output_is_not_error(self):
+        mem = self._make_memory(name='[TEST]')
+        result = apply_template('{name}', mem, 0)
+        self.assertTrue(result.ok)
+        self.assertEqual('[TEST]', result.value)
+
+    def test_conditional_match(self):
+        mem = self._make_memory(duplex='+')
+        result = apply_template('{duplex?+=RPTR|GMRS}', mem, 0)
+        self.assertEqual('RPTR', result.value)
+
+    def test_conditional_fallback(self):
+        mem = self._make_memory(duplex='')
+        result = apply_template('{duplex?+=RPTR|GMRS}', mem, 0)
+        self.assertEqual('GMRS', result.value)
+
+    def test_conditional_no_fallback_passthrough(self):
+        mem = self._make_memory(mode='AM')
+        result = apply_template('{mode?FM=F|NFM=N}', mem, 0)
+        self.assertEqual('AM', result.value)
+
+    def test_conditional_multi_match(self):
+        mem = self._make_memory(mode='NFM')
+        result = apply_template(
+            '{mode?FM=F|NFM=N|AM=A|?}', mem, 0)
+        self.assertEqual('N', result.value)
+
+    def test_conditional_with_other_tokens(self):
+        mem = self._make_memory(duplex='+')
+        result = apply_template(
+            '{duplex?+=RPT|SX} {seq:02d}', mem, 0)
+        self.assertEqual('RPT 01', result.value)
+
+    def test_conditional_case_insensitive_field(self):
+        mem = self._make_memory(duplex='+')
+        result = apply_template(
+            '{DUPLEX?+=RPTR|GMRS}', mem, 0)
+        self.assertEqual('RPTR', result.value)
+
+    def test_conditional_with_nested_token(self):
+        mem = self._make_memory(
+            freq=462562500, duplex='+')
+        result = apply_template(
+            '{duplex?+={freq:.1f}|SIMPLEX}', mem, 0)
+        self.assertTrue(result.ok)
+        self.assertEqual('462.6', result.value)
+
+    def test_conditional_with_nested_token_fallback(self):
+        mem = self._make_memory(
+            freq=462562500, duplex='')
+        result = apply_template(
+            '{duplex?+={freq:.1f}|SIMPLEX}', mem, 0)
+        self.assertTrue(result.ok)
+        self.assertEqual('SIMPLEX', result.value)
+
+    def test_conditional_unknown_field_error(self):
+        mem = self._make_memory()
+        result = apply_template(
+            '{bogus?a=b|c}', mem, 0)
+        self.assertFalse(result.ok)
+        self.assertIn('bogus', result.error)
+
+
+class TestResolveConditionals(base.BaseTest):
+    def test_simple_match(self):
+        d = CaseInsensitiveDict({'duplex': '+'})
+        result = resolve_conditionals(
+            '{duplex?+=RPTR|GMRS}', d)
+        self.assertEqual('RPTR', result)
+
+    def test_fallback(self):
+        d = CaseInsensitiveDict({'duplex': ''})
+        result = resolve_conditionals(
+            '{duplex?+=RPTR|GMRS}', d)
+        self.assertEqual('GMRS', result)
+
+    def test_no_fallback_passthrough(self):
+        d = CaseInsensitiveDict({'mode': 'AM'})
+        result = resolve_conditionals(
+            '{mode?FM=F|NFM=N}', d)
+        self.assertEqual('AM', result)
+
+    def test_multi_value_map(self):
+        d = CaseInsensitiveDict({'mode': 'NFM'})
+        result = resolve_conditionals(
+            '{mode?FM=F|NFM=N|AM=A|?}', d)
+        self.assertEqual('N', result)
+
+    def test_negated_match(self):
+        d = CaseInsensitiveDict({'duplex': ''})
+        result = resolve_conditionals(
+            '{duplex?!+=SPLX|RPT}', d)
+        self.assertEqual('SPLX', result)
+
+    def test_negated_no_match(self):
+        d = CaseInsensitiveDict({'duplex': '+'})
+        result = resolve_conditionals(
+            '{duplex?!+=SPLX|RPT}', d)
+        self.assertEqual('RPT', result)
+
+    def test_negated_empty(self):
+        d = CaseInsensitiveDict({'duplex': '+'})
+        result = resolve_conditionals(
+            '{duplex?!=HAS|NONE}', d)
+        self.assertEqual('HAS', result)
+
+    def test_negated_empty_matches(self):
+        d = CaseInsensitiveDict({'duplex': ''})
+        result = resolve_conditionals(
+            '{duplex?!=HAS|NONE}', d)
+        self.assertEqual('NONE', result)
+
+    def test_preserves_other_tokens(self):
+        d = CaseInsensitiveDict(
+            {'duplex': '+', 'seq': 1})
+        result = resolve_conditionals(
+            '{duplex?+=RPT|SX} {seq}', d)
+        self.assertEqual('RPT {seq}', result)
+
+    def test_unknown_field_raises(self):
+        d = CaseInsensitiveDict({'duplex': '+'})
+        with self.assertRaises(KeyError):
+            resolve_conditionals('{bogus?a=b}', d)
+
+    def test_replacement_with_equals(self):
+        d = CaseInsensitiveDict({'mode': 'FM'})
+        result = resolve_conditionals(
+            '{mode?FM=x=y|other}', d)
+        self.assertEqual('x=y', result)
+
+    def test_empty_replacement(self):
+        d = CaseInsensitiveDict({'duplex': '+'})
+        result = resolve_conditionals(
+            '{duplex?+=|GMRS}', d)
+        self.assertEqual('', result)
+
+    def test_case_insensitive_field(self):
+        d = CaseInsensitiveDict({'duplex': '+'})
+        result = resolve_conditionals(
+            '{DUPLEX?+=RPTR|GMRS}', d)
+        self.assertEqual('RPTR', result)
+
+
+class TestResolveArithmetic(base.BaseTest):
+    def test_addition(self):
+        d = CaseInsensitiveDict({'num': 5})
+        result = resolve_arithmetic('{num+1}', d)
+        self.assertEqual(6, d[result.strip('{}')])
+
+    def test_subtraction(self):
+        d = CaseInsensitiveDict({'num': 5})
+        result = resolve_arithmetic('{num-1}', d)
+        self.assertEqual(4, d[result.strip('{}')])
+
+    def test_multiplication(self):
+        d = CaseInsensitiveDict({'num': 5})
+        result = resolve_arithmetic('{num*2}', d)
+        self.assertEqual(10, d[result.strip('{}')])
+
+    def test_modulo(self):
+        d = CaseInsensitiveDict({'freq_khz': 462562})
+        result = resolve_arithmetic(
+            '{freq_khz%1000}', d)
+        self.assertEqual(
+            562, d[result.strip('{}')])
+
+    def test_integer_division(self):
+        d = CaseInsensitiveDict({'freq_khz': 462562})
+        result = resolve_arithmetic(
+            '{freq_khz//1000}', d)
+        self.assertEqual(
+            462, d[result.strip('{}')])
+
+    def test_preserves_format_spec(self):
+        d = CaseInsensitiveDict({'freq_khz': 462600})
+        result = resolve_arithmetic(
+            '{freq_khz%1000:03d}', d)
+        self.assertIn(':03d', result)
+
+    def test_preserves_other_tokens(self):
+        d = CaseInsensitiveDict(
+            {'num': 5, 'name': 'TEST'})
+        result = resolve_arithmetic(
+            '{num+1} {name}', d)
+        self.assertIn('{name}', result)
+
+    def test_unknown_field_raises(self):
+        d = CaseInsensitiveDict({'num': 5})
+        with self.assertRaises(KeyError):
+            resolve_arithmetic('{bogus+1}', d)
+
+    def test_non_numeric_raises(self):
+        d = CaseInsensitiveDict({'name': 'TEST'})
+        with self.assertRaises(ValueError):
+            resolve_arithmetic('{name+1}', d)
+
+    def test_division_by_zero_raises(self):
+        d = CaseInsensitiveDict({'num': 5})
+        with self.assertRaises(ValueError):
+            resolve_arithmetic('{num%0}', d)
+
+    def test_float_result_becomes_int(self):
+        d = CaseInsensitiveDict({'freq': 462.5})
+        result = resolve_arithmetic(
+            '{freq*1000}', d)
+        key = result.strip('{}')
+        # 462.5 * 1000 = 462500.0, converted to int
+        self.assertEqual(462500, d[key])
+
+    def test_case_insensitive_field(self):
+        d = CaseInsensitiveDict({'num': 5})
+        result = resolve_arithmetic('{NUM+1}', d)
+        self.assertEqual(6, d[result.strip('{}')])
+
+
+class TestApplyTemplateArithmetic(base.BaseTest):
+    def _make_memory(self, **kwargs):
+        mem = chirp_common.Memory()
+        mem.freq = 462562500
+        mem.number = 5
+        mem.name = 'GMRS 5'
+        mem.offset = 5000000
+        mem.duplex = '+'
+        mem.tmode = ''
+        mem.rtone = 88.5
+        mem.ctone = 88.5
+        mem.dtcs = 23
+        mem.mode = 'FM'
+        mem.tuning_step = 12.5
+        mem.skip = ''
+        mem.comment = ''
+        for k, v in kwargs.items():
+            setattr(mem, k, v)
+        return mem
+
+    def test_freq_khz_token(self):
+        mem = self._make_memory(freq=462562500)
+        result = apply_template('{freq_khz}', mem, 0)
+        self.assertEqual('462562', result.value)
+
+    def test_freq_khz_modulo(self):
+        mem = self._make_memory(freq=462600000)
+        result = apply_template(
+            '{freq_khz%1000:03d}', mem, 0)
+        self.assertEqual('600', result.value)
+
+    def test_freq_khz_modulo_625(self):
+        mem = self._make_memory(freq=462625000)
+        result = apply_template(
+            '{freq_khz%1000:03d}', mem, 0)
+        self.assertEqual('625', result.value)
+
+    def test_arithmetic_with_conditional(self):
+        mem = self._make_memory(
+            freq=462600000, duplex='+')
+        result = apply_template(
+            '{duplex?+=R|G}{freq_khz%1000:03d}',
+            mem, 0)
+        self.assertEqual('R600', result.value)
+
+    def test_num_plus_one(self):
+        mem = self._make_memory(number=5)
+        result = apply_template(
+            'CH{num+1:03d}', mem, 0)
+        self.assertEqual('CH006', result.value)


### PR DESCRIPTION
Add a Bulk Rename dialog, reachable from the memory editor's right-click menu and Edit menu, that renames selected channels from a template. Templates support Memory-field tokens, some derived convenience tokens such as {freq_khz}, sequence counters with offset/step/format ({seq+10/2:03d}), arithmetic operators, and conditional value maps with negation and nested tokens. A live preview shows results before applying. Renaming skips immutable and empty channels and is blocked on read-only or busy radios.