### PR TITLE
kenwood_tone: Add BCD processing for Tone & DCS

### DIFF
--- a/chirp/kenwood_tone.py
+++ b/chirp/kenwood_tone.py
@@ -24,31 +24,53 @@ class KenwoodToneModel:
     other radio manufacturers.
 
     Typically CTCSS tones are stored as the frequency in Hertz, multiplied by
-    10, and sometimes with a flag bit set (tone_flag).
+    10, and sometimes with a flag bit set (tone_flag). Some radios store it as
+    a base-10 integer. For example:
+    103.5 Hz * 10 becomes 1035, which is then stored as 0x040B.
 
-    DCS codes are stored either as octal or decimal (dcs_enc_base), with one
-    or more flag bits (dcs_base) set to indicate that it's DCS. Reverse
-    polarity is indicated by another flag bit (pol_mask). Finally, a completely
-    disabled tone/code field is often indicated by 0x0000 or 0xFFFF
-    (tone_init).
+    Other radios store this as a binary-coded decimal (BCD) number, where each
+    decimal digit (0–9) is represented by a fixed 4-bit binary sequence. An
+    equivalent way of thinking of it is storing a number in hexadecimal and
+    ignoring digits A-F. For example:
+    103.5 Hz * 10 becomes 1035, which is then stored as 0x1035.
 
-    Note that this requires your radio's memory structure to have u16 fields
-    named exactly "rxtone" and "txtone".
+    The method of storage depends on numerical base (tone_enc_base) used for
+    encoding and decoding.
+
+    DCS codes are stored as either octal, decimal, or BCD (dcs_enc_base).
+    For example, DCS 031 can be stored as 0x0019 octal, 0x001F decimal, or
+    0x0031 BCD / hexadecimal.
+
+    There can be one or more flag bits (dcs_base) set to indicate that it's
+    DCS. Reverse polarity is indicated by another flag bit (pol_mask).
+    Finally, a completely disabled tone/code field is often indicated by
+    0x0000 or 0xFFFF (tone_init).
+
+    Note that this requires your radio's memory structure to have u16 or ul16
+    fields named exactly "rxtone" and "txtone".
 
     :param dcs_base: Base value for DCS tones (e.g., 0x4000, 0x2800, 0x8000)
     :param pol_mask: Bitmask for polarity (e.g., 0x2000, 0x8000, 0x4000)
     :param tone_init: Initial value for uninitialized tones (0x0000, 0xFFFF)
     :param tone_flag: Flag to indicate a CTCSS tone (0x0000 or 0x8000)
-    :param dcs_enc_base: Numerical base for DCS encoding (8 or 10)
+    :param dcs_enc_base: Numerical base for DCS encoding (8, 10, or 16)
+    :param tone_enc_base: Numerical base for Tone encoding (10 or 16)
     """
+
     def __init__(self, dcs_base, pol_mask, tone_init=0x0000, tone_flag=0x8000,
-                 dcs_enc_base=8):
-        self.dcs_base = dcs_base
-        self.pol_mask = pol_mask
-        self.tone_init = tone_init
-        self.tone_flag = tone_flag
-        assert dcs_enc_base in (8, 10), "DCS encoding base must be 8 or 10"
-        self.dcs_enc_base = dcs_enc_base
+                 dcs_enc_base=8, tone_enc_base=10):
+        self.dcs_base = int(dcs_base)
+        self.pol_mask = int(pol_mask)
+        self.tone_init = int(tone_init)
+        self.tone_flag = int(tone_flag)
+        assert dcs_enc_base in (8, 10, 16), (
+            "DCS encoding base must be 8, 10, or 16"
+        )
+        self.dcs_enc_base = int(dcs_enc_base)
+        assert tone_enc_base in (10, 16), (
+            "Tone encoding base must be 10 or 16"
+        )
+        self.tone_enc_base = int(tone_enc_base)
 
     def _get_tone_val(self, tone_val):
         """
@@ -60,15 +82,21 @@ class KenwoodToneModel:
         if tone_val == 0xFFFF or tone_val == 0x0000:
             return None, None
 
+        code = pol = None
         if (tone_val & self.dcs_base) == self.dcs_base:
             if self.dcs_enc_base == 8:
                 code = int("%03o" % (tone_val & 0x07FF))
             elif self.dcs_enc_base == 10:
                 code = int("%03i" % (tone_val & 0x07FF))
+            elif self.dcs_enc_base == 16:
+                code = int("%03x" % (tone_val & 0x07FF))
             pol = (tone_val & self.pol_mask) and "R" or "N"
-            return code, pol
-
-        return (tone_val & 0x7fff) / 10.0, None
+        else:
+            if self.tone_enc_base == 10:
+                code = (tone_val & 0x7FFF) / 10.0
+            elif self.tone_enc_base == 16:
+                code = float("%04x" % (tone_val & 0x7FFF)) / 10.0
+        return code, pol
 
     def _set_tone_val(self, code, pol):
         """

--- a/chirp/kenwood_tone.py
+++ b/chirp/kenwood_tone.py
@@ -114,8 +114,9 @@ class KenwoodToneModel:
             if pol == "R":
                 val += self.pol_mask
             return val
-
-        return int(code * 10) + self.tone_flag
+        else:
+            freq = int(round(code * 10))
+            return int("%i" % freq, self.tone_enc_base) + self.tone_flag
 
     def set_tone(self, mem, _mem):
         """

--- a/tests/unit/test_kenwood_tone.py
+++ b/tests/unit/test_kenwood_tone.py
@@ -46,172 +46,414 @@ class TestKenwoodToneModelInit(base.BaseTest):
 class TestGetToneVal(base.BaseTest):
     def setUp(self):
         super().setUp()
-        self.model_dec = kenwood_tone.KenwoodToneModel(
+        self.model_8_10 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000)
-        self.model_dcs_bcd = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=16, tone_enc_base=10)
-        self.model_tone_bcd = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=8, tone_enc_base=16)
-
-    def test_get_tone_val_zero(self):
-        code, pol = self.model_dec._get_tone_val(0x0000)
-        self.assertIsNone(code)
-        self.assertIsNone(pol)
-
-    def test_get_tone_val_zero_dcs_bcd(self):
-        code, pol = self.model_dcs_bcd._get_tone_val(0x0000)
-        self.assertIsNone(code)
-        self.assertIsNone(pol)
-
-    def test_get_tone_val_zero_tone_bcd(self):
-        code, pol = self.model_tone_bcd._get_tone_val(0x0000)
-        self.assertIsNone(code)
-        self.assertIsNone(pol)
-
-    def test_get_tone_val_ffff(self):
-        code, pol = self.model_dec._get_tone_val(0xFFFF)
-        self.assertIsNone(code)
-        self.assertIsNone(pol)
-
-    def test_get_tone_val_ffff_dcs_bcd(self):
-        code, pol = self.model_dcs_bcd._get_tone_val(0xFFFF)
-        self.assertIsNone(code)
-        self.assertIsNone(pol)
-
-    def test_get_tone_val_ffff_tone_bcd(self):
-        code, pol = self.model_tone_bcd._get_tone_val(0xFFFF)
-        self.assertIsNone(code)
-        self.assertIsNone(pol)
-
-    def test_get_tone_val_ctcss(self):
-        code, pol = self.model_dec._get_tone_val(885 + 0x8000)
-        self.assertEqual(code, 88.5)
-        self.assertIsNone(pol)
-
-    def test_get_tone_val_ctcss_bcd(self):
-        code, pol = self.model_tone_bcd._get_tone_val(0x0885)
-        self.assertEqual(code, 88.5)
-        self.assertIsNone(pol)
-
-    def test_get_tone_val_ctcss_no_flag(self):
-        model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000, tone_flag=0x0000)
-        code, pol = model._get_tone_val(885)
-        self.assertEqual(code, 88.5)
-        self.assertIsNone(pol)
-
-    def test_get_tone_val_ctcss_no_flag_bcd(self):
-        model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000, tone_flag=0x0000,
-            dcs_enc_base=16, tone_enc_base=16)
-        code, pol = model._get_tone_val(0x0885)
-        self.assertEqual(code, 88.5)
-        self.assertIsNone(pol)
-
-    def test_get_tone_val_dcs_normal_polarity(self):
-        code, pol = self.model_dec._get_tone_val(0x4000 + 0o023)
-        self.assertEqual(code, 23)
-        self.assertEqual(pol, "N")
-
-    def test_get_tone_val_dcs_normal_polarity_bcd(self):
-        code, pol = self.model_dcs_bcd._get_tone_val(0x4000 + 0x023)
-        self.assertEqual(code, 23)
-        self.assertEqual(pol, "N")
-
-    def test_get_tone_val_dcs_reverse_polarity(self):
-        code, pol = self.model_dec._get_tone_val(0x4000 + 0o023 + 0x2000)
-        self.assertEqual(code, 23)
-        self.assertEqual(pol, "R")
-
-    def test_get_tone_val_dcs_reverse_polarity_bcd(self):
-        code, pol = self.model_dcs_bcd._get_tone_val(
-            0x4000 + 0x023 + 0x2000)
-        self.assertEqual(code, 23)
-        self.assertEqual(pol, "R")
-
-    def test_get_tone_val_dcs_decimal_encoding(self):
-        model = kenwood_tone.KenwoodToneModel(
+        self.model_10_10 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000,
             dcs_enc_base=10)
-        code, pol = model._get_tone_val(0x4000 + 23)
-        self.assertEqual(code, 23)
-        self.assertEqual(pol, "N")
-
-    def test_get_tone_val_dcs_decimal_encoding_bcd(self):
-        model = kenwood_tone.KenwoodToneModel(
+        self.model_16_10 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16)
+        self.model_8_16 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            tone_enc_base=16)
+        self.model_10_16 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000,
             dcs_enc_base=10, tone_enc_base=16)
-        code, pol = model._get_tone_val(0x4000 + 23)
+        self.model_16_16 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=16)
+
+    def test_get_tone_val_zero_8_10(self):
+        code, pol = self.model_8_10._get_tone_val(0x0000)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_zero_10_10(self):
+        code, pol = self.model_10_10._get_tone_val(0x0000)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_zero_16_10(self):
+        code, pol = self.model_16_10._get_tone_val(0x0000)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_zero_8_16(self):
+        code, pol = self.model_8_16._get_tone_val(0x0000)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_zero_10_16(self):
+        code, pol = self.model_10_16._get_tone_val(0x0000)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_zero_16_16(self):
+        code, pol = self.model_16_16._get_tone_val(0x0000)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ffff_8_10(self):
+        code, pol = self.model_8_10._get_tone_val(0xFFFF)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ffff_10_10(self):
+        code, pol = self.model_10_10._get_tone_val(0xFFFF)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ffff_16_10(self):
+        code, pol = self.model_16_10._get_tone_val(0xFFFF)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ffff_8_16(self):
+        code, pol = self.model_8_16._get_tone_val(0xFFFF)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ffff_10_16(self):
+        code, pol = self.model_10_16._get_tone_val(0xFFFF)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ffff_16_16(self):
+        code, pol = self.model_16_16._get_tone_val(0xFFFF)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_8_10(self):
+        code, pol = self.model_8_10._get_tone_val(885 + 0x8000)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_10_10(self):
+        code, pol = self.model_10_10._get_tone_val(885 + 0x8000)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_16_10(self):
+        code, pol = self.model_16_10._get_tone_val(885 + 0x8000)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_8_16(self):
+        code, pol = self.model_8_16._get_tone_val(0x0885)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_10_16(self):
+        code, pol = self.model_10_16._get_tone_val(0x0885)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_16_16(self):
+        code, pol = self.model_16_16._get_tone_val(0x0885)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_no_flag_8_10(self):
+        code, pol = self.model_8_10._get_tone_val(885)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_no_flag_10_10(self):
+        code, pol = self.model_10_10._get_tone_val(885)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_no_flag_16_10(self):
+        code, pol = self.model_16_10._get_tone_val(885)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_no_flag_8_16(self):
+        code, pol = self.model_8_16._get_tone_val(0x0885)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_no_flag_10_16(self):
+        code, pol = self.model_10_16._get_tone_val(0x0885)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_no_flag_16_16(self):
+        code, pol = self.model_16_16._get_tone_val(0x0885)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_dcs_normal_polarity_8_10(self):
+        code, pol = self.model_8_10._get_tone_val(0x4000 + 0o023)
         self.assertEqual(code, 23)
         self.assertEqual(pol, "N")
 
