### PR TITLE
Unify Baofeng setting descriptions across drivers

### DIFF
--- a/chirp/drivers/baofeng_digital.py
+++ b/chirp/drivers/baofeng_digital.py
@@ -358,7 +358,9 @@ class BaofengDigital(chirp_common.CloneModeRadio,
 
         rs = RadioSetting("bcl", "BCL",
                           RadioSettingValueBoolean(bcl))
-        rs.set_doc('Busy channel lockout.')
+        rs.set_doc('Prevents transmitting on a channel that is already in '
+                   'use. Pressing PTT on a busy channel sounds an alert '
+                   'tone instead of keying the transmitter.')
         mem.extra.append(rs)
 
         rs = RadioSetting("encryption_key", "Encryption key",

--- a/chirp/drivers/h777.py
+++ b/chirp/drivers/h777.py
@@ -450,8 +450,8 @@ class H777Radio(chirp_common.CloneModeRadio):
         rs = RadioSetting("bcl", "Busy Channel Lockout",
                           RadioSettingValueBoolean(not _mem.bcl))
         rs.set_doc('Prevents transmitting on a channel that is already in '
-                   'use. Pressing PTT while the channel is busy emits an '
-                   'alert tone and inhibits the transmitter')
+                   'use. Pressing PTT on a busy channel sounds an alert '
+                   'tone instead of keying the transmitter.')
         mem.extra.append(rs)
         if self._has_scramble:
             rs = RadioSetting("beatshift", "Beat Shift(scramble)",
@@ -511,14 +511,17 @@ class H777Radio(chirp_common.CloneModeRadio):
 
         rs = RadioSetting("voiceprompt", "Voice prompt",
                           RadioSettingValueBoolean(_settings.voiceprompt))
-        rs.set_doc('Announces channel changes and operations by voice')
+        rs.set_doc('Announces the channel number and other operations out '
+                   'loud as you use the radio. It can be intrusive in quiet '
+                   'surroundings.')
         basic.append(rs)
 
         rs = RadioSetting("voicelanguage", "Voice language",
                           RadioSettingValueList(
                               VOICE_LIST,
                               current_index=_settings.voicelanguage))
-        rs.set_doc('Language used for the voice prompts (Chinese or English)')
+        rs.set_doc('Selects the language the spoken voice prompts use. It '
+                   'has no effect unless Voice prompts are enabled.')
         basic.append(rs)
 
         rs = RadioSetting("scan", "Scan",
@@ -540,17 +543,17 @@ class H777Radio(chirp_common.CloneModeRadio):
 
         rs = RadioSetting("vox", "VOX",
                           RadioSettingValueBoolean(_settings.vox))
-        rs.set_doc('Voice Operated Transmit keys the transmitter when you '
-                   'speak into the microphone, eliminating the need to '
-                   'press PTT')
+        rs.set_doc('Voice operated transmit. The radio starts transmitting '
+                   'when you speak towards the microphone, so hands-free '
+                   'conversation is possible without pressing PTT.')
         basic.append(rs)
 
         rs = RadioSetting("voxlevel", "VOX level",
                           RadioSettingValueInteger(
                               1, self.MAX_VOXLEVEL, _settings.voxlevel + 1))
-        rs.set_doc('VOX gain sensitivity. If set too sensitive the radio '
-                   'keys up on background noise; if not sensitive enough it '
-                   'will not pick up your voice')
+        rs.set_doc('Sets the VOX sensitivity. Too sensitive a setting keys '
+                   'the transmitter on the noise around the radio, too '
+                   'insensitive a setting fails to pick up your voice.')
         basic.append(rs)
 
         rs = RadioSetting("voxinhibitonrx", "Inhibit VOX on receive",
@@ -590,24 +593,30 @@ class H777Radio(chirp_common.CloneModeRadio):
         rs = RadioSetting("settings2.beep", "Beep",
                           RadioSettingValueBoolean(
                               self._memobj.settings2.beep))
-        rs.set_doc('When enabled, the radio emits a short tone when you '
-                   'select a channel that has nothing programmed')
+        rs.set_doc('Sounds a short confirmation tone as you operate the '
+                   'radio. Turn it off when the radio has to be used '
+                   'discreetly.')
         basic.append(rs)
 
         rs = RadioSetting("settings2.batterysaver", "Battery saver",
                           RadioSettingValueBoolean(
                               self._memobj.settings2.batterysaver))
-        rs.set_doc('Reduces battery power used when no signal is being '
-                   'received. Activates automatically about 10 seconds '
-                   'after the last received signal or operation')
+        rs.set_doc('Cuts standby power consumption by switching the receiver '
+                   'off and on in a repeating cycle once no signal has been '
+                   'received for a few seconds. It considerably extends '
+                   'battery life, at the cost of occasionally clipping the '
+                   'first moment of an incoming transmission.')
         basic.append(rs)
 
         rs = RadioSetting("settings2.squelchlevel", "Squelch level",
                           RadioSettingValueInteger(
                               0, 9, self._memobj.settings2.squelchlevel))
-        rs.set_doc('Mutes the speaker when no signal is present so that you '
-                   'only hear sound when a signal is received. Higher '
-                   'levels require a stronger signal to unmute')
+        rs.set_doc('Sets how strong a received signal must be before the '
+                   'speaker unmutes. 0 leaves the squelch open so you hear '
+                   'noise all the time, higher values reject more weak '
+                   'signals and noise. Raise this value if the speaker keeps '
+                   'unmuting on interference, lower it if distant stations '
+                   'are being cut off.')
         basic.append(rs)
 
         if self._has_sidekey:
@@ -623,9 +632,10 @@ class H777Radio(chirp_common.CloneModeRadio):
             RadioSettingValueList(
                 TIMEOUTTIMER_LIST,
                 current_index=self._memobj.settings2.timeouttimer))
-        rs.set_doc('Limits the maximum length of a single transmission to '
-                   'prevent overheating the radio. An alert sounds when the '
-                   'limit is reached')
+        rs.set_doc('Limits how long a single transmission may last. When '
+                   'the time runs out the radio stops transmitting until '
+                   'PTT is released, which prevents overheating and stops a '
+                   'stuck PTT from blocking the channel for everyone else.')
         basic.append(rs)
 
         return top

--- a/chirp/drivers/radtel_t18.py
+++ b/chirp/drivers/radtel_t18.py
@@ -564,9 +564,9 @@ class T18Radio(chirp_common.CloneModeRadio):
         rs = RadioSetting("bcl", "Busy Channel Lockout",
                           RadioSettingValueBoolean(not _mem.bcl))
         rs.set_doc(
-            "Prevents transmitting on this channel while another station is "
-            "already using it. Pressing PTT on a busy channel sounds an "
-            "alert tone instead of keying the transmitter.")
+            "Prevents transmitting on a channel that is already in use. "
+            "Pressing PTT on a busy channel sounds an alert tone instead of "
+            "keying the transmitter.")
         mem.extra.append(rs)
         if self.MODEL != "RB18" and self.MODEL != "RB618" and \
                 self.MODEL != "FRS-B1" and self.MODEL != "BF-V8A" and \
@@ -738,7 +738,7 @@ class T18Radio(chirp_common.CloneModeRadio):
             "Sets how strong a received signal must be before the speaker "
             "unmutes. 0 leaves the squelch open so you hear noise all the "
             "time, higher values reject more weak signals and noise. Raise "
-            "this value if the radio keeps opening on interference, lower "
+            "this value if the speaker keeps unmuting on interference, lower "
             "it if distant stations are being cut off.")
         basic.append(rs)
 
@@ -796,8 +796,8 @@ class T18Radio(chirp_common.CloneModeRadio):
                               RadioSettingValueBoolean(_settings2.voicesw))
             rs.set_doc(
                 "Announces the channel number and other operations out loud "
-                "as you use the radio. Useful on a radio without a display, "
-                "but it can be intrusive in quiet surroundings.")
+                "as you use the radio. It can be intrusive in quiet "
+                "surroundings.")
             basic.append(rs)
         elif self.MODEL == "RT15":
             rs = RadioSetting("voiceprompt", "Voice prompts",
@@ -816,10 +816,11 @@ class T18Radio(chirp_common.CloneModeRadio):
         rs = RadioSetting("batterysaver", "Battery saver",
                           RadioSettingValueBoolean(_settings.batterysaver))
         rs.set_doc(
-            "Cuts standby power consumption by dozing the receiver once no "
-            "signal has been received for a few seconds. It considerably "
-            "extends battery life, at the cost of occasionally clipping the "
-            "first moment of an incoming transmission.")
+            "Cuts standby power consumption by switching the receiver off and "
+            "on in a repeating cycle once no signal has been received for a "
+            "few seconds. It considerably extends battery life, at the cost "
+            "of occasionally clipping the first moment of an incoming "
+            "transmission.")
         basic.append(rs)
 
         if self.MODEL not in ["RB29",
@@ -1085,10 +1086,9 @@ class T18Radio(chirp_common.CloneModeRadio):
                               RadioSettingValueInteger(
                                   1, 5, _settings2.voxgain))
             rs.set_doc(
-                "Sets the VOX sensitivity, on a scale of 1 to 5. Too "
-                "sensitive a setting keys the transmitter on the noise "
-                "around the radio, too insensitive a setting fails to pick "
-                "up your voice. Only has an effect when VOX is enabled.")
+                "Sets the VOX sensitivity. Too sensitive a setting keys the "
+                "transmitter on the noise around the radio, too insensitive "
+                "a setting fails to pick up your voice.")
             basic.append(rs)
 
         if self.MODEL == "RB29" or self.MODEL == "RB629":

