### PR TITLE
ar8200: Fix importing memories with AM mode

### DIFF
--- a/chirp/drivers/ar8200.py
+++ b/chirp/drivers/ar8200.py
@@ -985,8 +985,9 @@ class AR8200Radio(chirp_common.LiveRadio):
             if memory.mode == 'Auto':
                 mode = 0
             elif memory.mode == 'AM':
+                ammode = memory.extra['am'] if 'am' in memory.extra else 'AM'
                 mode = [mode[1] for mode in self._MODES
-                        if mode[0] == memory.extra['am']][0]
+                        if mode[0] == ammode][0]
             else:
                 mode = [mode[1] for mode in self._MODES
                         if mode[0] == memory.mode][0]
@@ -1037,8 +1038,9 @@ class AR8200Radio(chirp_common.LiveRadio):
             if memory.mode == 'Auto':
                 mode = 0
             elif memory.mode == 'AM':
+                ammode = memory.extra['am'] if 'am' in memory.extra else 'AM'
                 mode = [mode[1] for mode in self._MODES
-                        if mode[0] == memory.extra['am']][0]
+                        if mode[0] == ammode][0]
             else:
                 mode = [mode[1] for mode in self._MODES
                         if mode[0] == memory.mode][0]
@@ -1118,8 +1120,9 @@ class AR8200Radio(chirp_common.LiveRadio):
             if memory.mode == 'Auto':
                 mode = 0
             elif memory.mode == 'AM':
+                ammode = memory.extra['am'] if 'am' in memory.extra else 'AM'
                 mode = [mode[1] for mode in self._MODES
-                        if mode[0] == memory.extra['am']][0]
+                        if mode[0] == ammode][0]
             else:
                 mode = [mode[1] for mode in self._MODES
                         if mode[0] == memory.mode][0]


### PR DESCRIPTION
Importing a memory with the mode set to AM will trigger an exception because the device specific extra field 'am', which indicates the mode for the radio, does not exist.  Avoid this by using a default AM mode when the extra field is not present.