-    def test_get_tone_val_dcs_bcd_encoding(self):
-        model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=16)
-        code, pol = model._get_tone_val(0x4023)
+    def test_get_tone_val_dcs_normal_polarity_10_10(self):
+        code, pol = self.model_10_10._get_tone_val(0x4000 + 23)
         self.assertEqual(code, 23)
         self.assertEqual(pol, "N")
 
-    def test_get_tone_val_dcs_bcd_encoding_bcd(self):
-        model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=16)
-        code, pol = model._get_tone_val(0x4023)
+    def test_get_tone_val_dcs_normal_polarity_16_10(self):
+        code, pol = self.model_16_10._get_tone_val(0x4000 + 0x023)
         self.assertEqual(code, 23)
         self.assertEqual(pol, "N")
 
-    def test_get_tone_val_dcs_octal_encoding_large_code(self):
-        code, pol = self.model_dec._get_tone_val(0x4000 + 0o125)
-        self.assertEqual(code, 125)
+    def test_get_tone_val_dcs_normal_polarity_8_16(self):
+        code, pol = self.model_8_16._get_tone_val(0x4000 + 0o023)
+        self.assertEqual(code, 23)
         self.assertEqual(pol, "N")
 
-    def test_get_tone_val_dcs_octal_encoding_large_code_bcd(self):
-        code, pol = self.model_tone_bcd._get_tone_val(0x4000 + 0o125)
-        self.assertEqual(code, 125)
+    def test_get_tone_val_dcs_normal_polarity_10_16(self):
+        code, pol = self.model_10_16._get_tone_val(0x4000 + 23)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_normal_polarity_16_16(self):
+        code, pol = self.model_16_16._get_tone_val(0x4000 + 0x023)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_reverse_polarity_8_10(self):
+        code, pol = self.model_8_10._get_tone_val(0x4000 + 0o023 + 0x2000)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "R")
+
+    def test_get_tone_val_dcs_reverse_polarity_10_10(self):
+        code, pol = self.model_10_10._get_tone_val(0x4000 + 23 + 0x2000)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "R")
+
+    def test_get_tone_val_dcs_reverse_polarity_16_10(self):
+        code, pol = self.model_16_10._get_tone_val(0x4000 + 0x023 + 0x2000)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "R")
+
+    def test_get_tone_val_dcs_reverse_polarity_8_16(self):
+        code, pol = self.model_8_16._get_tone_val(0x4000 + 0o023 + 0x2000)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "R")
+
+    def test_get_tone_val_dcs_reverse_polarity_10_16(self):
+        code, pol = self.model_10_16._get_tone_val(0x4000 + 23 + 0x2000)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "R")
+
+    def test_get_tone_val_dcs_reverse_polarity_16_16(self):
+        code, pol = self.model_16_16._get_tone_val(0x4000 + 0x023 + 0x2000)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "R")
+
+    def test_get_tone_val_dcs_octal_encoding_large_code_8_10(self):
+        code, pol = self.model_8_10._get_tone_val(0x4000 + 0o754)
+        self.assertEqual(code, 754)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_octal_encoding_large_code_10_10(self):
+        code, pol = self.model_10_10._get_tone_val(0x4000 + 754)
+        self.assertEqual(code, 754)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_octal_encoding_large_code_16_10(self):
+        code, pol = self.model_16_10._get_tone_val(0x4000 + 0x754)
+        self.assertEqual(code, 754)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_octal_encoding_large_code_8_16(self):
+        code, pol = self.model_8_16._get_tone_val(0x4000 + 0o754)
+        self.assertEqual(code, 754)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_octal_encoding_large_code_10_16(self):
+        code, pol = self.model_10_16._get_tone_val(0x4000 + 754)
+        self.assertEqual(code, 754)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_octal_encoding_large_code_16_16(self):
+        code, pol = self.model_16_16._get_tone_val(0x4000 + 0x754)
+        self.assertEqual(code, 754)
         self.assertEqual(pol, "N")
 
 
 class TestSetToneVal(base.BaseTest):
     def setUp(self):
         super().setUp()
-        self.model = kenwood_tone.KenwoodToneModel(
+        self.model_8_10 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000)
+        self.model_10_10 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10)
+        self.model_16_10 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16)
+        self.model_8_16 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            tone_enc_base=16)
+        self.model_10_16 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10, tone_enc_base=16)
+        self.model_16_16 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=16)
 
-    def test_set_tone_val_none(self):
-        val = self.model._set_tone_val(None, None)
+    def test_set_tone_val_none_8_10(self):
+        val = self.model_8_10._set_tone_val(None, None)
         self.assertEqual(val, 0x0000)
 
-    def test_set_tone_val_ctcss(self):
-        val = self.model._set_tone_val(88.5, None)
+    def test_set_tone_val_none_10_10(self):
+        val = self.model_10_10._set_tone_val(None, None)
+        self.assertEqual(val, 0x0000)
+
+    def test_set_tone_val_none_16_10(self):
+        val = self.model_16_10._set_tone_val(None, None)
+        self.assertEqual(val, 0x0000)
+
+    def test_set_tone_val_none_8_16(self):
+        val = self.model_8_16._set_tone_val(None, None)
+        self.assertEqual(val, 0x0000)
+
+    def test_set_tone_val_none_10_16(self):
+        val = self.model_10_16._set_tone_val(None, None)
+        self.assertEqual(val, 0x0000)
+
+    def test_set_tone_val_none_16_16(self):
+        val = self.model_16_16._set_tone_val(None, None)
+        self.assertEqual(val, 0x0000)
+
+    def test_set_tone_val_ctcss_8_10(self):
+        val = self.model_8_10._set_tone_val(88.5, None)
         self.assertEqual(val, 885 + 0x8000)
 
-    def test_set_tone_val_ctcss_no_flag(self):
+    def test_set_tone_val_ctcss_10_10(self):
+        val = self.model_10_10._set_tone_val(88.5, None)
+        self.assertEqual(val, 885 + 0x8000)
+
+    def test_set_tone_val_ctcss_16_10(self):
+        val = self.model_16_10._set_tone_val(88.5, None)
+        self.assertEqual(val, 885 + 0x8000)
+
+    def test_set_tone_val_ctcss_8_16(self):
+        val = self.model_8_16._set_tone_val(88.5, None)
+        self.assertEqual(val, 0x8885)
+
+    def test_set_tone_val_ctcss_10_16(self):
+        val = self.model_10_16._set_tone_val(88.5, None)
+        self.assertEqual(val, 0x8885)
+
+    def test_set_tone_val_ctcss_16_16(self):
+        val = self.model_16_16._set_tone_val(88.5, None)
+        self.assertEqual(val, 0x8885)
+
+    def test_set_tone_val_ctcss_no_flag_8_10(self):
         model = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000, tone_flag=0x0000)
         val = model._set_tone_val(88.5, None)
         self.assertEqual(val, 885)
 
-    def test_set_tone_val_dcs_normal(self):
-        val = self.model._set_tone_val(23, "N")
+    def test_set_tone_val_ctcss_no_flag_10_10(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_flag=0x0000,
+            dcs_enc_base=10)
+        val = model._set_tone_val(88.5, None)
+        self.assertEqual(val, 885)
+
+    def test_set_tone_val_ctcss_no_flag_16_10(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_flag=0x0000,
+            dcs_enc_base=16)
+        val = model._set_tone_val(88.5, None)
+        self.assertEqual(val, 885)
+
+    def test_set_tone_val_ctcss_no_flag_8_16(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_flag=0x0000,
+            tone_enc_base=16)
+        val = model._set_tone_val(88.5, None)
+        self.assertEqual(val, 0x0885)
+
+    def test_set_tone_val_ctcss_no_flag_10_16(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_flag=0x0000,
+            dcs_enc_base=10, tone_enc_base=16)
+        val = model._set_tone_val(88.5, None)
+        self.assertEqual(val, 0x0885)
+
+    def test_set_tone_val_ctcss_no_flag_16_16(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_flag=0x0000,
+            dcs_enc_base=16, tone_enc_base=16)
+        val = model._set_tone_val(88.5, None)
+        self.assertEqual(val, 0x0885)
+
+    def test_set_tone_val_dcs_normal_8_10(self):
+        val = self.model_8_10._set_tone_val(23, "N")
         self.assertEqual(val, 0x4000 + 0o023)
 
-    def test_set_tone_val_dcs_reverse(self):
-        val = self.model._set_tone_val(23, "R")
+    def test_set_tone_val_dcs_normal_10_10(self):
+        val = self.model_10_10._set_tone_val(23, "N")
+        self.assertEqual(val, 0x4000 + 23)
+
+    def test_set_tone_val_dcs_normal_16_10(self):
+        val = self.model_16_10._set_tone_val(23, "N")
+        self.assertEqual(val, 0x4000 + 0x023)
+
+    def test_set_tone_val_dcs_normal_8_16(self):
+        val = self.model_8_16._set_tone_val(23, "N")
+        self.assertEqual(val, 0x4000 + 0o023)
+
+    def test_set_tone_val_dcs_normal_10_16(self):
+        val = self.model_10_16._set_tone_val(23, "N")
+        self.assertEqual(val, 0x4000 + 23)
+
+    def test_set_tone_val_dcs_normal_16_16(self):
+        val = self.model_16_16._set_tone_val(23, "N")
+        self.assertEqual(val, 0x4000 + 0x023)
+
+    def test_set_tone_val_dcs_reverse_8_10(self):
+        val = self.model_8_10._set_tone_val(23, "R")
         self.assertEqual(val, 0x4000 + 0o023 + 0x2000)
 
-    def test_set_tone_val_dcs_decimal_encoding(self):
-        model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=10)
-        val = model._set_tone_val(23, "N")
-        self.assertEqual(val, 0x4000 + 23)
+    def test_set_tone_val_dcs_reverse_10_10(self):
+        val = self.model_10_10._set_tone_val(23, "R")
+        self.assertEqual(val, 0x4000 + 23 + 0x2000)
+
+    def test_set_tone_val_dcs_reverse_16_10(self):
+        val = self.model_16_10._set_tone_val(23, "R")
+        self.assertEqual(val, 0x4000 + 0x023 + 0x2000)
+
+    def test_set_tone_val_dcs_reverse_8_16(self):
+        val = self.model_8_16._set_tone_val(23, "R")
+        self.assertEqual(val, 0x4000 + 0o023 + 0x2000)
+
+    def test_set_tone_val_dcs_reverse_10_16(self):
+        val = self.model_10_16._set_tone_val(23, "R")
+        self.assertEqual(val, 0x4000 + 23 + 0x2000)
+
+    def test_set_tone_val_dcs_reverse_16_16(self):
+        val = self.model_16_16._set_tone_val(23, "R")
+        self.assertEqual(val, 0x4000 + 0x023 + 0x2000)
 
 
 class TestSetTone(base.BaseTest):
     def setUp(self):
         super().setUp()
-        self.model = kenwood_tone.KenwoodToneModel(
+        self.model_8_10 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000)
+        self.model_10_10 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10)
+        self.model_16_10 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16)
+        self.model_8_16 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            tone_enc_base=16)
+        self.model_10_16 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10, tone_enc_base=16)
+        self.model_16_16 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=16)
 
     def _make_mem(self, **kwargs):
         mem = chirp_common.Memory()
@@ -219,95 +461,576 @@ class TestSetTone(base.BaseTest):
             setattr(mem, key, value)
         return mem
 
-    def test_set_tone_empty(self):
+    def test_set_tone_empty_8_10(self):
         mem = self._make_mem(tmode="")
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.rxtone, 0x0000)
         self.assertEqual(_mem.txtone, 0x0000)
 
