### PR TITLE
Add StartupWMClass to desktop file.

### DIFF
--- a/chirp/share/chirp.desktop
+++ b/chirp/share/chirp.desktop
@@ -11,3 +11,4 @@ MimeType=x-scheme-handler/chirp
 Categories=Utility;HamRadio
 Keywords=Hamradio;Programming;Handheld;Radio;Amateur;Programmer
 StartupNotify=true
+StartupWMClass=chirpw


### PR DESCRIPTION
Needed so that Chirp icon is shown in launcher. Background: 

https://specifications.freedesktop.org/desktop-entry/latest/recognized-keys.html#StartupWMClass

https://discussion.fedoraproject.org/t/how-to-ensure-a-launcher-icon-gets-linked-to-the-application-it-launches/67688 

https://askubuntu.com/questions/1553339/launch-icon-displays-config-icon-rather-than-specific-icon

https://github.com/flathub/com.google.Chrome/issues/446