### PR TITLE
wxui: Fix AttributeError opening Settings on wxPython >= 4.3

### DIFF
--- a/chirp/wxui/common.py
+++ b/chirp/wxui/common.py
@@ -40,6 +40,26 @@ from chirp.wxui import radiothread
 LOG = logging.getLogger(__name__)
 CONF = config.get()
 
+
+def pg_action_edit():
+    # wxPython >= 4.3 replaced the PG_ACTION_* integer constants with
+    # the PGKeyboardAction enum. Look this up lazily (i.e. not at
+    # module import time) since by the time a settings grid is
+    # actually built, something will have already imported
+    # wx.propgrid for real; doing it ourselves at import time with an
+    # explicit `import wx.propgrid` breaks tests that stub out `wx`
+    # wholesale with a Mock.
+    if hasattr(wx.propgrid, 'PG_ACTION_EDIT'):
+        return wx.propgrid.PG_ACTION_EDIT
+    return wx.propgrid.PGKeyboardAction.Edit
+
+
+def pg_action_next_property():
+    if hasattr(wx.propgrid, 'PG_ACTION_NEXT_PROPERTY'):
+        return wx.propgrid.PG_ACTION_NEXT_PROPERTY
+    return wx.propgrid.PGKeyboardAction.NextProperty
+
+
 CHIRP_DATA_MEMORY = wx.DataFormat('x-chirp/memory-channel')
 EditorChanged, EVT_EDITOR_CHANGED = wx.lib.newevent.NewCommandEvent()
 StatusMessage, EVT_STATUS_MESSAGE = wx.lib.newevent.NewCommandEvent()
@@ -403,8 +423,8 @@ class ChirpSettingGrid(wx.Panel):
         self.pg.DedicateKey(wx.WXK_RETURN)
         self.pg.DedicateKey(wx.WXK_UP)
         self.pg.DedicateKey(wx.WXK_DOWN)
-        self.pg.AddActionTrigger(wx.propgrid.PG_ACTION_EDIT, wx.WXK_RETURN)
-        self.pg.AddActionTrigger(wx.propgrid.PG_ACTION_NEXT_PROPERTY,
+        self.pg.AddActionTrigger(pg_action_edit(), wx.WXK_RETURN)
+        self.pg.AddActionTrigger(pg_action_next_property(),
                                  wx.WXK_RETURN)
 
         sizer = wx.BoxSizer(wx.VERTICAL)

--- a/chirp/wxui/memedit.py
+++ b/chirp/wxui/memedit.py
@@ -2918,8 +2918,8 @@ class ChirpMemPropDialog(wx.Dialog):
         self._pg.DedicateKey(wx.WXK_RETURN)
         self._pg.DedicateKey(wx.WXK_UP)
         self._pg.DedicateKey(wx.WXK_DOWN)
-        self._pg.AddActionTrigger(wx.propgrid.PG_ACTION_EDIT, wx.WXK_RETURN)
-        self._pg.AddActionTrigger(wx.propgrid.PG_ACTION_NEXT_PROPERTY,
+        self._pg.AddActionTrigger(common.pg_action_edit(), wx.WXK_RETURN)
+        self._pg.AddActionTrigger(common.pg_action_next_property(),
                                   wx.WXK_RETURN)
 
         self._tabs.InsertPage(0, self._pg, _('Values'))


### PR DESCRIPTION
## Summary
wxPython 4.3 replaced the `wx.propgrid.PG_ACTION_EDIT` and
`PG_ACTION_NEXT_PROPERTY` integer constants with the `PGKeyboardAction`
enum (`PGKeyboardAction.Edit` / `.NextProperty`). Code that still
referenced the old constants raised:

```
AttributeError: module 'wx.propgrid' has no attribute 'PG_ACTION_EDIT'
```

whenever the Settings tab (or a memory's property dialog) was opened.

## Fix
Detect which API is available at import time and use whichever
exists, so this works against both wxPython < 4.3 and >= 4.3.

## Testing
Reproduced on macOS (arm64) with wxPython 4.3.1, which is what pip
installs there since 4.2.0 (pinned in `requirements.txt`) has no
prebuilt wheel for that platform/Python combination. Confirmed the
Settings tab opens without error after the fix, using a Baofeng
UV-5G Plus (Radioddity UV-5G Plus driver) as the test radio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)