-    def test_set_tone_tone_mode(self):
+    def test_set_tone_empty_10_10(self):
+        mem = self._make_mem(tmode="")
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.rxtone, 0x0000)
+        self.assertEqual(_mem.txtone, 0x0000)
+
+    def test_set_tone_empty_16_10(self):
+        mem = self._make_mem(tmode="")
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.rxtone, 0x0000)
+        self.assertEqual(_mem.txtone, 0x0000)
+
+    def test_set_tone_empty_8_16(self):
+        mem = self._make_mem(tmode="")
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.rxtone, 0x0000)
+        self.assertEqual(_mem.txtone, 0x0000)
+
+    def test_set_tone_empty_10_16(self):
+        mem = self._make_mem(tmode="")
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.rxtone, 0x0000)
+        self.assertEqual(_mem.txtone, 0x0000)
+
+    def test_set_tone_empty_16_16(self):
+        mem = self._make_mem(tmode="")
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.rxtone, 0x0000)
+        self.assertEqual(_mem.txtone, 0x0000)
+
+    def test_set_tone_tone_mode_8_10(self):
         mem = self._make_mem(tmode="Tone", rtone=100.0)
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.txtone, int(100.0 * 10) + 0x8000)
         self.assertEqual(_mem.rxtone, 0x0000)
 
-    def test_set_tone_tsql_mode(self):
+    def test_set_tone_tone_mode_10_10(self):
+        mem = self._make_mem(tmode="Tone", rtone=100.0)
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, int(100.0 * 10) + 0x8000)
+        self.assertEqual(_mem.rxtone, 0x0000)
+
+    def test_set_tone_tone_mode_16_10(self):
+        mem = self._make_mem(tmode="Tone", rtone=100.0)
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, int(100.0 * 10) + 0x8000)
+        self.assertEqual(_mem.rxtone, 0x0000)
+
+    def test_set_tone_tone_mode_8_16(self):
+        mem = self._make_mem(tmode="Tone", rtone=100.0)
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9000)
+        self.assertEqual(_mem.rxtone, 0x0000)
+
+    def test_set_tone_tone_mode_10_16(self):
+        mem = self._make_mem(tmode="Tone", rtone=100.0)
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9000)
+        self.assertEqual(_mem.rxtone, 0x0000)
+
+    def test_set_tone_tone_mode_16_16(self):
+        mem = self._make_mem(tmode="Tone", rtone=100.0)
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9000)
+        self.assertEqual(_mem.rxtone, 0x0000)
+
+    def test_set_tone_tsql_mode_8_10(self):
         mem = self._make_mem(tmode="TSQL", ctone=107.2)
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.txtone, int(107.2 * 10) + 0x8000)
         self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
 
-    def test_set_tone_dtcs_mode(self):
+    def test_set_tone_tsql_mode_10_10(self):
+        mem = self._make_mem(tmode="TSQL", ctone=107.2)
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, int(107.2 * 10) + 0x8000)
+        self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
+
+    def test_set_tone_tsql_mode_16_10(self):
+        mem = self._make_mem(tmode="TSQL", ctone=107.2)
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, int(107.2 * 10) + 0x8000)
+        self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
+
+    def test_set_tone_tsql_mode_8_16(self):
+        mem = self._make_mem(tmode="TSQL", ctone=107.2)
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9072)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_tsql_mode_10_16(self):
+        mem = self._make_mem(tmode="TSQL", ctone=107.2)
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9072)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_tsql_mode_16_16(self):
+        mem = self._make_mem(tmode="TSQL", ctone=107.2)
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9072)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_dtcs_mode_8_10(self):
         mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NR")
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.txtone, 0x4000 + 0o023)
         self.assertEqual(_mem.rxtone, 0x4000 + 0o023 + 0x2000)
 
-    def test_set_tone_dtcs_mode_nn(self):
+    def test_set_tone_dtcs_mode_10_10(self):
+        mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NR")
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 23)
+        self.assertEqual(_mem.rxtone, 0x4000 + 23 + 0x2000)
+
+    def test_set_tone_dtcs_mode_16_10(self):
+        mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NR")
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0x023)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0x023 + 0x2000)
+
+    def test_set_tone_dtcs_mode_8_16(self):
+        mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NR")
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0o023)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0o023 + 0x2000)
+
+    def test_set_tone_dtcs_mode_10_16(self):
+        mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NR")
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 23)
+        self.assertEqual(_mem.rxtone, 0x4000 + 23 + 0x2000)
+
+    def test_set_tone_dtcs_mode_16_16(self):
+        mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NR")
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0x023)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0x023 + 0x2000)
+
+    def test_set_tone_dtcs_mode_nn_8_10(self):
         mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NN")
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.txtone, 0x4000 + 0o023)
         self.assertEqual(_mem.rxtone, 0x4000 + 0o023)
 
-    def test_set_tone_cross_tone_tone(self):
+    def test_set_tone_dtcs_mode_nn_10_10(self):
+        mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 23)
+        self.assertEqual(_mem.rxtone, 0x4000 + 23)
+
+    def test_set_tone_dtcs_mode_nn_16_10(self):
+        mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0x023)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0x023)
+
+    def test_set_tone_dtcs_mode_nn_8_16(self):
+        mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0o023)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0o023)
+
+    def test_set_tone_dtcs_mode_nn_10_16(self):
+        mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 23)
+        self.assertEqual(_mem.rxtone, 0x4000 + 23)
+
+    def test_set_tone_dtcs_mode_nn_16_16(self):
+        mem = self._make_mem(tmode="DTCS", dtcs=23, dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0x023)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0x023)
+
+    def test_set_tone_cross_tone_tone_8_10(self):
         mem = self._make_mem(tmode="Cross", cross_mode="Tone->Tone",
                              rtone=100.0, ctone=107.2)
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.txtone, int(100.0 * 10) + 0x8000)
         self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
 
-    def test_set_tone_cross_tone_dtcs(self):
+    def test_set_tone_cross_tone_tone_10_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="Tone->Tone",
+                             rtone=100.0, ctone=107.2)
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, int(100.0 * 10) + 0x8000)
+        self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
+
+    def test_set_tone_cross_tone_tone_16_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="Tone->Tone",
+                             rtone=100.0, ctone=107.2)
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, int(100.0 * 10) + 0x8000)
+        self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
+
+    def test_set_tone_cross_tone_tone_8_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="Tone->Tone",
+                             rtone=100.0, ctone=107.2)
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9000)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_cross_tone_tone_10_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="Tone->Tone",
+                             rtone=100.0, ctone=107.2)
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9000)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_cross_tone_tone_16_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="Tone->Tone",
+                             rtone=100.0, ctone=107.2)
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9000)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_cross_tone_dtcs_8_10(self):
         mem = self._make_mem(tmode="Cross", cross_mode="Tone->DTCS",
                              rtone=100.0, rx_dtcs=25,
                              dtcs_polarity="NN")
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.txtone, int(100.0 * 10) + 0x8000)
         self.assertEqual(_mem.rxtone, 0x4000 + 0o025)
 
-    def test_set_tone_cross_dtcs_tone(self):
+    def test_set_tone_cross_tone_dtcs_10_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="Tone->DTCS",
+                             rtone=100.0, rx_dtcs=25,
+                             dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, int(100.0 * 10) + 0x8000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 25)
+
+    def test_set_tone_cross_tone_dtcs_16_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="Tone->DTCS",
+                             rtone=100.0, rx_dtcs=25,
+                             dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, int(100.0 * 10) + 0x8000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0x025)
+
+    def test_set_tone_cross_tone_dtcs_8_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="Tone->DTCS",
+                             rtone=100.0, rx_dtcs=25,
+                             dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0o025)
+
+    def test_set_tone_cross_tone_dtcs_10_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="Tone->DTCS",
+                             rtone=100.0, rx_dtcs=25,
+                             dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 25)
+
+    def test_set_tone_cross_tone_dtcs_16_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="Tone->DTCS",
+                             rtone=100.0, rx_dtcs=25,
+                             dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x9000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0x025)
+
+    def test_set_tone_cross_dtcs_tone_8_10(self):
         mem = self._make_mem(tmode="Cross", cross_mode="DTCS->Tone",
                              dtcs=23, ctone=107.2,
                              dtcs_polarity="NN")
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.txtone, 0x4000 + 0o023)
         self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
 
-    def test_set_tone_cross_dtcs_dtcs(self):
+    def test_set_tone_cross_dtcs_tone_10_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="DTCS->Tone",
+                             dtcs=23, ctone=107.2,
+                             dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 23)
+        self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
+
+    def test_set_tone_cross_dtcs_tone_16_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="DTCS->Tone",
+                             dtcs=23, ctone=107.2,
+                             dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0x023)
+        self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
+
+    def test_set_tone_cross_dtcs_tone_8_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="DTCS->Tone",
+                             dtcs=23, ctone=107.2,
+                             dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0o023)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_cross_dtcs_tone_10_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="DTCS->Tone",
+                             dtcs=23, ctone=107.2,
+                             dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 23)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_cross_dtcs_tone_16_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="DTCS->Tone",
+                             dtcs=23, ctone=107.2,
+                             dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0x023)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_cross_dtcs_dtcs_8_10(self):
         mem = self._make_mem(tmode="Cross", cross_mode="DTCS->DTCS",
                              dtcs=23, rx_dtcs=25,
                              dtcs_polarity="RN")
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.txtone, 0x4000 + 0o023 + 0x2000)
         self.assertEqual(_mem.rxtone, 0x4000 + 0o025)
 
-    def test_set_tone_cross_none_tone(self):
+    def test_set_tone_cross_dtcs_dtcs_10_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="DTCS->DTCS",
+                             dtcs=23, rx_dtcs=25,
+                             dtcs_polarity="RN")
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 23 + 0x2000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 25)
+
+    def test_set_tone_cross_dtcs_dtcs_16_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="DTCS->DTCS",
+                             dtcs=23, rx_dtcs=25,
+                             dtcs_polarity="RN")
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0x023 + 0x2000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0x025)
+
+    # Show that the tone_bcd flag doesn't interfere with DCS parsing.
+    def test_set_tone_cross_dtcs_dtcs_8_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="DTCS->DTCS",
+                             dtcs=23, rx_dtcs=25,
+                             dtcs_polarity="RN")
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0o023 + 0x2000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0o025)
+
+    def test_set_tone_cross_dtcs_dtcs_10_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="DTCS->DTCS",
+                             dtcs=23, rx_dtcs=25,
+                             dtcs_polarity="RN")
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 23 + 0x2000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 25)
+
+    def test_set_tone_cross_dtcs_dtcs_16_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="DTCS->DTCS",
+                             dtcs=23, rx_dtcs=25,
+                             dtcs_polarity="RN")
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x4000 + 0x023 + 0x2000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0x025)
+
+    def test_set_tone_cross_none_tone_8_10(self):
         mem = self._make_mem(tmode="Cross", cross_mode="->Tone",
                              ctone=107.2)
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.txtone, 0x0000)
         self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
 
-    def test_set_tone_cross_none_dtcs(self):
+    def test_set_tone_cross_none_tone_10_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="->Tone",
+                             ctone=107.2)
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x0000)
+        self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
+
+    def test_set_tone_cross_none_tone_16_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="->Tone",
+                             ctone=107.2)
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x0000)
+        self.assertEqual(_mem.rxtone, int(107.2 * 10) + 0x8000)
+
+    def test_set_tone_cross_none_tone_8_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="->Tone",
+                             ctone=107.2)
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x0000)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_cross_none_tone_10_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="->Tone",
+                             ctone=107.2)
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x0000)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_cross_none_tone_16_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="->Tone",
+                             ctone=107.2)
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x0000)
+        self.assertEqual(_mem.rxtone, 0x9072)
+
+    def test_set_tone_cross_none_dtcs_8_10(self):
         mem = self._make_mem(tmode="Cross", cross_mode="->DTCS",
                              rx_dtcs=25, dtcs_polarity="NN")
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         self.assertEqual(_mem.txtone, 0x0000)
         self.assertEqual(_mem.rxtone, 0x4000 + 0o025)
 
