### PR TITLE
TM-D710 Fixes

### DIFF
--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -80,15 +80,13 @@ def _command(ser, cmd, rsplen, w8t=0.01):
 
 def _connect_radio(radio):
     """Determine baud rate and verify radio on-line"""
-    global BAUD
     xid = "D710" + radio.SHORT
     resp = kenwood_live.KenwoodLiveRadio(None).get_id(radio.pipe)
     # If we are running at 9600 baud (the default), then the default
     # timeout of 250ms is too short for some clone-mode responses. 1s should
     # always be enough.
     radio.pipe.timeout = 1
-    BAUD = radio.pipe.baudrate      # As detected by kenwood_live
-    LOG.debug("Got [%s] at %i Baud." % (resp, BAUD))
+    LOG.debug("Got [%s] at %i Baud." % (resp, radio.pipe.baudrate))
     resp = resp[3:]     # Strip "ID " prefix
     if len(resp) > 2:   # Got something from "ID"
         if resp == xid:     # Good comms
@@ -1535,7 +1533,6 @@ class KenwoodTMD710Radio(KenwoodTMx710Radio):
 
     def _read_mem(radio):
         """ Load the memory map """
-        global BAUD
         status = chirp_common.Status()
         status.cur = 0
         val = 0
@@ -1547,7 +1544,6 @@ class KenwoodTMD710Radio(KenwoodTMx710Radio):
 
         data = ""
 
-        radio.pipe.baudrate = BAUD
         cmc = b"0M PROGRAM" + TERM
         resp0 = _command(radio.pipe, cmc, 3, W8S)
         junk = radio.pipe.read(16)       # flushit
@@ -1582,12 +1578,10 @@ class KenwoodTMD710Radio(KenwoodTMx710Radio):
         _update_status(radio, status)
         # Exit Prog mode, no TERM
         resp = _command(radio.pipe, b"E", 2, W8S)     # Rtns 06 0d
-        radio.pipe.baudrate = BAUD
         return data
 
     def _write_mem(radio):
         """ PROG MCP Blocks Send """
-        global BAUD
         # UI progress
         status = chirp_common.Status()
         status.cur = 0
@@ -1599,7 +1593,6 @@ class KenwoodTMD710Radio(KenwoodTMx710Radio):
         radio.status_fn(status)
 
         imgadr = 0
-        radio.pipe.baudrate = BAUD
         resp0 = _command(radio.pipe, b"0M PROGRAM" + TERM, 3, W8S)
         # Read block 0 magic header thingy, save it
         cmc = b"R" + bytes([0, 0, 4])
@@ -1974,7 +1967,6 @@ class KenwoodTMD710GRadio(KenwoodTMx710Radio):
 
     def _read_mem(radio):
         """ Load the memory map """
-        global BAUD
         status = chirp_common.Status()
         status.cur = 0
         val = 0
@@ -1986,7 +1978,6 @@ class KenwoodTMD710GRadio(KenwoodTMx710Radio):
 
         data = b""
 
-        radio.pipe.baudrate = BAUD
         resp0 = radio.pipe.read(16)     # flush
         cmc = b"0M PROGRAM" + TERM
         resp0 = _command(radio.pipe, cmc, 3, W8S)
@@ -2020,12 +2011,10 @@ class KenwoodTMD710GRadio(KenwoodTMx710Radio):
                 _update_status(radio, status)        # UI Update
         # Exit Prog mode, no TERM
         resp = _command(radio.pipe, b"E", 0, W8S)
-        radio.pipe.baudrate = BAUD
         return data
 
     def _write_mem(radio):
         """ PROG MCP Blocks Send """
-        global BAUD
         # UI progress
         status = chirp_common.Status()
         status.cur = 0
@@ -2037,7 +2026,6 @@ class KenwoodTMD710GRadio(KenwoodTMx710Radio):
         radio.status_fn(status)
 
         imgadr = 0
-        radio.pipe.baudrate = BAUD
         resp0 = _command(radio.pipe, b"0M PROGRAM" + TERM, 3, W8S)
         radio.pipe.baudrate = 57600
         LOG.debug("Switching to 57600 baud upload.")