--- a/chirp/drivers/retevis_rt22.py
+++ b/chirp/drivers/retevis_rt22.py
@@ -519,7 +519,7 @@ class RT22Radio(chirp_common.CloneModeRadio):
             "Sets how strong a received signal must be before the speaker "
             "unmutes. 0 leaves the squelch open so you hear noise all the "
             "time, higher values reject more weak signals and noise. Raise "
-            "this value if the radio keeps opening on interference, lower "
+            "this value if the speaker keeps unmuting on interference, lower "
             "it if distant stations are being cut off.")
         basic.append(rs)
 
@@ -538,9 +538,8 @@ class RT22Radio(chirp_common.CloneModeRadio):
                           RadioSettingValueList(
                               VOICE_LIST, current_index=_settings.voice))
         rs.set_doc(
-            "Announces the channel number out loud in the selected language "
-            "each time you change channel. Useful on a radio without a "
-            "display. Off silences the announcements.")
+            "Selects the language for spoken radio-operation prompts, or "
+            "disables those prompts.")
         basic.append(rs)
 
         rs = RadioSetting("pf2key", "PF2 Key",
@@ -568,7 +567,7 @@ class RT22Radio(chirp_common.CloneModeRadio):
         rs.set_doc(
             "Sets the VOX sensitivity. Too sensitive a setting keys the "
             "transmitter on the noise around the radio, too insensitive a "
-            "setting fails to pick up your voice. OFF disables VOX.")
+            "setting fails to pick up your voice.")
         basic.append(rs)
 
         rs = RadioSetting("voxdelay", "VOX Delay Time (Old | New)",
@@ -584,10 +583,11 @@ class RT22Radio(chirp_common.CloneModeRadio):
         rs = RadioSetting("save", "Battery Save",
                           RadioSettingValueBoolean(_settings.save))
         rs.set_doc(
-            "Cuts standby power consumption by dozing the receiver once no "
-            "signal has been received for a few seconds. It considerably "
-            "extends battery life, at the cost of occasionally clipping the "
-            "first moment of an incoming transmission.")
+            "Cuts standby power consumption by switching the receiver off and "
+            "on in a repeating cycle once no signal has been received for a "
+            "few seconds. It considerably extends battery life, at the cost "
+            "of occasionally clipping the first moment of an incoming "
+            "transmission.")
         basic.append(rs)
 
         rs = RadioSetting("beep", "Beep",

--- a/chirp/drivers/uv5r.py
+++ b/chirp/drivers/uv5r.py
@@ -1028,9 +1028,9 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
         rs = RadioSetting("bcl", "BCL",
                           RadioSettingValueBoolean(_mem.bcl))
         rs.set_doc(
-            "Busy Channel Lockout. Prevents transmitting on this channel "
-            "while the radio is receiving a signal, even when a different "
-            "CTCSS tone or DCS code keeps that signal muted.")
+            "Prevents transmitting on a channel that is already in use. "
+            "Pressing PTT on a busy channel sounds an alert tone instead of "
+            "keying the transmitter.")
         mem.extra.append(rs)
 
         rs = RadioSetting("pttid", "PTT ID",
@@ -1213,28 +1213,30 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
                           RadioSettingValueInteger(0, 9, _settings.squelch))
         rs.set_doc(
             "Sets how strong a received signal must be before the speaker "
-            "unmutes. 0 leaves the squelch open; higher values reject more "
-            "weak signals and noise. The manual recommends 5 as a starting "
-            "point.")
+            "unmutes. 0 leaves the squelch open so you hear noise all the "
+            "time, higher values reject more weak signals and noise. Raise "
+            "this value if the speaker keeps unmuting on interference, lower "
+            "it if distant stations are being cut off.")
         basic.append(rs)
 
         rs = RadioSetting("save", "Battery Saver",
                           RadioSettingValueList(
                               SAVE_LIST, current_index=_settings.save))
         rs.set_doc(
-            "Reduces standby battery use by periodically putting the "
-            "receiver to sleep. Higher ratios save more power, but may "
-            "delay reception of the beginning of a transmission.")
+            "Cuts standby power consumption by switching the receiver off and "
+            "on in a repeating cycle once no signal has been received for a "
+            "few seconds. It considerably extends battery life, at the cost "
+            "of occasionally clipping the first moment of an incoming "
+            "transmission.")
         basic.append(rs)
 
         rs = RadioSetting("vox", "VOX Sensitivity",
                           RadioSettingValueList(
                               VOX_LIST, current_index=_settings.vox))
         rs.set_doc(
-            "Allows voice-operated transmission without pressing PTT. "
-            "Lower numbered levels are more sensitive; choose a level that "
-            "responds to speech without being triggered by background "
-            "noise, or select OFF to disable VOX.")
+            "Sets the VOX sensitivity. Too sensitive a setting keys the "
+            "transmitter on the noise around the radio, too insensitive a "
+            "setting fails to pick up your voice.")
         advanced.append(rs)
 
         if self.MODEL == "UV-6":
