### PR TITLE
kenwood_itm: Fix DCS parsing

### DIFF
--- a/chirp/drivers/kenwood_itm.py
+++ b/chirp/drivers/kenwood_itm.py
@@ -18,6 +18,7 @@ import csv
 import logging
 
 from chirp import chirp_common, errors, directory
+from chirp import kenwood_tone
 from chirp.drivers import generic_csv
 
 LOG = logging.getLogger(__name__)
@@ -63,17 +64,12 @@ class ITMRadio(generic_csv.CSVRadio):
         return mem
 
     def _clean_tmode(self, headers, line, mem):
-        rtone = eval(generic_csv.get_datum_by_header(headers, line, "TXSIG"))
-        ctone = eval(generic_csv.get_datum_by_header(headers, line, "RXSIG"))
+        txtone = kenwood_tone.parse_qtdqt(
+            generic_csv.get_datum_by_header(headers, line, "TXSIG"))
+        rxtone = kenwood_tone.parse_qtdqt(
+            generic_csv.get_datum_by_header(headers, line, "RXSIG"))
 
-        if rtone:
-            mem.tmode = "Tone"
-        if ctone:
-            mem.tmode = "TSQL"
-
-        mem.rtone = rtone or 88.5
-        mem.ctone = ctone or mem.rtone
-
+        chirp_common.split_tone_decode(mem, txtone, rxtone)
         return mem
 
     def load(self, filename=None):

--- a/chirp/kenwood_tone.py
+++ b/chirp/kenwood_tone.py
@@ -217,6 +217,8 @@ def parse_qtdqt(selcall):
         try:
             val = int(selcall[1:4])
             pol = selcall[4]
+            if pol == 'I':
+                pol = 'R'
             return 'DTCS', val, pol
         except (ValueError, IndexError):
             raise ValueError(
@@ -244,6 +246,9 @@ def format_qtdqt(mode, val, pol):
     :returns: A selcall string like '103.5' or 'D023N'
     """
     if mode == 'DTCS':
+        pol = pol.upper()
+        if pol == 'R':
+            pol = 'I'
         return 'D%03.3i%s' % (val, pol)
     elif mode == 'Tone':
         return '%3.1f' % val

--- a/tests/unit/test_kenwood_tone.py
+++ b/tests/unit/test_kenwood_tone.py
@@ -2085,6 +2085,12 @@ class TestParseQtdqt(base.BaseTest):
         self.assertEqual(val, 32)
         self.assertEqual(pol, "R")
 
+    def test_parse_dcs_inverse(self):
+        mode, val, pol = kenwood_tone.parse_qtdqt("D032I")
+        self.assertEqual(mode, "DTCS")
+        self.assertEqual(val, 32)
+        self.assertEqual(pol, "R")
+
     def test_parse_dcs_lowercase(self):
         mode, val, pol = kenwood_tone.parse_qtdqt("d023n")
         self.assertEqual(mode, "DTCS")
@@ -2114,7 +2120,7 @@ class TestFormatQtdqt(base.BaseTest):
 
     def test_format_dcs_reverse(self):
         result = kenwood_tone.format_qtdqt("DTCS", 32, "R")
-        self.assertEqual(result, "D032R")
+        self.assertEqual(result, "D032I")
 
     def test_format_tone(self):
         result = kenwood_tone.format_qtdqt("Tone", 103.5, "")


### PR DESCRIPTION
This fixes kenwood_itm DCS parsing as previously the squelch fields
were assumed to only be a float (i.e. a CTCSS tone).

This also fixes kenwood_tone to properly parse and format DCS codes
with the kenwood-style "I" instead of the CHIRP/Icom-style "R"
notation.