@@ -2087,5 +2075,3 @@ class KenwoodTMD710GRadio(KenwoodTMx710Radio):
         resp0 = _command(radio.pipe, cmc, 16, W8S)
         # Write E to Exit PROG mode
         resp = _command(radio.pipe, b"E", 0, W8S)
-        radio.pipe.baudrate = BAUD
-        return

--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -80,6 +80,9 @@ def _command(ser, cmd, rsplen, w8t=0.01):
 
 def _connect_radio(radio):
     """Determine baud rate and verify radio on-line"""
+    status = chirp_common.Status()
+    status.msg = 'Probing baud rate of radio'
+    _update_status(radio, status)
     xid = "D710" + radio.SHORT
     resp = kenwood_live.KenwoodLiveRadio(None).get_id(radio.pipe)
     # If we are running at 9600 baud (the default), then the default

--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -103,7 +103,6 @@ def _update_status(self, status, step=1):
     """ Increment status bar """
     status.cur += step
     self.status_fn(status)
-    return
 
 
 def _val_list(setting, opts, obj, atrb, fix=0, ndx=-1):
@@ -117,7 +116,6 @@ def _val_list(setting, opts, obj, atrb, fix=0, ndx=-1):
         setattr(obj[ndx], atrb, value)
     else:
         setattr(obj, atrb, value)
-    return
 
 
 class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
@@ -417,7 +415,6 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
                 setattr(_mem, "splitstep", val)
             else:
                 setattr(_mem, ext.get_name(), ext.value)
-        return
 
     def get_settings(self):
         """Translate the MEM_FORMAT structs into settings in the UI"""
@@ -459,7 +456,6 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
                 setattr(obj, atrb, value)
             else:
                 setattr(obj[ndx], atrb, value)
-            return
 
         def _mhz_val(setting, obj, atrb, ndx=-1, ndy=-1):
             """ Callback to set freq back to Hz """
@@ -473,7 +469,6 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
                     setattr(obj[ndx].progvfo[ndy], stx[1], vx)
                 else:
                     setattr(obj[ndx], atrb, vx)
-            return
 
         def _char_to_str(chrx):
             """ Remove ff pads from char array """
@@ -494,7 +489,6 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
                 raise errors.RadioError(sx)
             str2 = str1.ljust(6, chr(255))      # pad to 6 with ff's
             setattr(obj, atrb, str2)
-            return
 
         def _pad_str(setting, lenstr, padchr, obj, atrb, ndx=-1):
             """ pad string to lenstr with padchr  """
@@ -504,7 +498,6 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
                 setattr(obj, atrb, str2)
             else:
                 setattr(obj[ndx], atrb, str2)
-            return
 
         # ===== BASIC GROUP =====
         sx = _char_to_str(_com.comnt)
@@ -1235,7 +1228,6 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
                     except Exception:
                         LOG.debug(element.get_name())
                         raise
-        return
 
     @classmethod
     def match_model(cls, fdata, fyle):
@@ -1657,7 +1649,6 @@ class KenwoodTMD710Radio(KenwoodTMx710Radio):
             raise errors.RadioError(sx)
         # Write E to Exit PROG mode
         resp = _command(radio.pipe, b"E", 2, W8S)
-        return
 
 
 @directory.register

--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -205,6 +205,9 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
             LOG.exception('Unexpected error during download')
             raise errors.RadioError('Unexpected error communicating '
                                     'with the radio')
+        finally:
+            resp = _command(self.pipe, b"E", 0, W8S)
+
         self._mmap = memmap.MemoryMapBytes(data)
         self.process_mmap()
 
@@ -221,6 +224,8 @@ class KenwoodTMx710Radio(chirp_common.CloneModeRadio):
             LOG.exception('Unexpected error during upload')
             raise errors.RadioError('Unexpected error communicating '
                                     'with the radio')
+        finally:
+            resp = _command(self.pipe, b"E", 0, W8S)
 
     def process_mmap(self):
         """Process the mem map into the mem object"""
@@ -1548,7 +1553,6 @@ class KenwoodTMD710Radio(KenwoodTMx710Radio):
                 resp0 = _command(radio.pipe, cmc, 260, W8S)
                 junk = _command(radio.pipe, ACK, 1, W8S)
                 if len(resp0) < 260:
-                    junk = _command(radio.pipe, b"E", 2, W8S)
                     sx = "Block 0x%x read error: " % bkx
                     sx += "Got %i bytes, expected 260." % len(resp0)
                     LOG.error(sx)
@@ -1571,8 +1575,6 @@ class KenwoodTMD710Radio(KenwoodTMx710Radio):
         data += resp0[4:]
         junk = _command(radio.pipe, ACK, 1, W8S)
         _update_status(radio, status)
-        # Exit Prog mode, no TERM
-        resp = _command(radio.pipe, b"E", 2, W8S)     # Rtns 06 0d
         return data
 
     def _write_mem(radio):
@@ -1650,8 +1652,6 @@ class KenwoodTMD710Radio(KenwoodTMx710Radio):
             LOG.error("Mht0 Write error at 00 00 04 , no ACK.")
             sx = "Radio failed to acknowledge upload packet!"
             raise errors.RadioError(sx)
-        # Write E to Exit PROG mode
-        resp = _command(radio.pipe, b"E", 2, W8S)
 
 
 @directory.register
@@ -1987,7 +1987,6 @@ class KenwoodTMD710GRadio(KenwoodTMx710Radio):
                                  radio._make_command(b'R', addr, 0),
                                  radio._packet_size[blkn], W8S)
                 if len(resp0) < radio._packet_size[blkn]:
-                    junk = _command(radio.pipe, b"E", 0, W8S)
                     lb = len(resp0)
                     xb = radio._packet_size[blkn]
                     sx = "Block 0x%x, 0x%x read error: " % (blkn, bkx)
@@ -2003,8 +2002,6 @@ class KenwoodTMD710GRadio(KenwoodTMx710Radio):
                 else:
                     data += resp0[5:]       # skip cmd echo
                 _update_status(radio, status)        # UI Update
-        # Exit Prog mode, no TERM
-        resp = _command(radio.pipe, b"E", 0, W8S)
         return data
 
     def _write_mem(radio):
@@ -2067,5 +2064,3 @@ class KenwoodTMD710GRadio(KenwoodTMx710Radio):
         resp0 = _command(radio.pipe, cmc, 1, W8S)
         cmc = radio._make_command(b'Z', radio._block_addr[0], 1, mht0[0:1])
         resp0 = _command(radio.pipe, cmc, 16, W8S)
-        # Write E to Exit PROG mode
-        resp = _command(radio.pipe, b"E", 0, W8S)

--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -83,6 +83,10 @@ def _connect_radio(radio):
     global BAUD
     xid = "D710" + radio.SHORT
     resp = kenwood_live.KenwoodLiveRadio(None).get_id(radio.pipe)
+    # If we are running at 9600 baud (the default), then the default
+    # timeout of 250ms is too short for some clone-mode responses. 1s should
+    # always be enough.
+    radio.pipe.timeout = 1
     BAUD = radio.pipe.baudrate      # As detected by kenwood_live
     LOG.debug("Got [%s] at %i Baud." % (resp, BAUD))
     resp = resp[3:]     # Strip "ID " prefix

--- a/chirp/drivers/tmd710.py
+++ b/chirp/drivers/tmd710.py
@@ -2048,7 +2048,7 @@ class KenwoodTMD710GRadio(KenwoodTMx710Radio):
                     data = radio.get_mmap()[imgadr:imgadr + 256]
                 cmc = radio._make_command(b'W', addr, 0, data)
 
-                resp0 = _command(radio.pipe, cmc, 6, W8S)
+                resp0 = _command(radio.pipe, cmc, 1, W8S)
                 if bkx > 0 and resp0 != ACK:
                     LOG.error("Packet 0x%x Write error, no ACK!" % bkx)
                     sx = "Radio failed to acknowledge upload. "


### PR DESCRIPTION
- **tmd710: Fix clone mode at lower speeds**
- **tmd710: Remove bogus global baud re-setting**
- **tmd710: Remove unnecessary C-style naked returns**
- **tmd710: Report status while probing baud rate**
- **tmd710: Terminate clone properly in finally block**
- **tmd710: Fix TM-D710G extremely slow write speed**