@@ -1244,9 +1246,9 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
             rs = RadioSetting("autolk", "Vox",
                               RadioSettingValueBoolean(_settings.autolk))
             rs.set_doc(
-                "Enables voice-operated transmission. When "
-                "enabled, speaking into the microphone can start "
-                "transmission without pressing PTT.")
+                "Voice operated transmit. The radio starts transmitting "
+                "when you speak towards the microphone, so hands-free "
+                "conversation is possible without pressing PTT.")
             advanced.append(rs)
 
         if self.MODEL != "UV-6":
@@ -1286,9 +1288,8 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
                               RadioSettingValueList(
                                   TDRAB_LIST, current_index=_settings.tdrab))
             rs.set_doc(
-                "Selects A or B as the transmit side while Dual Watch is "
-                "enabled. Off leaves transmit selection under the radio's "
-                "normal Dual Watch behavior.")
+                "Selects which side has transmit priority while Dual Watch "
+                "is enabled.")
             advanced.append(rs)
 
         if self.MODEL == "UV-6":
@@ -1313,16 +1314,18 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
         rs = RadioSetting("beep", "Beep",
                           RadioSettingValueBoolean(_settings.beep))
         rs.set_doc(
-            "Enables the audible confirmation beep for keypad presses.")
+            "Sounds a short confirmation tone as you operate the radio. "
+            "Turn it off when the radio has to be used discreetly.")
         basic.append(rs)
 
         rs = RadioSetting("timeout", "Timeout Timer",
                           RadioSettingValueList(
                               TIMEOUT_LIST, current_index=_settings.timeout))
         rs.set_doc(
-            "Limits the length of one continuous transmission. When the "
-            "selected time expires, the radio stops transmitting to help "
-            "prevent overheating and an accidentally stuck transmitter.")
+            "Limits how long a single transmission may last. When the time "
+            "runs out the radio stops transmitting until PTT is released, "
+            "which prevents overheating and stops a stuck PTT from blocking "
+            "the channel for everyone else.")
         basic.append(rs)
 
         if ((self._is_orig() and self._my_version() < 251) or
@@ -1330,7 +1333,9 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
             rs = RadioSetting("voice", "Voice",
                               RadioSettingValueBoolean(_settings.voice))
             rs.set_doc(
-                "Enables or disables spoken prompts for radio operations.")
+                "Announces the channel number and other operations out loud "
+                "as you use the radio. It can be intrusive in quiet "
+                "surroundings.")
             advanced.append(rs)
         else:
             rs = RadioSetting("voice", "Voice",
@@ -1372,9 +1377,9 @@ class BaofengUV5R(chirp_common.CloneModeRadio):
         rs = RadioSetting("bcl", "Busy Channel Lockout",
                           RadioSettingValueBoolean(_settings.bcl))
         rs.set_doc(
-            "Prevents transmitting while the radio is receiving a signal. "
-            "This helps avoid interrupting other users whose signal is "
-            "muted by your selected CTCSS tone or DCS code.")
+            "Prevents transmitting on a channel that is already in use. "
+            "Pressing PTT on a busy channel sounds an alert tone instead of "
+            "keying the transmitter.")
         advanced.append(rs)
 
         if self.MODEL != "UV-6":


### PR DESCRIPTION
Unifies documentation strings across all radios in the Baofeng family (+clones). This will, in theory, make it easier to translate later on.
