### PR TITLE
Default Int vs. Default Float

### DIFF
--- a/chirp/chirp_common.py
+++ b/chirp/chirp_common.py
@@ -178,7 +178,7 @@ def dBm_to_watts(dBm):
 class PowerLevel:
     """Represents a power level supported by a radio"""
 
-    def __init__(self, label, watts=0, dBm=0):
+    def __init__(self, label, watts=0.0, dBm=0.0):
         if watts:
             dBm = watts_to_dBm(watts)
         self._power = float(dBm)


### PR DESCRIPTION

Setting a default value for watts and dBm as an integer instead of a float means that linters such as Pylance in VSCode will display an error: Argument of type "float" cannot be assigned to parameter "watts" of type "int" in function "__init__"
   "float" is not assignable to "int"

This error appears in every single driver that uses a floating point value for power.

Changing the default value from "0" to "0.0" means that both watts and dBm will get treated as a floating point value at all times.
