### PR TITLE
Documentation: Baofeng T-20(FRS) and Retevis RT22 (clone)

### DIFF
--- a/chirp/drivers/radtel_t18.py
+++ b/chirp/drivers/radtel_t18.py
@@ -563,6 +563,10 @@ class T18Radio(chirp_common.CloneModeRadio):
         mem.extra = RadioSettingGroup("Extra", "extra")
         rs = RadioSetting("bcl", "Busy Channel Lockout",
                           RadioSettingValueBoolean(not _mem.bcl))
+        rs.set_doc(
+            "Prevents transmitting on this channel while another station is "
+            "already using it. Pressing PTT on a busy channel sounds an "
+            "alert tone instead of keying the transmitter.")
         mem.extra.append(rs)
         if self.MODEL != "RB18" and self.MODEL != "RB618" and \
                 self.MODEL != "FRS-B1" and self.MODEL != "BF-V8A" and \
@@ -730,12 +734,23 @@ class T18Radio(chirp_common.CloneModeRadio):
         rs = RadioSetting("squelchlevel", "Squelch level",
                           RadioSettingValueInteger(
                               0, 9, _settings.squelchlevel))
+        rs.set_doc(
+            "Sets how strong a received signal must be before the speaker "
+            "unmutes. 0 leaves the squelch open so you hear noise all the "
+            "time, higher values reject more weak signals and noise. Raise "
+            "this value if the radio keeps opening on interference, lower "
+            "it if distant stations are being cut off.")
         basic.append(rs)
 
         rs = RadioSetting("timeouttimer", "Timeout timer",
                           RadioSettingValueList(
                               self.TIMEOUTTIMER_LIST,
                               current_index=_settings.timeouttimer))
+        rs.set_doc(
+            "Limits how long a single transmission may last. When the time "
+            "runs out the radio stops transmitting until PTT is released, "
+            "which prevents overheating and stops a stuck PTT from blocking "
+            "the channel for everyone else.")
         basic.append(rs)
 
         if self.MODEL == "RB18" or self.MODEL == "RB618":
@@ -746,6 +761,13 @@ class T18Radio(chirp_common.CloneModeRadio):
                 self.MODEL == "BF-T20FRS":
             rs = RadioSetting("settings2.scan", "Scan",
                               RadioSettingValueBoolean(_settings2.scan))