-    def test_set_tone_with_tone_init_ffff(self):
+    def test_set_tone_cross_none_dtcs_10_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="->DTCS",
+                             rx_dtcs=25, dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x0000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 25)
+
+    def test_set_tone_cross_none_dtcs_16_10(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="->DTCS",
+                             rx_dtcs=25, dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x0000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0x025)
+
+    def test_set_tone_cross_none_dtcs_8_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="->DTCS",
+                             rx_dtcs=25, dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x0000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0o025)
+
+    def test_set_tone_cross_none_dtcs_10_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="->DTCS",
+                             rx_dtcs=25, dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x0000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 25)
+
+    def test_set_tone_cross_none_dtcs_16_16(self):
+        mem = self._make_mem(tmode="Cross", cross_mode="->DTCS",
+                             rx_dtcs=25, dtcs_polarity="NN")
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        self.assertEqual(_mem.txtone, 0x0000)
+        self.assertEqual(_mem.rxtone, 0x4000 + 0x025)
+
+    def test_set_tone_with_tone_init_ffff_8_10(self):
         model = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000, tone_init=0xFFFF)
+        mem = self._make_mem(tmode="")
+        _mem = MockMemory()
+        model.set_tone(mem, _mem)
+        self.assertEqual(_mem.rxtone, 0xFFFF)
+        self.assertEqual(_mem.txtone, 0xFFFF)
+
+    def test_set_tone_with_tone_init_ffff_10_10(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_init=0xFFFF,
+            dcs_enc_base=10)
+        mem = self._make_mem(tmode="")
+        _mem = MockMemory()
+        model.set_tone(mem, _mem)
+        self.assertEqual(_mem.rxtone, 0xFFFF)
+        self.assertEqual(_mem.txtone, 0xFFFF)
+
+    def test_set_tone_with_tone_init_ffff_16_10(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_init=0xFFFF,
+            dcs_enc_base=16)
+        mem = self._make_mem(tmode="")
+        _mem = MockMemory()
+        model.set_tone(mem, _mem)
+        self.assertEqual(_mem.rxtone, 0xFFFF)
+        self.assertEqual(_mem.txtone, 0xFFFF)
+
+    def test_set_tone_with_tone_init_ffff_8_16(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_init=0xFFFF,
+            tone_enc_base=16)
+        mem = self._make_mem(tmode="")
+        _mem = MockMemory()
+        model.set_tone(mem, _mem)
+        self.assertEqual(_mem.rxtone, 0xFFFF)
+        self.assertEqual(_mem.txtone, 0xFFFF)
+
+    def test_set_tone_with_tone_init_ffff_10_16(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_init=0xFFFF,
+            dcs_enc_base=10, tone_enc_base=16)
+        mem = self._make_mem(tmode="")
+        _mem = MockMemory()
+        model.set_tone(mem, _mem)
+        self.assertEqual(_mem.rxtone, 0xFFFF)
+        self.assertEqual(_mem.txtone, 0xFFFF)
+
+    def test_set_tone_with_tone_init_ffff_16_16(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_init=0xFFFF,
+            dcs_enc_base=16, tone_enc_base=16)
         mem = self._make_mem(tmode="")
         _mem = MockMemory()
         model.set_tone(mem, _mem)
@@ -318,245 +1041,596 @@ class TestSetTone(base.BaseTest):
 class TestGetTone(base.BaseTest):
     def setUp(self):
         super().setUp()
-
-    def test_get_tone_empty(self):
-        self.model = kenwood_tone.KenwoodToneModel(
+        self.model_8_10 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000)
-        _mem = MockMemory()
-        mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
-        self.assertEqual(mem.tmode, "")
-
-    def test_get_tone_empty_bcd(self):
-        self.model = kenwood_tone.KenwoodToneModel(
+        self.model_10_10 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10)
+        self.model_16_10 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16)
+        self.model_8_16 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            tone_enc_base=16)
+        self.model_10_16 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10, tone_enc_base=16)
+        self.model_16_16 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000,
             dcs_enc_base=16, tone_enc_base=16)
+
+    def test_get_tone_empty_8_10(self):
         _mem = MockMemory()
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "")
 
-    def test_get_tone_tone_mode(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
+    def test_get_tone_empty_10_10(self):
+        _mem = MockMemory()
+        mem = chirp_common.Memory()
+        self.model_10_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "")
+
+    def test_get_tone_empty_16_10(self):
+        _mem = MockMemory()
+        mem = chirp_common.Memory()
+        self.model_16_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "")
+
+    def test_get_tone_empty_8_16(self):
+        _mem = MockMemory()
+        mem = chirp_common.Memory()
+        self.model_8_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "")
+
+    def test_get_tone_empty_10_16(self):
+        _mem = MockMemory()
+        mem = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "")
+
+    def test_get_tone_empty_16_16(self):
+        _mem = MockMemory()
+        mem = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "")
+
+    def test_get_tone_tone_mode_8_10(self):
         _mem = MockMemory()
         _mem.txtone = int(100.0 * 10) + 0x8000
         _mem.rxtone = 0x0000
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Tone")
         self.assertEqual(mem.rtone, 100.0)
 
-    def test_get_tone_tone_mode_bcd(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=16, tone_enc_base=16)
+    def test_get_tone_tone_mode_10_10(self):
+        _mem = MockMemory()
+        _mem.txtone = int(100.0 * 10) + 0x8000
+        _mem.rxtone = 0x0000
+        mem = chirp_common.Memory()
+        self.model_10_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Tone")
+        self.assertEqual(mem.rtone, 100.0)
+
+    def test_get_tone_tone_mode_16_10(self):
+        _mem = MockMemory()
+        _mem.txtone = int(100.0 * 10) + 0x8000
+        _mem.rxtone = 0x0000
+        mem = chirp_common.Memory()
+        self.model_16_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Tone")
+        self.assertEqual(mem.rtone, 100.0)
+
+    def test_get_tone_tone_mode_8_16(self):
         _mem = MockMemory()
         _mem.txtone = 0x9000
         _mem.rxtone = 0x0000
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_16.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Tone")
         self.assertEqual(mem.rtone, 100.0)
 
-    def test_get_tone_tsql_mode(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
+    def test_get_tone_tone_mode_10_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x9000
+        _mem.rxtone = 0x0000
+        mem = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Tone")
+        self.assertEqual(mem.rtone, 100.0)
+
+    def test_get_tone_tone_mode_16_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x9000
+        _mem.rxtone = 0x0000
+        mem = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Tone")
+        self.assertEqual(mem.rtone, 100.0)
+
+    def test_get_tone_tsql_mode_8_10(self):
         _mem = MockMemory()
         _mem.txtone = int(107.2 * 10) + 0x8000
         _mem.rxtone = int(107.2 * 10) + 0x8000
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "TSQL")
         self.assertEqual(mem.ctone, 107.2)
 
-    def test_get_tone_tsql_mode_bcd(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=16, tone_enc_base=16)
+    def test_get_tone_tsql_mode_10_10(self):
+        _mem = MockMemory()
+        _mem.txtone = int(107.2 * 10) + 0x8000
+        _mem.rxtone = int(107.2 * 10) + 0x8000
+        mem = chirp_common.Memory()
+        self.model_10_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "TSQL")
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_tsql_mode_16_10(self):
+        _mem = MockMemory()
+        _mem.txtone = int(107.2 * 10) + 0x8000
+        _mem.rxtone = int(107.2 * 10) + 0x8000
+        mem = chirp_common.Memory()
+        self.model_16_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "TSQL")
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_tsql_mode_8_16(self):
         _mem = MockMemory()
         _mem.txtone = 0x9072
         _mem.rxtone = 0x9072
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_16.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "TSQL")
         self.assertEqual(mem.ctone, 107.2)
 
-    def test_get_tone_dtcs_mode(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
+    def test_get_tone_tsql_mode_10_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x9072
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "TSQL")
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_tsql_mode_16_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x9072
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "TSQL")
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_dtcs_mode_8_10(self):
         _mem = MockMemory()
         _mem.txtone = 0x4000 + 0o023
         _mem.rxtone = 0x4000 + 0o023
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "DTCS")
         self.assertEqual(mem.dtcs, 23)
         self.assertEqual(mem.dtcs_polarity, "NN")
 
-    def test_get_tone_dtcs_mode_bcd(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=8, tone_enc_base=16)
+    def test_get_tone_dtcs_mode_10_10(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 23
+        _mem.rxtone = 0x4000 + 23
+        mem = chirp_common.Memory()
+        self.model_10_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "DTCS")
+        self.assertEqual(mem.dtcs, 23)
+        self.assertEqual(mem.dtcs_polarity, "NN")
+
+    def test_get_tone_dtcs_mode_16_10(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 0x023
+        _mem.rxtone = 0x4000 + 0x023
+        mem = chirp_common.Memory()
+        self.model_16_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "DTCS")
+        self.assertEqual(mem.dtcs, 23)
+        self.assertEqual(mem.dtcs_polarity, "NN")
+
+    def test_get_tone_dtcs_mode_8_16(self):
         _mem = MockMemory()
         _mem.txtone = 0x4000 + 0o023
         _mem.rxtone = 0x4000 + 0o023
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_16.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "DTCS")
         self.assertEqual(mem.dtcs, 23)
         self.assertEqual(mem.dtcs_polarity, "NN")
 
-    def test_get_tone_dtcs_with_polarity(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
+    def test_get_tone_dtcs_mode_10_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 23
+        _mem.rxtone = 0x4000 + 23
+        mem = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "DTCS")
+        self.assertEqual(mem.dtcs, 23)
+        self.assertEqual(mem.dtcs_polarity, "NN")
+
+    def test_get_tone_dtcs_mode_16_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 0x023
+        _mem.rxtone = 0x4000 + 0x023
+        mem = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "DTCS")
+        self.assertEqual(mem.dtcs, 23)
+        self.assertEqual(mem.dtcs_polarity, "NN")
+
+    def test_get_tone_dtcs_with_polarity_8_10(self):
         _mem = MockMemory()
         _mem.txtone = 0x4000 + 0o023 + 0x2000
         _mem.rxtone = 0x4000 + 0o023
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "DTCS")
         self.assertEqual(mem.dtcs_polarity, "RN")
 
-    def test_get_tone_dtcs_with_polarity_bcd(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=16, tone_enc_base=16)
+    def test_get_tone_dtcs_with_polarity_10_10(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 23 + 0x2000
+        _mem.rxtone = 0x4000 + 23
+        mem = chirp_common.Memory()
+        self.model_8_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "DTCS")
+        self.assertEqual(mem.dtcs_polarity, "RN")
+
+    def test_get_tone_dtcs_with_polarity_16_10(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 0x023 + 0x2000
+        _mem.rxtone = 0x4000 + 0x023
+        mem = chirp_common.Memory()
+        self.model_8_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "DTCS")
+        self.assertEqual(mem.dtcs_polarity, "RN")
+
+    def test_get_tone_dtcs_with_polarity_8_16(self):
         _mem = MockMemory()
         _mem.txtone = 0x4000 + 0o023 + 0x2000
         _mem.rxtone = 0x4000 + 0o023
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_16.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "DTCS")
         self.assertEqual(mem.dtcs_polarity, "RN")
 
-    def test_get_tone_cross_tone_tone(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
+    def test_get_tone_dtcs_with_polarity_10_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 23 + 0x2000
+        _mem.rxtone = 0x4000 + 23
+        mem = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "DTCS")
+        self.assertEqual(mem.dtcs_polarity, "RN")
+
+    def test_get_tone_dtcs_with_polarity_16_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 0x023 + 0x2000
+        _mem.rxtone = 0x4000 + 0x023
+        mem = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "DTCS")
+        self.assertEqual(mem.dtcs_polarity, "RN")
+
+    def test_get_tone_cross_tone_tone_8_10(self):
         _mem = MockMemory()
         _mem.txtone = int(100.0 * 10) + 0x8000
         _mem.rxtone = int(107.2 * 10) + 0x8000
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Cross")
         self.assertEqual(mem.cross_mode, "Tone->Tone")
         self.assertEqual(mem.rtone, 100.0)
         self.assertEqual(mem.ctone, 107.2)
 
-    def test_get_tone_cross_tone_tone_bcd(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=16, tone_enc_base=16)
+    def test_get_tone_cross_tone_tone_10_10(self):
         _mem = MockMemory()
-        _mem.txtone = 0x9000
-        _mem.rxtone = 0x9072
+        _mem.txtone = int(100.0 * 10) + 0x8000
+        _mem.rxtone = int(107.2 * 10) + 0x8000
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Cross")
         self.assertEqual(mem.cross_mode, "Tone->Tone")
         self.assertEqual(mem.rtone, 100.0)
         self.assertEqual(mem.ctone, 107.2)
 
