### PR TITLE
uvk5_egzumer: Fix battery_text and mic_bar never being saved

### DIFF
--- a/chirp/drivers/uvk5_egzumer.py
+++ b/chirp/drivers/uvk5_egzumer.py
@@ -656,11 +656,11 @@ class UVK5RadioEgzumer(uvk5.UVK5RadioBase):
                 _mem.AM_fix = element.value
 
             # mic_bar
-            elif elname == "mem.mic_bar":
+            elif elname == "mic_bar":
                 _mem.mic_bar = element.value
 
             # Batterie txt
-            elif elname == "_mem.battery_text":
+            elif elname == "battery_text":
                 _mem.battery_text = element.value
 
             # Tail tone elimination


### PR DESCRIPTION
## Problem

Two settings in the Quansheng UV-K5 *egzumer* driver are accepted in the CHIRP
UI but never written to the radio on upload — they silently revert after a
power cycle:

- **Battery Level Display (BatTXT)** — `battery_text`
- **Mic bar** — `mic_bar`

## Root cause

In `set_settings()`, the `elname` guards for these two settings carry a stray
prefix that doesn't match the name assigned in `get_settings()`, so the
branches never run and the values are dropped:

| setting | `get_settings()` name | `set_settings()` guard |
|---|---|---|
| `battery_text` | `"battery_text"` | `"_mem.battery_text"` |
| `mic_bar` | `"mic_bar"` | `"mem.mic_bar"` |

## Fix

Drop the prefixes so each guard matches its setting name (2 lines).

## Reproduce

1. Download from a UV-K5 (egzumer firmware).
2. Change "Battery Level Display (BatTXT)" (e.g. Voltage → Percentage) and/or "Mic bar".
3. Upload — the radio still shows the old values.

Verified on hardware that `battery_text` persists across a power cycle after the
fix (UV-K5 V1, CHIRP next-20260619). `mic_bar` carries the identical typo and is
corrected the same way.

Fixes #12534

🤖 Generated with [Claude Code](https://claude.com/claude-code)