+            rs.set_doc(
+                "Enables channel scanning. The radio steps through the "
+                "programmed channels, stops on the first one it finds busy "
+                "and resumes a few seconds after that channel goes quiet. "
+                "Channels marked to skip are left out, and at least two "
+                "channels have to remain in the scan list for scanning to "
+                "start.")
             basic.append(rs)
         else:
             rs = RadioSetting("scanmode", "Scan mode",
@@ -772,6 +794,10 @@ class T18Radio(chirp_common.CloneModeRadio):
                 self.MODEL == "BF-T20FRS":
             rs = RadioSetting("settings2.voicesw", "Voice prompts",
                               RadioSettingValueBoolean(_settings2.voicesw))
+            rs.set_doc(
+                "Announces the channel number and other operations out loud "
+                "as you use the radio. Useful on a radio without a display, "
+                "but it can be intrusive in quiet surroundings.")
             basic.append(rs)
         elif self.MODEL == "RT15":
             rs = RadioSetting("voiceprompt", "Voice prompts",
@@ -789,6 +815,11 @@ class T18Radio(chirp_common.CloneModeRadio):
 
         rs = RadioSetting("batterysaver", "Battery saver",
                           RadioSettingValueBoolean(_settings.batterysaver))
+        rs.set_doc(
+            "Cuts standby power consumption by dozing the receiver once no "
+            "signal has been received for a few seconds. It considerably "
+            "extends battery life, at the cost of occasionally clipping the "
+            "first moment of an incoming transmission.")
         basic.append(rs)
 
         if self.MODEL not in ["RB29",
@@ -799,6 +830,9 @@ class T18Radio(chirp_common.CloneModeRadio):
                               ]:
             rs = RadioSetting("beep", "Beep",
                               RadioSettingValueBoolean(_settings.beep))
+            rs.set_doc(
+                "Sounds a short confirmation tone as you operate the radio. "
+                "Turn it off when the radio has to be used discreetly.")
             basic.append(rs)
 
         if self.MODEL == "RB19" or self.MODEL == "RB19P" \
@@ -991,38 +1025,70 @@ class T18Radio(chirp_common.CloneModeRadio):
                               RadioSettingValueList(
                                   SIDEKEYV8A_LIST,
                                   current_index=_settings.sidekey2))
+            rs.set_doc(
+                "Chooses what the programmable key does: Monitor opens the "
+                "squelch so that signals too weak to break it can still be "
+                "heard, High/Low Power switches the transmit power, and "
+                "Alarm triggers the emergency alarm.")
             basic.append(rs)
 
             rs = RadioSetting("settings2.rxemergency", "RX emergency",
                               RadioSettingValueBoolean(_settings2.rxemergency))
+            rs.set_doc(
+                "Lets this radio respond to an emergency alarm sent by "
+                "another radio on the same channel instead of ignoring it.")
             basic.append(rs)
 
             rs = RadioSetting("settings2.voiceselect", "Language",
                               RadioSettingValueList(
                                   VOICE_LIST2,
                                   current_index=_settings2.voiceselect))
+            rs.set_doc(
+                "Selects the language the spoken voice prompts use. It has "
+                "no effect unless Voice prompts are enabled.")
             basic.append(rs)
 
             rs = RadioSetting("settings2.hivoltnotx",
                               "High voltage inhibit TX",
                               RadioSettingValueBoolean(_settings2.hivoltnotx))
+            rs.set_doc(
+                "Blocks transmitting while the battery voltage is above the "
+                "safe range, which protects the radio when an out-of-spec "
+                "battery or charger is fitted.")
             basic.append(rs)
 
             rs = RadioSetting("settings2.lovoltnotx", "Low voltage inhibit TX",
                               RadioSettingValueBoolean(_settings2.lovoltnotx))
+            rs.set_doc(
+                "Blocks transmitting once the battery is nearly flat. "
+                "Transmitting draws far more current than receiving, so "
+                "this keeps the remaining charge available for listening.")
             basic.append(rs)
 
             rs = RadioSetting("settings2.vox", "VOX",
                               RadioSettingValueBoolean(_settings2.vox))
+            rs.set_doc(
+                "Voice operated transmit. The radio starts transmitting "
+                "when you speak towards the microphone, so hands-free "
+                "conversation is possible without pressing PTT.")
             basic.append(rs)
 
             rs = RadioSetting("settings2.voxnotxonrx", "RX disable VOX",
                               RadioSettingValueBoolean(_settings2.voxnotxonrx))
+            rs.set_doc(
+                "Suspends VOX while a signal is being received, so that "
+                "your own voice does not key the transmitter on top of the "
+                "station you are listening to.")
             basic.append(rs)
 
             rs = RadioSetting("settings2.voxgain", "Vox Gain",
                               RadioSettingValueInteger(
                                   1, 5, _settings2.voxgain))
+            rs.set_doc(
+                "Sets the VOX sensitivity, on a scale of 1 to 5. Too "
+                "sensitive a setting keys the transmitter on the noise "
+                "around the radio, too insensitive a setting fails to pick "
+                "up your voice. Only has an effect when VOX is enabled.")
             basic.append(rs)
 
         if self.MODEL == "RB29" or self.MODEL == "RB629":

--- a/chirp/drivers/retevis_rt22.py
+++ b/chirp/drivers/retevis_rt22.py
@@ -515,45 +515,86 @@ class RT22Radio(chirp_common.CloneModeRadio):
 
         rs = RadioSetting("squelch", "Squelch Level",
                           RadioSettingValueInteger(0, 9, _settings.squelch))
+        rs.set_doc(
+            "Sets how strong a received signal must be before the speaker "
+            "unmutes. 0 leaves the squelch open so you hear noise all the "
+            "time, higher values reject more weak signals and noise. Raise "
+            "this value if the radio keeps opening on interference, lower "
+            "it if distant stations are being cut off.")
         basic.append(rs)
 
         rs = RadioSetting("tot", "Time-out timer",
                           RadioSettingValueList(
                               TIMEOUTTIMER_LIST,
                               current_index=_settings.tot))
+        rs.set_doc(
+            "Limits how long a single transmission may last. When the time "
+            "runs out the radio stops transmitting until PTT is released, "
+            "which prevents overheating and stops a stuck PTT from blocking "
+            "the channel for everyone else.")
         basic.append(rs)
 
         rs = RadioSetting("voice", "Voice Prompts",
                           RadioSettingValueList(
                               VOICE_LIST, current_index=_settings.voice))
+        rs.set_doc(
+            "Announces the channel number out loud in the selected language "
+            "each time you change channel. Useful on a radio without a "
+            "display. Off silences the announcements.")
         basic.append(rs)
 
         rs = RadioSetting("pf2key", "PF2 Key",
                           RadioSettingValueList(
                               PF2KEY_LIST, current_index=_settings.pf2key))
+        rs.set_doc(
+            "Chooses what the programmable key does when held down: Scan "
+            "steps through the channels looking for activity, Local Alarm "
+            "sounds the alarm on this radio, and Remote Alarm instead sends "
+            "the alarm to the other radios on the channel without sounding "
+            "it here.")
         basic.append(rs)
 
         rs = RadioSetting("vox", "Vox",
                           RadioSettingValueBoolean(_settings.vox))
+        rs.set_doc(
+            "Voice operated transmit. The radio starts transmitting when "
+            "you speak towards the microphone, so hands-free conversation "
+            "is possible without pressing PTT.")
         basic.append(rs)
 
         rs = RadioSetting("voxgain", "VOX Level",
                           RadioSettingValueList(
                               VOX_LIST, current_index=_settings.voxgain))
+        rs.set_doc(
+            "Sets the VOX sensitivity. Too sensitive a setting keys the "
+            "transmitter on the noise around the radio, too insensitive a "
+            "setting fails to pick up your voice. OFF disables VOX.")
         basic.append(rs)
 
         rs = RadioSetting("voxdelay", "VOX Delay Time (Old | New)",
                           RadioSettingValueList(
                               VOXDELAY_LIST,
                               current_index=_settings.voxdelay))
+        rs.set_doc(
+            "How long the transmitter stays keyed after you stop speaking. "
+            "A longer delay avoids dropping the transmission during natural "
+            "pauses in speech.")
         basic.append(rs)
 
         rs = RadioSetting("save", "Battery Save",
                           RadioSettingValueBoolean(_settings.save))
+        rs.set_doc(
+            "Cuts standby power consumption by dozing the receiver once no "
+            "signal has been received for a few seconds. It considerably "
+            "extends battery life, at the cost of occasionally clipping the "
+            "first moment of an incoming transmission.")
         basic.append(rs)
 
         rs = RadioSetting("beep", "Beep",
                           RadioSettingValueBoolean(_settings.beep))
+        rs.set_doc(
+            "Sounds a short confirmation tone as you operate the radio. "
+            "Turn it off when the radio has to be used discreetly.")
         basic.append(rs)
 
         if self.MODEL != "W31E":
@@ -571,11 +612,18 @@ class RT22Radio(chirp_common.CloneModeRadio):
                 rs = RadioSetting("embedded_msg.line1", "Embedded Message 1",
                                   RadioSettingValueString(0, 32, _filter(
                                       _message.line1)))
+                rs.set_doc(
+                    "Free-form text of up to 32 characters stored in the "
+                    "radio, typically used as an owner or service note. The "
+                    "radio has no display, so it is never shown on the "
+                    "radio itself.")
                 basic.append(rs)
 
                 rs = RadioSetting("embedded_msg.line2", "Embedded Message 2",
                                   RadioSettingValueString(0, 32, _filter(
                                       _message.line2)))
+                rs.set_doc(
+                    "Second line of the free-form text stored in the radio.")
                 basic.append(rs)
 
         return top


### PR DESCRIPTION
Based on the manuals in english, I've auto-generated user-friendly descriptions for radio settings for Baofeng T-20(FRS) and Retevis RT22 (clone).