-    def test_get_tone_cross_tone_dtcs(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
+    def test_get_tone_cross_tone_tone_16_10(self):
+        _mem = MockMemory()
+        _mem.txtone = int(100.0 * 10) + 0x8000
+        _mem.rxtone = int(107.2 * 10) + 0x8000
+        mem = chirp_common.Memory()
+        self.model_8_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "Tone->Tone")
+        self.assertEqual(mem.rtone, 100.0)
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_tone_tone_8_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x9000
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model_8_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "Tone->Tone")
+        self.assertEqual(mem.rtone, 100.0)
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_tone_tone_10_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x9000
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "Tone->Tone")
+        self.assertEqual(mem.rtone, 100.0)
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_tone_tone_16_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x9000
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "Tone->Tone")
+        self.assertEqual(mem.rtone, 100.0)
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_tone_dtcs_8_10(self):
         _mem = MockMemory()
         _mem.txtone = int(100.0 * 10) + 0x8000
         _mem.rxtone = 0x4000 + 0o025
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Cross")
         self.assertEqual(mem.cross_mode, "Tone->DTCS")
         self.assertEqual(mem.rtone, 100.0)
         self.assertEqual(mem.rx_dtcs, 25)
 
-    def test_get_tone_cross_tone_bcd_dtcs(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=8, tone_enc_base=16)
+    def test_get_tone_cross_tone_dtcs_10_10(self):
+        _mem = MockMemory()
+        _mem.txtone = int(100.0 * 10) + 0x8000
+        _mem.rxtone = 0x4000 + 25
+        mem = chirp_common.Memory()
+        self.model_10_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "Tone->DTCS")
+        self.assertEqual(mem.rtone, 100.0)
+        self.assertEqual(mem.rx_dtcs, 25)
+
+    def test_get_tone_cross_tone_dtcs_16_10(self):
+        _mem = MockMemory()
+        _mem.txtone = int(100.0 * 10) + 0x8000
+        _mem.rxtone = 0x4000 + 0x025
+        mem = chirp_common.Memory()
+        self.model_16_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "Tone->DTCS")
+        self.assertEqual(mem.rtone, 100.0)
+        self.assertEqual(mem.rx_dtcs, 25)
+
+    def test_get_tone_cross_tone_dtcs_8_16(self):
         _mem = MockMemory()
         _mem.txtone = 0x9000
         _mem.rxtone = 0x4000 + 0o025
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_16.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Cross")
         self.assertEqual(mem.cross_mode, "Tone->DTCS")
         self.assertEqual(mem.rtone, 100.0)
         self.assertEqual(mem.rx_dtcs, 25)
 
-    def test_get_tone_cross_dtcs_tone(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
+    def test_get_tone_cross_tone_dtcs_10_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x9000
+        _mem.rxtone = 0x4000 + 25
+        mem = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "Tone->DTCS")
+        self.assertEqual(mem.rtone, 100.0)
+        self.assertEqual(mem.rx_dtcs, 25)
+
+    def test_get_tone_cross_tone_dtcs_16_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x9000
+        _mem.rxtone = 0x4000 + 0x025
+        mem = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "Tone->DTCS")
+        self.assertEqual(mem.rtone, 100.0)
+        self.assertEqual(mem.rx_dtcs, 25)
+
+    def test_get_tone_cross_dtcs_tone_8_10(self):
         _mem = MockMemory()
         _mem.txtone = 0x4000 + 0o023
         _mem.rxtone = int(107.2 * 10) + 0x8000
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Cross")
         self.assertEqual(mem.cross_mode, "DTCS->Tone")
         self.assertEqual(mem.dtcs, 23)
         self.assertEqual(mem.ctone, 107.2)
 
-    def test_get_tone_cross_dtcs_tone_bcd(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=8, tone_enc_base=16)
+    def test_get_tone_cross_dtcs_tone_10_10(self):
         _mem = MockMemory()
-        _mem.txtone = 0x4000 + 0o023
-        _mem.rxtone = 0x9072
+        _mem.txtone = 0x4000 + 23
+        _mem.rxtone = int(107.2 * 10) + 0x8000
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_10_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Cross")
         self.assertEqual(mem.cross_mode, "DTCS->Tone")
         self.assertEqual(mem.dtcs, 23)
         self.assertEqual(mem.ctone, 107.2)
 
-    def test_get_tone_cross_none_tone(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
+    def test_get_tone_cross_dtcs_tone_16_10(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 0x023
+        _mem.rxtone = int(107.2 * 10) + 0x8000
+        mem = chirp_common.Memory()
+        self.model_16_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "DTCS->Tone")
+        self.assertEqual(mem.dtcs, 23)
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_dtcs_tone_8_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 0o023
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model_8_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "DTCS->Tone")
+        self.assertEqual(mem.dtcs, 23)
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_dtcs_tone_10_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 23
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "DTCS->Tone")
+        self.assertEqual(mem.dtcs, 23)
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_dtcs_tone_16_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 0x023
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "DTCS->Tone")
+        self.assertEqual(mem.dtcs, 23)
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_none_tone_8_10(self):
         _mem = MockMemory()
         _mem.txtone = 0x0000
         _mem.rxtone = int(107.2 * 10) + 0x8000
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Cross")
         self.assertEqual(mem.cross_mode, "->Tone")
         self.assertEqual(mem.ctone, 107.2)
 
-    def test_get_tone_cross_none_tone_bcd(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=8, tone_enc_base=16)
+    def test_get_tone_cross_none_tone_10_10(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x0000
+        _mem.rxtone = int(107.2 * 10) + 0x8000
+        mem = chirp_common.Memory()
+        self.model_10_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "->Tone")
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_none_tone_16_10(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x0000
+        _mem.rxtone = int(107.2 * 10) + 0x8000
+        mem = chirp_common.Memory()
+        self.model_16_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "->Tone")
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_none_tone_8_16(self):
         _mem = MockMemory()
         _mem.txtone = 0x0000
         _mem.rxtone = 0x9072
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_16.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Cross")
         self.assertEqual(mem.cross_mode, "->Tone")
         self.assertEqual(mem.ctone, 107.2)
 
-    def test_get_tone_cross_none_dtcs(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
+    def test_get_tone_cross_none_tone_10_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x0000
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "->Tone")
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_none_tone_16_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x0000
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "->Tone")
+        self.assertEqual(mem.ctone, 107.2)
+
+    def test_get_tone_cross_none_dtcs_8_10(self):
         _mem = MockMemory()
         _mem.txtone = 0x0000
         _mem.rxtone = 0x4000 + 0o025
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_10.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Cross")
         self.assertEqual(mem.cross_mode, "->DTCS")
         self.assertEqual(mem.rx_dtcs, 25)
 
-    def test_get_tone_cross_none_bcd_dtcs(self):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=8, tone_enc_base=16)
+    def test_get_tone_cross_none_dtcs_10_10(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x0000
+        _mem.rxtone = 0x4000 + 25
+        mem = chirp_common.Memory()
+        self.model_10_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "->DTCS")
+        self.assertEqual(mem.rx_dtcs, 25)
+
+    def test_get_tone_cross_none_dtcs_16_10(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x0000
+        _mem.rxtone = 0x4000 + 0x025
+        mem = chirp_common.Memory()
+        self.model_16_10.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "->DTCS")
+        self.assertEqual(mem.rx_dtcs, 25)
+
+    def test_get_tone_cross_none_dtcs_8_16(self):
         _mem = MockMemory()
         _mem.txtone = 0x0000
         _mem.rxtone = 0x4000 + 0o025
         mem = chirp_common.Memory()
-        self.model.get_tone(_mem, mem)
+        self.model_8_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "->DTCS")
+        self.assertEqual(mem.rx_dtcs, 25)
+
+    def test_get_tone_cross_none_dtcs_10_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x0000
+        _mem.rxtone = 0x4000 + 25
+        mem = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "->DTCS")
+        self.assertEqual(mem.rx_dtcs, 25)
+
+    def test_get_tone_cross_none_dtcs_16_16(self):
+        _mem = MockMemory()
+        _mem.txtone = 0x0000
+        _mem.rxtone = 0x4000 + 0x025
+        mem = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "Cross")
         self.assertEqual(mem.cross_mode, "->DTCS")
         self.assertEqual(mem.rx_dtcs, 25)
@@ -565,179 +1639,408 @@ class TestGetTone(base.BaseTest):
 class TestRoundTrip(base.BaseTest):
     def setUp(self):
         super().setUp()
-
-    def _round_trip(self, mem):
-        self.model = kenwood_tone.KenwoodToneModel(
+        self.model_8_10 = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
+        self.model_10_10 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=8, tone_enc_base=10)
-        _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
-        result = chirp_common.Memory()
-        self.model.get_tone(_mem, result)
-        return result
-
-    def _round_trip_dcs_dec_tone_dec(self, mem):
-        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_enc_base=10)
+        self.model_16_10 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=10, tone_enc_base=10)
-        _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
-        result = chirp_common.Memory()
-        self.model.get_tone(_mem, result)
-        return result
-
-    def _round_trip_dcs_bcd_tone_dec(self, mem):
-        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_enc_base=16)
+        self.model_8_16 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=16, tone_enc_base=10)
-        _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
-        result = chirp_common.Memory()
-        self.model.get_tone(_mem, result)
-        return result
-
-    def _round_trip_dcs_oct_tone_bcd(self, mem):
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=8, tone_enc_base=16)
-        _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
-        result = chirp_common.Memory()
-        self.model.get_tone(_mem, result)
-        return result
-
-    def _round_trip_dcs_dec_tone_bcd(self, mem):
-        self.model = kenwood_tone.KenwoodToneModel(
+            tone_enc_base=16)
+        self.model_10_16 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000,
             dcs_enc_base=10, tone_enc_base=16)
-        _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
-        result = chirp_common.Memory()
-        self.model.get_tone(_mem, result)
-        return result
-
-    def _round_trip_dcs_bcd_tone_bcd(self, mem):
-        self.model = kenwood_tone.KenwoodToneModel(
+        self.model_16_16 = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000,
             dcs_enc_base=16, tone_enc_base=16)
+
+    def _round_trip_8_10(self, mem):
         _mem = MockMemory()
-        self.model.set_tone(mem, _mem)
+        self.model_8_10.set_tone(mem, _mem)
         result = chirp_common.Memory()
-        self.model.get_tone(_mem, result)
+        self.model_8_10.get_tone(_mem, result)
         return result
 
-    # More round trip tests to come when BCD is implemented in set_tone.
+    def _round_trip_10_10(self, mem):
+        _mem = MockMemory()
+        self.model_10_10.set_tone(mem, _mem)
+        result = chirp_common.Memory()
+        self.model_10_10.get_tone(_mem, result)
+        return result
 
-    def test_round_trip_empty(self):
+    def _round_trip_16_10(self, mem):
+        _mem = MockMemory()
+        self.model_16_10.set_tone(mem, _mem)
+        result = chirp_common.Memory()
+        self.model_16_10.get_tone(_mem, result)
+        return result
+
+    def _round_trip_8_16(self, mem):
+        _mem = MockMemory()
+        self.model_8_16.set_tone(mem, _mem)
+        result = chirp_common.Memory()
+        self.model_8_16.get_tone(_mem, result)
+        return result
+
+    def _round_trip_10_16(self, mem):
+        _mem = MockMemory()
+        self.model_10_16.set_tone(mem, _mem)
+        result = chirp_common.Memory()
+        self.model_10_16.get_tone(_mem, result)
+        return result
+
+    def _round_trip_16_16(self, mem):
+        _mem = MockMemory()
+        self.model_16_16.set_tone(mem, _mem)
+        result = chirp_common.Memory()
+        self.model_16_16.get_tone(_mem, result)
+        return result
+
+    def test_round_trip_empty_8_10(self):
         mem = chirp_common.Memory()
         mem.tmode = ""
-        result = self._round_trip(mem)
+        result = self._round_trip_8_10(mem)
         self.assertEqual(result.tmode, "")
 
-    def test_round_trip_empty_dcs_dec_tone_dec(self):
+    def test_round_trip_empty_10_10(self):
         mem = chirp_common.Memory()
         mem.tmode = ""
-        result = self._round_trip_dcs_dec_tone_dec(mem)
+        result = self._round_trip_10_10(mem)
         self.assertEqual(result.tmode, "")
 
-    def test_round_trip_tone(self):
+    def test_round_trip_empty_16_10(self):
+        mem = chirp_common.Memory()
+        mem.tmode = ""
+        result = self._round_trip_16_10(mem)
+        self.assertEqual(result.tmode, "")
+
+    def test_round_trip_empty_8_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = ""
+        result = self._round_trip_8_16(mem)
+        self.assertEqual(result.tmode, "")
+
+    def test_round_trip_empty_10_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = ""
+        result = self._round_trip_10_16(mem)
+        self.assertEqual(result.tmode, "")
+
+    def test_round_trip_empty_16_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = ""
+        result = self._round_trip_16_16(mem)
+        self.assertEqual(result.tmode, "")
+
+    def test_round_trip_tone_8_10(self):
         mem = chirp_common.Memory()
         mem.tmode = "Tone"
         mem.rtone = 100.0
-        result = self._round_trip(mem)
+        result = self._round_trip_8_10(mem)
         self.assertEqual(result.tmode, "Tone")
         self.assertEqual(result.rtone, 100.0)
 
-    def test_round_trip_tone_dcs_dec_tone_dec(self):
+    def test_round_trip_tone_10_10(self):
         mem = chirp_common.Memory()
         mem.tmode = "Tone"
         mem.rtone = 100.0
-        result = self._round_trip_dcs_dec_tone_dec(mem)
+        result = self._round_trip_10_10(mem)
         self.assertEqual(result.tmode, "Tone")
         self.assertEqual(result.rtone, 100.0)
 
-    def test_round_trip_tsql(self):
+    def test_round_trip_tone_16_10(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Tone"
+        mem.rtone = 100.0
+        result = self._round_trip_16_10(mem)
+        self.assertEqual(result.tmode, "Tone")
+        self.assertEqual(result.rtone, 100.0)
+
+    def test_round_trip_tone_8_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Tone"
+        mem.rtone = 100.0
+        result = self._round_trip_8_16(mem)
+        self.assertEqual(result.tmode, "Tone")
+        self.assertEqual(result.rtone, 100.0)
+
+    def test_round_trip_tone_10_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Tone"
+        mem.rtone = 100.0
+        result = self._round_trip_10_16(mem)
+        self.assertEqual(result.tmode, "Tone")
+        self.assertEqual(result.rtone, 100.0)
+
+    def test_round_trip_tone_16_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Tone"
+        mem.rtone = 100.0
+        result = self._round_trip_16_16(mem)
+        self.assertEqual(result.tmode, "Tone")
+        self.assertEqual(result.rtone, 100.0)
+
+    def test_round_trip_tsql_8_10(self):
         mem = chirp_common.Memory()
         mem.tmode = "TSQL"
         mem.ctone = 107.2
-        result = self._round_trip(mem)
+        result = self._round_trip_8_10(mem)
         self.assertEqual(result.tmode, "TSQL")
         self.assertEqual(result.ctone, 107.2)
 
-    def test_round_trip_tsql_dcs_dec_tone_dec(self):
+    def test_round_trip_tsql_10_10(self):
         mem = chirp_common.Memory()
         mem.tmode = "TSQL"
         mem.ctone = 107.2
-        result = self._round_trip_dcs_dec_tone_dec(mem)
+        result = self._round_trip_10_10(mem)
         self.assertEqual(result.tmode, "TSQL")
         self.assertEqual(result.ctone, 107.2)
 
-    def test_round_trip_dtcs(self):
+    def test_round_trip_tsql_16_10(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "TSQL"
+        mem.ctone = 107.2
+        result = self._round_trip_16_10(mem)
+        self.assertEqual(result.tmode, "TSQL")
+        self.assertEqual(result.ctone, 107.2)
+
+    def test_round_trip_tsql_8_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "TSQL"
+        mem.ctone = 107.2
+        result = self._round_trip_8_16(mem)
+        self.assertEqual(result.tmode, "TSQL")
+        self.assertEqual(result.ctone, 107.2)
+
+    def test_round_trip_tsql_10_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "TSQL"
+        mem.ctone = 107.2
+        result = self._round_trip_10_16(mem)
+        self.assertEqual(result.tmode, "TSQL")
+        self.assertEqual(result.ctone, 107.2)
+
+    def test_round_trip_tsql_16_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "TSQL"
+        mem.ctone = 107.2
+        result = self._round_trip_16_16(mem)
+        self.assertEqual(result.tmode, "TSQL")
+        self.assertEqual(result.ctone, 107.2)
+
+    def test_round_trip_dtcs_8_10(self):
         mem = chirp_common.Memory()
         mem.tmode = "DTCS"
         mem.dtcs = 23
         mem.dtcs_polarity = "NR"
-        result = self._round_trip(mem)
+        result = self._round_trip_8_10(mem)
         self.assertEqual(result.tmode, "DTCS")
         self.assertEqual(result.dtcs, 23)
         self.assertEqual(result.dtcs_polarity, "NR")
 
-    def test_round_trip_dtcs_dcs_dec_tone_dec(self):
+    def test_round_trip_dtcs_10_10(self):
         mem = chirp_common.Memory()
         mem.tmode = "DTCS"
         mem.dtcs = 23
         mem.dtcs_polarity = "NR"
-        result = self._round_trip_dcs_dec_tone_dec(mem)
+        result = self._round_trip_10_10(mem)
         self.assertEqual(result.tmode, "DTCS")
         self.assertEqual(result.dtcs, 23)
         self.assertEqual(result.dtcs_polarity, "NR")
 
-    def test_round_trip_cross_tone_tone(self):
+    def test_round_trip_dtcs_16_10(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "DTCS"
+        mem.dtcs = 23
+        mem.dtcs_polarity = "NR"
+        result = self._round_trip_16_10(mem)
+        self.assertEqual(result.tmode, "DTCS")
+        self.assertEqual(result.dtcs, 23)
+        self.assertEqual(result.dtcs_polarity, "NR")
+
+    def test_round_trip_dtcs_8_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "DTCS"
+        mem.dtcs = 23
+        mem.dtcs_polarity = "NR"
+        result = self._round_trip_8_16(mem)
+        self.assertEqual(result.tmode, "DTCS")
+        self.assertEqual(result.dtcs, 23)
+        self.assertEqual(result.dtcs_polarity, "NR")
+
+    def test_round_trip_dtcs_10_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "DTCS"
+        mem.dtcs = 23
+        mem.dtcs_polarity = "NR"
+        result = self._round_trip_10_16(mem)
+        self.assertEqual(result.tmode, "DTCS")
+        self.assertEqual(result.dtcs, 23)
+        self.assertEqual(result.dtcs_polarity, "NR")
+
+    def test_round_trip_dtcs_16_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "DTCS"
+        mem.dtcs = 23
+        mem.dtcs_polarity = "NR"
+        result = self._round_trip_16_16(mem)
+        self.assertEqual(result.tmode, "DTCS")
+        self.assertEqual(result.dtcs, 23)
+        self.assertEqual(result.dtcs_polarity, "NR")
+
+    def test_round_trip_cross_tone_tone_8_10(self):
         mem = chirp_common.Memory()
         mem.tmode = "Cross"
         mem.cross_mode = "Tone->Tone"
         mem.rtone = 100.0
         mem.ctone = 107.2
-        result = self._round_trip(mem)
+        result = self._round_trip_8_10(mem)
         self.assertEqual(result.tmode, "Cross")
         self.assertEqual(result.cross_mode, "Tone->Tone")
         self.assertEqual(result.rtone, 100.0)
         self.assertEqual(result.ctone, 107.2)
 
-    def test_round_trip_cross_tone_tone_dcs_dec_tone_dec(self):
+    def test_round_trip_cross_tone_tone_10_10(self):
         mem = chirp_common.Memory()
         mem.tmode = "Cross"
         mem.cross_mode = "Tone->Tone"
         mem.rtone = 100.0
         mem.ctone = 107.2
-        result = self._round_trip_dcs_dec_tone_dec(mem)
+        result = self._round_trip_10_10(mem)
         self.assertEqual(result.tmode, "Cross")
         self.assertEqual(result.cross_mode, "Tone->Tone")
         self.assertEqual(result.rtone, 100.0)
         self.assertEqual(result.ctone, 107.2)
 
-    def test_round_trip_cross_dtcs_dtcs(self):
+    def test_round_trip_cross_tone_tone_16_10(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Cross"
+        mem.cross_mode = "Tone->Tone"
+        mem.rtone = 100.0
+        mem.ctone = 107.2
+        result = self._round_trip_16_10(mem)
+        self.assertEqual(result.tmode, "Cross")
+        self.assertEqual(result.cross_mode, "Tone->Tone")
+        self.assertEqual(result.rtone, 100.0)
+        self.assertEqual(result.ctone, 107.2)
+
+    def test_round_trip_cross_tone_tone_8_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Cross"
+        mem.cross_mode = "Tone->Tone"
+        mem.rtone = 100.0
+        mem.ctone = 107.2
+        result = self._round_trip_8_16(mem)
+        self.assertEqual(result.tmode, "Cross")
+        self.assertEqual(result.cross_mode, "Tone->Tone")
+        self.assertEqual(result.rtone, 100.0)
+        self.assertEqual(result.ctone, 107.2)
+
+    def test_round_trip_cross_tone_tone_10_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Cross"
+        mem.cross_mode = "Tone->Tone"
+        mem.rtone = 100.0
+        mem.ctone = 107.2
+        result = self._round_trip_10_16(mem)
+        self.assertEqual(result.tmode, "Cross")
+        self.assertEqual(result.cross_mode, "Tone->Tone")
+        self.assertEqual(result.rtone, 100.0)
+        self.assertEqual(result.ctone, 107.2)
+
+    def test_round_trip_cross_tone_tone_16_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Cross"
+        mem.cross_mode = "Tone->Tone"
+        mem.rtone = 100.0
+        mem.ctone = 107.2
+        result = self._round_trip_16_16(mem)
+        self.assertEqual(result.tmode, "Cross")
+        self.assertEqual(result.cross_mode, "Tone->Tone")
+        self.assertEqual(result.rtone, 100.0)
+        self.assertEqual(result.ctone, 107.2)
+
+    def test_round_trip_cross_dtcs_dtcs_8_10(self):
         mem = chirp_common.Memory()
         mem.tmode = "Cross"
         mem.cross_mode = "DTCS->DTCS"
         mem.dtcs = 23
         mem.rx_dtcs = 25
         mem.dtcs_polarity = "RN"
-        result = self._round_trip(mem)
+        result = self._round_trip_8_10(mem)
         self.assertEqual(result.tmode, "Cross")
         self.assertEqual(result.cross_mode, "DTCS->DTCS")
         self.assertEqual(result.dtcs, 23)
         self.assertEqual(result.rx_dtcs, 25)
         self.assertEqual(result.dtcs_polarity, "RN")
 
-    def test_round_trip_cross_dtcs_dtcs_dcs_dec_tone_dec(self):
+    def test_round_trip_cross_dtcs_dtcs_10_10(self):
         mem = chirp_common.Memory()
         mem.tmode = "Cross"
         mem.cross_mode = "DTCS->DTCS"
         mem.dtcs = 23
         mem.rx_dtcs = 25
         mem.dtcs_polarity = "RN"
-        result = self._round_trip_dcs_dec_tone_dec(mem)
+        result = self._round_trip_10_10(mem)
+        self.assertEqual(result.tmode, "Cross")
+        self.assertEqual(result.cross_mode, "DTCS->DTCS")
+        self.assertEqual(result.dtcs, 23)
+        self.assertEqual(result.rx_dtcs, 25)
+        self.assertEqual(result.dtcs_polarity, "RN")
+
+    def test_round_trip_cross_dtcs_dtcs_16_10(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Cross"
+        mem.cross_mode = "DTCS->DTCS"
+        mem.dtcs = 23
+        mem.rx_dtcs = 25
+        mem.dtcs_polarity = "RN"
+        result = self._round_trip_16_10(mem)
+        self.assertEqual(result.tmode, "Cross")
+        self.assertEqual(result.cross_mode, "DTCS->DTCS")
+        self.assertEqual(result.dtcs, 23)
+        self.assertEqual(result.rx_dtcs, 25)
+        self.assertEqual(result.dtcs_polarity, "RN")
+
+    def test_round_trip_cross_dtcs_dtcs_8_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Cross"
+        mem.cross_mode = "DTCS->DTCS"
+        mem.dtcs = 23
+        mem.rx_dtcs = 25
+        mem.dtcs_polarity = "RN"
+        result = self._round_trip_8_16(mem)
+        self.assertEqual(result.tmode, "Cross")
+        self.assertEqual(result.cross_mode, "DTCS->DTCS")
+        self.assertEqual(result.dtcs, 23)
+        self.assertEqual(result.rx_dtcs, 25)
+        self.assertEqual(result.dtcs_polarity, "RN")
+
+    def test_round_trip_cross_dtcs_dtcs_10_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Cross"
+        mem.cross_mode = "DTCS->DTCS"
+        mem.dtcs = 23
+        mem.rx_dtcs = 25
+        mem.dtcs_polarity = "RN"
+        result = self._round_trip_10_16(mem)
+        self.assertEqual(result.tmode, "Cross")
+        self.assertEqual(result.cross_mode, "DTCS->DTCS")
+        self.assertEqual(result.dtcs, 23)
+        self.assertEqual(result.rx_dtcs, 25)
+        self.assertEqual(result.dtcs_polarity, "RN")
+
+    def test_round_trip_cross_dtcs_dtcs_16_16(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Cross"
+        mem.cross_mode = "DTCS->DTCS"
+        mem.dtcs = 23
+        mem.rx_dtcs = 25
+        mem.dtcs_polarity = "RN"
+        result = self._round_trip_16_16(mem)
         self.assertEqual(result.tmode, "Cross")
         self.assertEqual(result.cross_mode, "DTCS->DTCS")
         self.assertEqual(result.dtcs, 23)
@@ -857,8 +2160,7 @@ class TestDifferentParameterSets(base.BaseTest):
 
     def test_decimal_dcs_encoding(self):
         model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=10)
+            dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=10)
         val = model._set_tone_val(123, "N")
         self.assertEqual(val, 0x4000 + 123)
 
@@ -872,8 +2174,7 @@ class TestDifferentParameterSets(base.BaseTest):
 
     def test_bcd_dcs_encoding(self):
         model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000,
-            dcs_enc_base=16, tone_enc_base=16)
+            dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=16)
         val = model._set_tone_val(123, "N")
         self.assertEqual(val, 0x4123)
 

--- a/tests/unit/test_kenwood_tone.py
+++ b/tests/unit/test_kenwood_tone.py
@@ -18,41 +18,80 @@ class TestKenwoodToneModelInit(base.BaseTest):
         self.assertEqual(model.tone_init, 0x0000)
         self.assertEqual(model.tone_flag, 0x8000)
         self.assertEqual(model.dcs_enc_base, 8)
+        self.assertEqual(model.tone_enc_base, 10)
 
     def test_init_custom_params(self):
         model = kenwood_tone.KenwoodToneModel(
             dcs_base=0x2800, pol_mask=0x8000,
-            tone_init=0xFFFF, tone_flag=0x0000, dcs_enc_base=10)
+            tone_init=0xFFFF, tone_flag=0x0000,
+            dcs_enc_base=10, tone_enc_base=16)
         self.assertEqual(model.dcs_base, 0x2800)
         self.assertEqual(model.pol_mask, 0x8000)
         self.assertEqual(model.tone_init, 0xFFFF)
         self.assertEqual(model.tone_flag, 0x0000)
         self.assertEqual(model.dcs_enc_base, 10)
+        self.assertEqual(model.tone_enc_base, 16)
 
     def test_init_invalid_dcs_enc_base(self):
         with self.assertRaises(AssertionError):
             kenwood_tone.KenwoodToneModel(
-                dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=16)
+                dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=15)
+
+    def test_init_invalid_tone_enc_base(self):
+        with self.assertRaises(AssertionError):
+            kenwood_tone.KenwoodToneModel(
+                dcs_base=0x4000, pol_mask=0x2000, tone_enc_base=15)
 
 
 class TestGetToneVal(base.BaseTest):
     def setUp(self):
         super().setUp()
-        self.model = kenwood_tone.KenwoodToneModel(
+        self.model_dec = kenwood_tone.KenwoodToneModel(
             dcs_base=0x4000, pol_mask=0x2000)
+        self.model_dcs_bcd = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=10)
+        self.model_tone_bcd = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=8, tone_enc_base=16)
 
     def test_get_tone_val_zero(self):
-        code, pol = self.model._get_tone_val(0x0000)
+        code, pol = self.model_dec._get_tone_val(0x0000)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_zero_dcs_bcd(self):
+        code, pol = self.model_dcs_bcd._get_tone_val(0x0000)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_zero_tone_bcd(self):
+        code, pol = self.model_tone_bcd._get_tone_val(0x0000)
         self.assertIsNone(code)
         self.assertIsNone(pol)
 
     def test_get_tone_val_ffff(self):
-        code, pol = self.model._get_tone_val(0xFFFF)
+        code, pol = self.model_dec._get_tone_val(0xFFFF)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ffff_dcs_bcd(self):
+        code, pol = self.model_dcs_bcd._get_tone_val(0xFFFF)
+        self.assertIsNone(code)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ffff_tone_bcd(self):
+        code, pol = self.model_tone_bcd._get_tone_val(0xFFFF)
         self.assertIsNone(code)
         self.assertIsNone(pol)
 
     def test_get_tone_val_ctcss(self):
-        code, pol = self.model._get_tone_val(885 + 0x8000)
+        code, pol = self.model_dec._get_tone_val(885 + 0x8000)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
+    def test_get_tone_val_ctcss_bcd(self):
+        code, pol = self.model_tone_bcd._get_tone_val(0x0885)
         self.assertEqual(code, 88.5)
         self.assertIsNone(pol)
 
@@ -63,25 +102,72 @@ class TestGetToneVal(base.BaseTest):
         self.assertEqual(code, 88.5)
         self.assertIsNone(pol)
 
+    def test_get_tone_val_ctcss_no_flag_bcd(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, tone_flag=0x0000,
+            dcs_enc_base=16, tone_enc_base=16)
+        code, pol = model._get_tone_val(0x0885)
+        self.assertEqual(code, 88.5)
+        self.assertIsNone(pol)
+
     def test_get_tone_val_dcs_normal_polarity(self):
-        code, pol = self.model._get_tone_val(0x4000 + 0o023)
+        code, pol = self.model_dec._get_tone_val(0x4000 + 0o023)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_normal_polarity_bcd(self):
+        code, pol = self.model_dcs_bcd._get_tone_val(0x4000 + 0x023)
         self.assertEqual(code, 23)
         self.assertEqual(pol, "N")
 
     def test_get_tone_val_dcs_reverse_polarity(self):
-        code, pol = self.model._get_tone_val(0x4000 + 0o023 + 0x2000)
+        code, pol = self.model_dec._get_tone_val(0x4000 + 0o023 + 0x2000)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "R")
+
+    def test_get_tone_val_dcs_reverse_polarity_bcd(self):
+        code, pol = self.model_dcs_bcd._get_tone_val(
+            0x4000 + 0x023 + 0x2000)
         self.assertEqual(code, 23)
         self.assertEqual(pol, "R")
 
     def test_get_tone_val_dcs_decimal_encoding(self):
         model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=10)
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10)
         code, pol = model._get_tone_val(0x4000 + 23)
         self.assertEqual(code, 23)
         self.assertEqual(pol, "N")
 
+    def test_get_tone_val_dcs_decimal_encoding_bcd(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10, tone_enc_base=16)
+        code, pol = model._get_tone_val(0x4000 + 23)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_bcd_encoding(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=16)
+        code, pol = model._get_tone_val(0x4023)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_bcd_encoding_bcd(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=16)
+        code, pol = model._get_tone_val(0x4023)
+        self.assertEqual(code, 23)
+        self.assertEqual(pol, "N")
+
     def test_get_tone_val_dcs_octal_encoding_large_code(self):
-        code, pol = self.model._get_tone_val(0x4000 + 0o125)
+        code, pol = self.model_dec._get_tone_val(0x4000 + 0o125)
+        self.assertEqual(code, 125)
+        self.assertEqual(pol, "N")
+
+    def test_get_tone_val_dcs_octal_encoding_large_code_bcd(self):
+        code, pol = self.model_tone_bcd._get_tone_val(0x4000 + 0o125)
         self.assertEqual(code, 125)
         self.assertEqual(pol, "N")
 
@@ -232,16 +318,27 @@ class TestSetTone(base.BaseTest):
 class TestGetTone(base.BaseTest):
     def setUp(self):
         super().setUp()
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
 
     def test_get_tone_empty(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
+        _mem = MockMemory()
+        mem = chirp_common.Memory()
+        self.model.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "")
+
+    def test_get_tone_empty_bcd(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=16)
         _mem = MockMemory()
         mem = chirp_common.Memory()
         self.model.get_tone(_mem, mem)
         self.assertEqual(mem.tmode, "")
 
     def test_get_tone_tone_mode(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
         _mem = MockMemory()
         _mem.txtone = int(100.0 * 10) + 0x8000
         _mem.rxtone = 0x0000
@@ -250,7 +347,21 @@ class TestGetTone(base.BaseTest):
         self.assertEqual(mem.tmode, "Tone")
         self.assertEqual(mem.rtone, 100.0)
 
+    def test_get_tone_tone_mode_bcd(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=16)
+        _mem = MockMemory()
+        _mem.txtone = 0x9000
+        _mem.rxtone = 0x0000
+        mem = chirp_common.Memory()
+        self.model.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Tone")
+        self.assertEqual(mem.rtone, 100.0)
+
     def test_get_tone_tsql_mode(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
         _mem = MockMemory()
         _mem.txtone = int(107.2 * 10) + 0x8000
         _mem.rxtone = int(107.2 * 10) + 0x8000
@@ -259,7 +370,34 @@ class TestGetTone(base.BaseTest):
         self.assertEqual(mem.tmode, "TSQL")
         self.assertEqual(mem.ctone, 107.2)
 
+    def test_get_tone_tsql_mode_bcd(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=16)
+        _mem = MockMemory()
+        _mem.txtone = 0x9072
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "TSQL")
+        self.assertEqual(mem.ctone, 107.2)
+
     def test_get_tone_dtcs_mode(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 0o023
+        _mem.rxtone = 0x4000 + 0o023
+        mem = chirp_common.Memory()
+        self.model.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "DTCS")
+        self.assertEqual(mem.dtcs, 23)
+        self.assertEqual(mem.dtcs_polarity, "NN")
+
+    def test_get_tone_dtcs_mode_bcd(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=8, tone_enc_base=16)
         _mem = MockMemory()
         _mem.txtone = 0x4000 + 0o023
         _mem.rxtone = 0x4000 + 0o023
@@ -270,6 +408,20 @@ class TestGetTone(base.BaseTest):
         self.assertEqual(mem.dtcs_polarity, "NN")
 
     def test_get_tone_dtcs_with_polarity(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 0o023 + 0x2000
+        _mem.rxtone = 0x4000 + 0o023
+        mem = chirp_common.Memory()
+        self.model.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "DTCS")
+        self.assertEqual(mem.dtcs_polarity, "RN")
+
+    def test_get_tone_dtcs_with_polarity_bcd(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=16)
         _mem = MockMemory()
         _mem.txtone = 0x4000 + 0o023 + 0x2000
         _mem.rxtone = 0x4000 + 0o023
@@ -279,6 +431,8 @@ class TestGetTone(base.BaseTest):
         self.assertEqual(mem.dtcs_polarity, "RN")
 
     def test_get_tone_cross_tone_tone(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
         _mem = MockMemory()
         _mem.txtone = int(100.0 * 10) + 0x8000
         _mem.rxtone = int(107.2 * 10) + 0x8000
@@ -289,7 +443,23 @@ class TestGetTone(base.BaseTest):
         self.assertEqual(mem.rtone, 100.0)
         self.assertEqual(mem.ctone, 107.2)
 
+    def test_get_tone_cross_tone_tone_bcd(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=16)
+        _mem = MockMemory()
+        _mem.txtone = 0x9000
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "Tone->Tone")
+        self.assertEqual(mem.rtone, 100.0)
+        self.assertEqual(mem.ctone, 107.2)
+
     def test_get_tone_cross_tone_dtcs(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
         _mem = MockMemory()
         _mem.txtone = int(100.0 * 10) + 0x8000
         _mem.rxtone = 0x4000 + 0o025
@@ -300,7 +470,23 @@ class TestGetTone(base.BaseTest):
         self.assertEqual(mem.rtone, 100.0)
         self.assertEqual(mem.rx_dtcs, 25)
 
+    def test_get_tone_cross_tone_bcd_dtcs(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=8, tone_enc_base=16)
+        _mem = MockMemory()
+        _mem.txtone = 0x9000
+        _mem.rxtone = 0x4000 + 0o025
+        mem = chirp_common.Memory()
+        self.model.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "Tone->DTCS")
+        self.assertEqual(mem.rtone, 100.0)
+        self.assertEqual(mem.rx_dtcs, 25)
+
     def test_get_tone_cross_dtcs_tone(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
         _mem = MockMemory()
         _mem.txtone = 0x4000 + 0o023
         _mem.rxtone = int(107.2 * 10) + 0x8000
@@ -311,7 +497,23 @@ class TestGetTone(base.BaseTest):
         self.assertEqual(mem.dtcs, 23)
         self.assertEqual(mem.ctone, 107.2)
 
+    def test_get_tone_cross_dtcs_tone_bcd(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=8, tone_enc_base=16)
+        _mem = MockMemory()
+        _mem.txtone = 0x4000 + 0o023
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "DTCS->Tone")
+        self.assertEqual(mem.dtcs, 23)
+        self.assertEqual(mem.ctone, 107.2)
+
     def test_get_tone_cross_none_tone(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
         _mem = MockMemory()
         _mem.txtone = 0x0000
         _mem.rxtone = int(107.2 * 10) + 0x8000
@@ -321,7 +523,35 @@ class TestGetTone(base.BaseTest):
         self.assertEqual(mem.cross_mode, "->Tone")
         self.assertEqual(mem.ctone, 107.2)
 
+    def test_get_tone_cross_none_tone_bcd(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=8, tone_enc_base=16)
+        _mem = MockMemory()
+        _mem.txtone = 0x0000
+        _mem.rxtone = 0x9072
+        mem = chirp_common.Memory()
+        self.model.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "->Tone")
+        self.assertEqual(mem.ctone, 107.2)
+
     def test_get_tone_cross_none_dtcs(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000)
+        _mem = MockMemory()
+        _mem.txtone = 0x0000
+        _mem.rxtone = 0x4000 + 0o025
+        mem = chirp_common.Memory()
+        self.model.get_tone(_mem, mem)
+        self.assertEqual(mem.tmode, "Cross")
+        self.assertEqual(mem.cross_mode, "->DTCS")
+        self.assertEqual(mem.rx_dtcs, 25)
+
+    def test_get_tone_cross_none_bcd_dtcs(self):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=8, tone_enc_base=16)
         _mem = MockMemory()
         _mem.txtone = 0x0000
         _mem.rxtone = 0x4000 + 0o025
@@ -335,15 +565,68 @@ class TestGetTone(base.BaseTest):
 class TestRoundTrip(base.BaseTest):
     def setUp(self):
         super().setUp()
-        self.model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000)
 
     def _round_trip(self, mem):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=8, tone_enc_base=10)
         _mem = MockMemory()
         self.model.set_tone(mem, _mem)
         result = chirp_common.Memory()
         self.model.get_tone(_mem, result)
         return result
+
+    def _round_trip_dcs_dec_tone_dec(self, mem):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10, tone_enc_base=10)
+        _mem = MockMemory()
+        self.model.set_tone(mem, _mem)
+        result = chirp_common.Memory()
+        self.model.get_tone(_mem, result)
+        return result
+
+    def _round_trip_dcs_bcd_tone_dec(self, mem):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=10)
+        _mem = MockMemory()
+        self.model.set_tone(mem, _mem)
+        result = chirp_common.Memory()
+        self.model.get_tone(_mem, result)
+        return result
+
+    def _round_trip_dcs_oct_tone_bcd(self, mem):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=8, tone_enc_base=16)
+        _mem = MockMemory()
+        self.model.set_tone(mem, _mem)
+        result = chirp_common.Memory()
+        self.model.get_tone(_mem, result)
+        return result
+
+    def _round_trip_dcs_dec_tone_bcd(self, mem):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10, tone_enc_base=16)
+        _mem = MockMemory()
+        self.model.set_tone(mem, _mem)
+        result = chirp_common.Memory()
+        self.model.get_tone(_mem, result)
+        return result
+
+    def _round_trip_dcs_bcd_tone_bcd(self, mem):
+        self.model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=16)
+        _mem = MockMemory()
+        self.model.set_tone(mem, _mem)
+        result = chirp_common.Memory()
+        self.model.get_tone(_mem, result)
+        return result
+
+    # More round trip tests to come when BCD is implemented in set_tone.
 
     def test_round_trip_empty(self):
         mem = chirp_common.Memory()
@@ -351,11 +634,25 @@ class TestRoundTrip(base.BaseTest):
         result = self._round_trip(mem)
         self.assertEqual(result.tmode, "")
 
+    def test_round_trip_empty_dcs_dec_tone_dec(self):
+        mem = chirp_common.Memory()
+        mem.tmode = ""
+        result = self._round_trip_dcs_dec_tone_dec(mem)
+        self.assertEqual(result.tmode, "")
+
     def test_round_trip_tone(self):
         mem = chirp_common.Memory()
         mem.tmode = "Tone"
         mem.rtone = 100.0
         result = self._round_trip(mem)
+        self.assertEqual(result.tmode, "Tone")
+        self.assertEqual(result.rtone, 100.0)
+
+    def test_round_trip_tone_dcs_dec_tone_dec(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Tone"
+        mem.rtone = 100.0
+        result = self._round_trip_dcs_dec_tone_dec(mem)
         self.assertEqual(result.tmode, "Tone")
         self.assertEqual(result.rtone, 100.0)
 
@@ -367,12 +664,30 @@ class TestRoundTrip(base.BaseTest):
         self.assertEqual(result.tmode, "TSQL")
         self.assertEqual(result.ctone, 107.2)
 
+    def test_round_trip_tsql_dcs_dec_tone_dec(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "TSQL"
+        mem.ctone = 107.2
+        result = self._round_trip_dcs_dec_tone_dec(mem)
+        self.assertEqual(result.tmode, "TSQL")
+        self.assertEqual(result.ctone, 107.2)
+
     def test_round_trip_dtcs(self):
         mem = chirp_common.Memory()
         mem.tmode = "DTCS"
         mem.dtcs = 23
         mem.dtcs_polarity = "NR"
         result = self._round_trip(mem)
+        self.assertEqual(result.tmode, "DTCS")
+        self.assertEqual(result.dtcs, 23)
+        self.assertEqual(result.dtcs_polarity, "NR")
+
+    def test_round_trip_dtcs_dcs_dec_tone_dec(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "DTCS"
+        mem.dtcs = 23
+        mem.dtcs_polarity = "NR"
+        result = self._round_trip_dcs_dec_tone_dec(mem)
         self.assertEqual(result.tmode, "DTCS")
         self.assertEqual(result.dtcs, 23)
         self.assertEqual(result.dtcs_polarity, "NR")
@@ -389,6 +704,18 @@ class TestRoundTrip(base.BaseTest):
         self.assertEqual(result.rtone, 100.0)
         self.assertEqual(result.ctone, 107.2)
 
+    def test_round_trip_cross_tone_tone_dcs_dec_tone_dec(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Cross"
+        mem.cross_mode = "Tone->Tone"
+        mem.rtone = 100.0
+        mem.ctone = 107.2
+        result = self._round_trip_dcs_dec_tone_dec(mem)
+        self.assertEqual(result.tmode, "Cross")
+        self.assertEqual(result.cross_mode, "Tone->Tone")
+        self.assertEqual(result.rtone, 100.0)
+        self.assertEqual(result.ctone, 107.2)
+
     def test_round_trip_cross_dtcs_dtcs(self):
         mem = chirp_common.Memory()
         mem.tmode = "Cross"
@@ -397,6 +724,20 @@ class TestRoundTrip(base.BaseTest):
         mem.rx_dtcs = 25
         mem.dtcs_polarity = "RN"
         result = self._round_trip(mem)
+        self.assertEqual(result.tmode, "Cross")
+        self.assertEqual(result.cross_mode, "DTCS->DTCS")
+        self.assertEqual(result.dtcs, 23)
+        self.assertEqual(result.rx_dtcs, 25)
+        self.assertEqual(result.dtcs_polarity, "RN")
+
+    def test_round_trip_cross_dtcs_dtcs_dcs_dec_tone_dec(self):
+        mem = chirp_common.Memory()
+        mem.tmode = "Cross"
+        mem.cross_mode = "DTCS->DTCS"
+        mem.dtcs = 23
+        mem.rx_dtcs = 25
+        mem.dtcs_polarity = "RN"
+        result = self._round_trip_dcs_dec_tone_dec(mem)
         self.assertEqual(result.tmode, "Cross")
         self.assertEqual(result.cross_mode, "DTCS->DTCS")
         self.assertEqual(result.dtcs, 23)
@@ -516,7 +857,8 @@ class TestDifferentParameterSets(base.BaseTest):
 
     def test_decimal_dcs_encoding(self):
         model = kenwood_tone.KenwoodToneModel(
-            dcs_base=0x4000, pol_mask=0x2000, dcs_enc_base=10)
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=10)
         val = model._set_tone_val(123, "N")
         self.assertEqual(val, 0x4000 + 123)
 
@@ -525,5 +867,20 @@ class TestDifferentParameterSets(base.BaseTest):
         self.assertEqual(pol, "N")
 
         code, pol = model._get_tone_val(0x4000 + 123 + 0x2000)
+        self.assertEqual(code, 123)
+        self.assertEqual(pol, "R")
+
+    def test_bcd_dcs_encoding(self):
+        model = kenwood_tone.KenwoodToneModel(
+            dcs_base=0x4000, pol_mask=0x2000,
+            dcs_enc_base=16, tone_enc_base=16)
+        val = model._set_tone_val(123, "N")
+        self.assertEqual(val, 0x4123)
+
+        code, pol = model._get_tone_val(0x4123)
+        self.assertEqual(code, 123)
+        self.assertEqual(pol, "N")
+
+        code, pol = model._get_tone_val(0x4123 + 0x2000)
         self.assertEqual(code, 123)
         self.assertEqual(pol, "R")


### PR DESCRIPTION
Related to issue #11669 and PR #1589

First half of BCD work on kenwood_tone functions.

As part of the 5RH driver work, it was suggested to look at using the
kenwood_tone functions as the data appeared to be similar. A closer
look showed that they were similar, but not enough to be functional.

The existing Kenwood function puts the tone frequency * 10 into a 16-bit
integer, such that 100.0 Hz becomes 1000 which becomes 0x03E8.

For the 5RH, the tone frequency * 10 is stored as a BCD (which is
effectively hexadecimal with six digits ignored). In this case, 100.0 Hz
becomes 1000 which becomes 0x1000.

In the process of testing the code, I modified the h777 driver to use it,
and discovered that those radios also stored the DCS code as BCD. Meaning
that a DCS code of 031, which would be stored as 0x0019 in octal or 0x001F
in decimal, would instead be stored as 0x0031.

The addition of the tone_enc_base variable for processing tone frequencies
as BCD, and the ability to set dcs_enc_base to 16 (effectively processing
as BCD), should widen the pool of potential users for this function, and
cut down on the number of separate tone implemenations and their tests.
The changes made to the h777 driver are an example of this.

With Dan's suggestion, this PR has been split into two parts: implementing
the first half (decoding with _get_tone_val()) to test against existing
code for encoding. The next commit will then implement the encoding half.

All test cases were duplicated using two tone models; model_dec with
dcs_enc_base defaulted to 8 and tone_enc_base defaulted to 10, and
model_bcd with dcs_enc_base and tone_enc_base both set to 16.
Both models allow testing new inputs and outputs, as well as validating
that the new settings do not interfere with parsing when it is not
expected to.
